### PR TITLE
fix: move addPeers after addMessages to prevent silent hang

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -177,12 +177,6 @@ const honchoPlugin = {
 
         const lastSavedIndex = (meta.lastSavedIndex as number) ?? 0;
 
-        // Add peers (session now guaranteed to exist)
-        await session.addPeers([
-          [OWNER_ID, { observeMe: true, observeOthers: false }],
-          [OPENCLAW_ID, { observeMe: true, observeOthers: true }],
-        ]);
-
         // Skip if nothing new
         if (event.messages.length <= lastSavedIndex) {
           api.logger.debug?.("No new messages to save");
@@ -204,6 +198,16 @@ const honchoPlugin = {
 
         // Update watermark in Honcho
         await session.setMetadata({ ...meta, lastSavedIndex: event.messages.length });
+
+        // Add peers after messages exist (addPeers can hang on empty sessions)
+        try {
+          await session.addPeers([
+            [OWNER_ID, { observeMe: true, observeOthers: false }],
+            [OPENCLAW_ID, { observeMe: true, observeOthers: true }],
+          ]);
+        } catch (peerError) {
+          api.logger.warn?.(`[honcho] Failed to add peers (non-fatal): ${peerError}`);
+        }
       } catch (error) {
         api.logger.error(`[honcho] Failed to save messages to Honcho: ${error}`);
         if (error instanceof Error) {


### PR DESCRIPTION
## Problem

`addPeers()` called on Honcho sessions with no messages causes a silent hang in the `agent_end` hook. The hook fires correctly (confirmed via gateway debug logs showing `success=true` with valid messages), but execution stops at `addPeers()` — no error is thrown, no rejection is logged, and the catch block is never reached.

This means **no messages are ever saved to Honcho** despite the plugin loading and registering correctly.

## Root Cause

`session.addPeers()` is called before `session.addMessages()`. On new sessions with no messages yet, `addPeers()` appears to hang indefinitely (possibly an API-side requirement that sessions have content before peers can be attached).

## Fix

1. **Reorder**: Move `addPeers()` to after `addMessages()` so messages are persisted first
2. **Non-fatal wrap**: Wrap `addPeers()` in its own try-catch so peer attachment failures don't block message persistence

## Diagnosis

Discovered on OpenClaw v2026.2.6-3 with `@honcho-ai/sdk` v2.0.0:

1. Gateway logs confirmed `[hooks] running agent_end (1 handlers)` on every turn
2. Added debug tracing through the handler — all steps succeeded until `addPeers()`
3. No error logged, no rejection caught — execution simply stopped
4. After reordering: messages save successfully, watermarks persist, peers attach after messages exist

## Testing

Verified on production OpenClaw instance:
- Messages flowing into Honcho sessions with correct watermark tracking
- Peer observation working after messages exist
- No regressions on existing Honcho tool functionality (honcho_search, honcho_profile, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session workflow by adjusting when peer-addition operations are triggered relative to message saving
  * Peer operations now only occur after messages are successfully saved, preventing failures with empty sessions
  * Enhanced error handling with non-fatal logging for peer-addition failures to prevent application interruptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->