### PR TITLE
feat: configurable noise filters and owner peer observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,52 @@ The plugin ships template files in `node_modules/@honcho-ai/openclaw-honcho/work
 
 Run `openclaw honcho setup` to configure interactively, or set values directly in `~/.openclaw/openclaw.json` under `plugins.entries["openclaw-honcho"].config`.
 
-| Key           | Type     | Default                    | Description                               |
-| ------------- | -------- | -------------------------- | ----------------------------------------- |
-| `apiKey`      | `string` | —                          | Honcho API key (required for managed; omit for self-hosted). |
-| `workspaceId` | `string` | `"openclaw"`               | Honcho workspace ID for memory isolation. |
-| `baseUrl`     | `string` | `"https://api.honcho.dev"` | API endpoint (for self-hosted instances). |
+| Key                    | Type       | Default                    | Description                               |
+| ---------------------- | ---------- | -------------------------- | ----------------------------------------- |
+| `apiKey`               | `string`   | —                          | Honcho API key (required for managed; omit for self-hosted). |
+| `workspaceId`          | `string`   | `"openclaw"`               | Honcho workspace ID for memory isolation. |
+| `baseUrl`              | `string`   | `"https://api.honcho.dev"` | API endpoint (for self-hosted instances). |
+| `noisePatterns`        | `string[]` | —                          | Additional substring patterns to skip messages. Merged with built-in defaults. |
+| `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
 
 ### Self-Hosted / Local Honcho
 
 Run `openclaw honcho setup`, enter a blank API key, and set the Base URL to your instance (e.g., `http://localhost:8000`).
 
 For setting up a local Honcho server, see the [Honcho local development guide](https://github.com/plastic-labs/honcho?tab=readme-ov-file#local-development).
+
+### Noise Filtering
+
+The plugin automatically drops messages that match noise patterns before saving to Honcho. Built-in defaults filter:
+
+- `HEARTBEAT_OK` — assistant heartbeat acknowledgments
+- `A scheduled reminder has been triggered` — cron reminder boilerplate
+- `Execute your Session Startup sequence now` — session startup commands
+- `Queued messages from` — queued message wrapper headers
+
+Add custom patterns via `noisePatterns` in your config:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw-honcho": {
+        "config": {
+          "noisePatterns": ["my custom noise string"]
+        }
+      }
+    }
+  }
+}
+```
+
+Custom patterns are merged with the built-in defaults. Matching uses substring comparison (`String.includes()`), not regex.
+
+### Owner Peer Observation
+
+Honcho's `observeOthers` controls whether a peer forms representations of other peers based on messages it witnessed in shared sessions. The agent peer always has `observeOthers: true` — it sees and reasons about the user's messages. The owner (user) peer defaults to `observeOthers: false` — modeled only from what the user said, not what the agent replied.
+
+Set `ownerObserveOthers: true` to let the owner peer also observe agent messages. This gives Honcho perspective-aware memory: the owner stores conclusions about the agent based only on what it witnessed, enabling the user's representation to reflect the full conversational context rather than just their own side of it.
 
 ## How it works
 
@@ -80,7 +115,7 @@ Once installed, the plugin works automatically:
 - **Message Observation** — After every AI turn, the conversation is persisted to Honcho. Both user and agent messages are observed, allowing Honcho to build and refine its models. Message capture starts when the plugin is active for a session, and preserves original timestamps for captured messages.
 - **Tool-Based Context Access** — The AI can query Honcho mid-conversation using tools like `honcho_recall`, `honcho_search`, and `honcho_analyze` to retrieve relevant context about the user. Context is injected during OpenClaw's `before_prompt_build` phase, ensuring accurate turn boundaries.
 - **Dual Peer Model** — Honcho maintains separate representations: one for the user (preferences, facts, communication style) and one for the agent (personality, learned behaviors). Each OpenClaw agent gets its own Honcho peer (`agent-{id}`), so multi-agent workspaces maintain isolated memory.
-- **Clean Persistence** — Platform metadata (conversation info, sender headers, thread context, forwarded messages) is stripped before saving to Honcho, ensuring only meaningful content is persisted.
+- **Clean Persistence** — Platform metadata (conversation info, sender headers, thread context, forwarded messages) is stripped before saving to Honcho, ensuring only meaningful content is persisted. Noise messages (heartbeat acks, cron boilerplate, startup commands) are dropped entirely via configurable pattern filters.
 
 Honcho handles all reasoning and synthesis in the cloud.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `apiKey`               | `string`   | —                          | Honcho API key (required for managed; omit for self-hosted). |
 | `workspaceId`          | `string`   | `"openclaw"`               | Honcho workspace ID for memory isolation. |
 | `baseUrl`              | `string`   | `"https://api.honcho.dev"` | API endpoint (for self-hosted instances). |
-| `noisePatterns`        | `string[]` | —                          | Additional substring patterns to skip messages. Merged with built-in defaults. |
+| `noisePatterns`        | `string[]` | built-in defaults          | Patterns to skip messages. User-provided patterns are merged with built-in defaults (unless `disableDefaultNoisePatterns` is set). |
+| `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
 
 ### Self-Hosted / Local Honcho

--- a/clawhub/honcho-setup/SKILL.md
+++ b/clawhub/honcho-setup/SKILL.md
@@ -7,17 +7,19 @@ description: >
   restarts the gateway. **UPLOADS WORKSPACE CONTENT TO EXTERNAL API** via
   `openclaw honcho setup`: sends USER.md, MEMORY.md, IDENTITY.md, memory/,
   canvas/, SOUL.md, AGENTS.md, BOOTSTRAP.md, TOOLS.md to api.honcho.dev
-  (managed, default) or your self-hosted HONCHO_BASE_URL. HEARTBEAT.md is
-  excluded. Requires user confirmation before uploading. No workspace or
-  memory files are deleted, moved, or modified. `openclaw honcho setup`
-  does write plugin configuration to ~/.openclaw/openclaw.json.
+  (managed, default) or your self-hosted HONCHO_BASE_URL. HEARTBEAT.md is excluded. Requires explicit interactive user confirmation before uploading,
+  even when HONCHO_API_KEY is pre-set. No workspace or memory files are
+  deleted, moved, or modified. `openclaw honcho setup` writes plugin
+  configuration to ~/.openclaw/openclaw.json. After setup, the plugin
+  persistently observes conversations and transmits data to Honcho across
+  sessions; disable with `openclaw plugins disable openclaw-honcho`.
 metadata:
   openclaw:
     emoji: "🧠"
     required_env: []  # Nothing is strictly required - self-hosted mode works without API key
     optional_env:
       - name: HONCHO_API_KEY
-        description: "Required for managed Honcho (https://app.honcho.dev). If set, openclaw honcho setup will use it automatically. If not set, the setup command will prompt for it."
+        description: "Required for managed Honcho (https://app.honcho.dev). If set, the setup command skips the API key prompt but still requires explicit user confirmation before any data upload. If not set, the setup command will prompt for it interactively."
       - name: HONCHO_BASE_URL
         description: "Base URL for a self-hosted Honcho instance (e.g. http://localhost:8000). Defaults to https://api.honcho.dev (managed)."
     required_binaries:
@@ -109,7 +111,9 @@ Verify the plugin is active by checking gateway logs or running:
 openclaw honcho status
 ```
 
-Honcho memory is now active. The plugin will automatically observe conversations and make memory available via `honcho_recall`, `honcho_search`, `honcho_profile`, and related tools.
+Honcho memory is now active.
+
+> **Ongoing behavior after setup**: Once enabled, the plugin will persistently observe conversations in this workspace and send conversation data to `api.honcho.dev` (or your configured `HONCHO_BASE_URL`) to build and retrieve memory. This is ongoing network activity that continues across sessions. Memory is made available via `honcho_recall`, `honcho_search`, `honcho_profile`, and related tools. To stop this behavior, disable the plugin with `openclaw plugins disable openclaw-honcho`.
 
 ---
 
@@ -124,7 +128,7 @@ This skill runs three commands: `openclaw plugins install`, `openclaw honcho set
 - **uploaded_content**: USER.md, MEMORY.md, IDENTITY.md, all files under memory/, all files under canvas/, SOUL.md, AGENTS.md, BOOTSTRAP.md, TOOLS.md — uploaded by `openclaw honcho setup` during migration
 - **not_uploaded**: HEARTBEAT.md — excluded by design, never read or uploaded
 - **Where it goes**: By default to `api.honcho.dev` (managed Honcho cloud service). For self-hosted instances, to your configured `HONCHO_BASE_URL`
-- **User control**: `openclaw honcho setup` requires explicit confirmation before any upload. You will see the exact list of files and the destination URL
+- **User control**: `openclaw honcho setup` always requires explicit interactive confirmation before any upload, even when `HONCHO_API_KEY` is pre-set in the environment. You will see the exact list of files and the destination URL
 - **Purpose**: Migrating file-based memory system to Honcho API for AI agent personalization and memory
 
 ### File Modifications
@@ -139,6 +143,11 @@ This skill runs three commands: `openclaw plugins install`, `openclaw honcho set
 ### Network Access
 - **Managed mode**: Connects to `api.honcho.dev` (Honcho cloud service)
 - **Self-hosted mode**: Connects to your configured `HONCHO_BASE_URL` (e.g., `http://localhost:8000`)
+
+### Ongoing Behavior After Setup
+- **Persistent observation**: Once enabled, the plugin observes all conversations in the workspace and transmits conversation data to the configured Honcho endpoint on an ongoing basis
+- **Network activity**: Continues across sessions as long as the plugin is enabled — this is not a one-time migration
+- **How to stop**: Run `openclaw plugins disable openclaw-honcho` to stop all observation and network activity
 
 ### Open Source
 - **Honcho SDK**: Open source at https://github.com/plastic-labs/honcho

--- a/config.ts
+++ b/config.ts
@@ -14,6 +14,7 @@ export type HonchoConfig = {
   workspaceId: string;
   baseUrl: string;
   noisePatterns: string[];
+  disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
 };
 
@@ -43,10 +44,16 @@ export const honchoConfigSchema = {
       apiKey = process.env.HONCHO_API_KEY;
     }
 
+    const disableDefaultNoisePatterns = cfg.disableDefaultNoisePatterns === true;
     const userPatterns = Array.isArray(cfg.noisePatterns)
-      ? (cfg.noisePatterns as unknown[]).filter((p): p is string => typeof p === "string" && p.length > 0)
+      ? (cfg.noisePatterns as unknown[])
+          .filter((p): p is string => typeof p === "string")
+          .map((p) => p.trim())
+          .filter((p) => p.length > 0)
       : [];
-    const noisePatterns = [...new Set([...DEFAULT_NOISE_PATTERNS, ...userPatterns])];
+    const noisePatterns = [
+      ...new Set([...(disableDefaultNoisePatterns ? [] : DEFAULT_NOISE_PATTERNS), ...userPatterns]),
+    ];
 
     return {
       apiKey,
@@ -59,6 +66,7 @@ export const honchoConfigSchema = {
           ? cfg.baseUrl
           : process.env.HONCHO_BASE_URL ?? "https://api.honcho.dev",
       noisePatterns,
+      disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
     };
   },

--- a/config.ts
+++ b/config.ts
@@ -2,10 +2,19 @@
  * Configuration schema and parsing for the Honcho memory plugin.
  */
 
+export const DEFAULT_NOISE_PATTERNS: string[] = [
+  "HEARTBEAT_OK",
+  "A scheduled reminder has been triggered",
+  "Execute your Session Startup sequence now",
+  "Queued messages from",
+];
+
 export type HonchoConfig = {
   apiKey?: string;
   workspaceId: string;
   baseUrl: string;
+  noisePatterns: string[];
+  ownerObserveOthers: boolean;
 };
 
 /**
@@ -34,6 +43,11 @@ export const honchoConfigSchema = {
       apiKey = process.env.HONCHO_API_KEY;
     }
 
+    const userPatterns = Array.isArray(cfg.noisePatterns)
+      ? (cfg.noisePatterns as unknown[]).filter((p): p is string => typeof p === "string" && p.length > 0)
+      : [];
+    const noisePatterns = [...new Set([...DEFAULT_NOISE_PATTERNS, ...userPatterns])];
+
     return {
       apiKey,
       workspaceId:
@@ -44,6 +58,8 @@ export const honchoConfigSchema = {
         typeof cfg.baseUrl === "string" && cfg.baseUrl.length > 0
           ? cfg.baseUrl
           : process.env.HONCHO_BASE_URL ?? "https://api.honcho.dev",
+      noisePatterns,
+      ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
     };
   },
 };

--- a/helpers.ts
+++ b/helpers.ts
@@ -132,10 +132,25 @@ export function cleanMessageContent(content: string): string {
 
 /**
  * Returns true if the message should be dropped entirely.
- * Uses substring matching — no regex.
+ * Patterns starting with "/" are treated as anchored regexes (e.g. "/^HEARTBEAT/i").
+ * All other patterns match by exact equality or prefix (startsWith).
  */
 export function shouldSkipMessage(content: string, noisePatterns: string[]): boolean {
-  return noisePatterns.some((pattern) => content.includes(pattern));
+  return noisePatterns.some((pattern) => {
+    if (pattern.startsWith("/")) {
+      const lastSlash = pattern.lastIndexOf("/", pattern.length - 1);
+      if (lastSlash > 0) {
+        const source = pattern.slice(1, lastSlash);
+        const flags = pattern.slice(lastSlash + 1);
+        try {
+          return new RegExp(source, flags).test(content);
+        } catch {
+          // fall through to literal match if regex is invalid
+        }
+      }
+    }
+    return content === pattern || content.startsWith(pattern);
+  });
 }
 
 export function extractMessages(

--- a/helpers.ts
+++ b/helpers.ts
@@ -130,10 +130,19 @@ export function cleanMessageContent(content: string): string {
   return cleaned.trim();
 }
 
+/**
+ * Returns true if the message should be dropped entirely.
+ * Uses substring matching — no regex.
+ */
+export function shouldSkipMessage(content: string, noisePatterns: string[]): boolean {
+  return noisePatterns.some((pattern) => content.includes(pattern));
+}
+
 export function extractMessages(
   rawMessages: unknown[],
   ownerPeer: Peer,
-  agentPeer: Peer
+  agentPeer: Peer,
+  noisePatterns: string[] = []
 ): MessageInput[] {
   const result: MessageInput[] = [];
 
@@ -162,6 +171,9 @@ export function extractMessages(
 
     content = cleanMessageContent(content);
     content = content.trim();
+
+    if (!content) continue;
+    if (shouldSkipMessage(content, noisePatterns)) continue;
 
     if (content) {
       const peer = role === "user" ? ownerPeer : agentPeer;

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -49,7 +49,7 @@ export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState):
       const startIndex = Math.max(turnStartIndex, lastSavedIndex);
 
       const peerConfigs: Array<[string, { observeMe: boolean; observeOthers: boolean }]> = [
-        [OWNER_ID, { observeMe: true, observeOthers: false }],
+        [OWNER_ID, { observeMe: true, observeOthers: state.cfg.ownerObserveOthers }],
         [agentPeer.id, { observeMe: true, observeOthers: true }],
       ];
       if (parentPeer) {
@@ -65,7 +65,7 @@ export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState):
       }
 
       const newRawMessages = event.messages.slice(startIndex);
-      const messages = extractMessages(newRawMessages, state.ownerPeer!, agentPeer);
+      const messages = extractMessages(newRawMessages, state.ownerPeer!, agentPeer, state.cfg.noisePatterns);
 
       if (messages.length === 0) {
         await session.setMetadata({ ...existingMeta, ...sessionMeta, lastSavedIndex: event.messages.length });

--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,8 @@ import { registerAnalyzeTool } from "./tools/analyze.js";
 import { registerMemoryPassthrough } from "./tools/memory-passthrough.js";
 import { registerCli } from "./commands/cli.js";
 
+let _loggedLoaded = false;
+
 export default {
   id: "openclaw-honcho",
   name: "Memory (Honcho)",
@@ -50,6 +52,11 @@ export default {
     // CLI
     registerCli(api, state);
 
-    api.logger.info("Honcho memory plugin loaded");
+    if (!_loggedLoaded) {
+      api.logger.info("Honcho memory plugin loaded");
+      _loggedLoaded = true;
+    } else {
+      api.logger.debug("Honcho memory plugin registered for workspace");
+    }
   },
 };

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -16,6 +16,16 @@
       "baseUrl": {
         "type": "string",
         "default": "https://api.honcho.dev"
+      },
+      "noisePatterns": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Additional substring patterns to skip messages. Built-in defaults (HEARTBEAT_OK, cron reminders, etc.) always apply."
+      },
+      "ownerObserveOthers": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether the owner peer observes agent messages. When true, Honcho models the user's awareness of assistant responses."
       }
     }
   },
@@ -35,6 +45,16 @@
       "label": "API Base URL",
       "advanced": true,
       "placeholder": "https://api.honcho.dev"
+    },
+    "noisePatterns": {
+      "label": "Noise Patterns",
+      "advanced": true,
+      "help": "Additional substring patterns to filter. Messages containing any pattern are dropped before saving to Honcho."
+    },
+    "ownerObserveOthers": {
+      "label": "Owner Observes Agent",
+      "advanced": true,
+      "help": "When enabled, Honcho models the user as aware of the agent's responses. Default: off."
     }
   }
 }


### PR DESCRIPTION
config.ts — Added ownerObserveOthers: boolean to HonchoConfig, defaults to false in parser

hooks/capture.ts — Owner peer now uses state.cfg.ownerObserveOthers instead of hardcoded false

openclaw.plugin.json — Added ownerObserveOthers boolean property + UI hint (marked advanced)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable noise filtering with user-specified patterns and an option to disable built-in defaults.
  * Owner peer observation toggle to control whether owners see agent messages.
  * Plugin UI exposes new noisePatterns and ownerObserveOthers settings.

* **Bug Fixes / Behavior**
  * Noise-matched messages are now dropped entirely before persistence (platform metadata still stripped).

* **Documentation**
  * README and setup docs expanded with noise-filtering, owner observation, and post‑setup behavior details.

* **Chores**
  * Reduced duplicate load logs; register now logs per workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->