### PR TITLE
fix: guard against missing api.runtime.tools in memory-passthrough

### DIFF
--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -5,6 +5,9 @@ import type { PluginState } from "../state.js";
 export function registerMemoryPassthrough(api: OpenClawPluginApi, _state: PluginState): void {
   api.registerTool(
     (ctx) => {
+      if (!api.runtime?.tools) {
+        return null;
+      }
       const memorySearchTool = api.runtime.tools.createMemorySearchTool({
         config: ctx.config,
         agentSessionKey: ctx.sessionKey,


### PR DESCRIPTION
## Summary

Fixes #36.

When OpenClaw doesn't expose `api.runtime.tools`, `registerMemoryPassthrough` throws a `TypeError: Cannot read properties of undefined (reading 'createMemorySearchTool')` on every request. Because `api.registerTool` runs its callback per-request, this fires continuously. OpenClaw catches the exception internally, but the `memory_search` and `memory_get` tools silently fail to register with no visible error.

## Fix

Adds a null guard (`if (!api.runtime?.tools) return null`) before accessing `api.runtime.tools`. This is consistent with the existing guard on lines 16-18 that checks for `null` individual tool results. The callback now returns `null` early when `api.runtime.tools` is unavailable, which is the same signal OpenClaw uses to indicate "no tools to register."

## Test plan

- [ ] Verify against an OpenClaw version that exposes `api.runtime.tools` — tools should register as before
- [ ] Verify against an OpenClaw version that does **not** expose `api.runtime.tools` — no TypeError, tools gracefully absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of memory search and retrieval functionality by preventing errors when runtime support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->