### PR TITLE
fix: use agent-{id} naming for default agent peer on fresh workspaces

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -88,9 +88,15 @@ const honchoPlugin = {
       const wsMeta = await honcho.getMetadata();
       agentPeerMap = (wsMeta.agentPeerMap as Record<string, string>) ?? {};
 
-      // Ensure legacy "openclaw" peer is mapped to the default agent
+      // Bootstrap agent-peer mapping for the default agent
       const defaultId = resolveDefaultAgentId();
-      if (!Object.values(agentPeerMap).includes(LEGACY_PEER_ID)) {
+      // Fresh workspace: use agent-{id} naming consistent with other agents
+      if (Object.keys(agentPeerMap).length === 0) {
+        agentPeerMap[defaultId] = `agent-${defaultId}`;
+        await honcho.setMetadata({ ...wsMeta, agentPeerMap });
+      }
+      // Existing workspace with legacy "openclaw" mapping: preserve it
+      else if (!Object.values(agentPeerMap).includes(LEGACY_PEER_ID) && !agentPeerMap[defaultId]) {
         agentPeerMap[defaultId] = LEGACY_PEER_ID;
         await honcho.setMetadata({ ...wsMeta, agentPeerMap });
       }


### PR DESCRIPTION
## Problem

The bootstrap logic in `index.ts` unconditionally assigns the Honcho peer ID `"openclaw"` to the default agent (prime). Every other agent gets an `agent-{agentId}` peer ID (e.g. `agent-developer`, `agent-researcher`), so the default agent is the odd one out.

**Before** — peer list on a fresh workspace:
```
prime   → openclaw
developer → agent-developer
researcher → agent-researcher
```

**After** — peer list on a fresh workspace:
```
prime   → agent-prime
developer → agent-developer
researcher → agent-researcher
```

## Fix

Two-case logic replaces the single unconditional assignment:

1. **Fresh workspace** (`agentPeerMap` is empty): assign `agent-{defaultId}` — consistent with all other agents.
2. **Existing workspace** where `"openclaw"` isn't in the map yet (and the default agent has no entry): fall back to `"openclaw"` so users with data already stored under that peer ID don't lose it.

If `"openclaw"` is already present in the map, nothing changes (fully backward-compatible).

## Diff summary

```diff
-      // Ensure legacy "openclaw" peer is mapped to the default agent
+      // Bootstrap agent-peer mapping for the default agent
       const defaultId = resolveDefaultAgentId();
-      if (!Object.values(agentPeerMap).includes(LEGACY_PEER_ID)) {
+      if (Object.keys(agentPeerMap).length === 0) {
+        agentPeerMap[defaultId] = `agent-${defaultId}`;
+        await honcho.setMetadata({ ...wsMeta, agentPeerMap });
+      }
+      else if (!Object.values(agentPeerMap).includes(LEGACY_PEER_ID) && !agentPeerMap[defaultId]) {
         agentPeerMap[defaultId] = LEGACY_PEER_ID;
         await honcho.setMetadata({ ...wsMeta, agentPeerMap });
       }
```