### PR TITLE
fix: add disableDefaultNoisePatterns to manifest configSchema

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -26,6 +26,11 @@
         "type": "boolean",
         "default": false,
         "description": "Whether the owner peer observes agent messages. When true, Honcho models the user's awareness of assistant responses."
+      },
+      "disableDefaultNoisePatterns": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, built-in noise patterns are not applied — only noisePatterns entries are used."
       }
     }
   },
@@ -55,6 +60,11 @@
       "label": "Owner Observes Agent",
       "advanced": true,
       "help": "When enabled, Honcho models the user as aware of the agent's responses. Default: off."
+    },
+    "disableDefaultNoisePatterns": {
+      "label": "Disable Default Noise Patterns",
+      "advanced": true,
+      "help": "When enabled, only custom noisePatterns entries are used — built-in defaults are skipped."
     }
   }
 }


### PR DESCRIPTION
## Summary

The README documents `disableDefaultNoisePatterns` as a config option, but the `openclaw.plugin.json` manifest is missing it from both `configSchema.properties` and `uiHints`.

This means OpenClaw's config validation (which uses `additionalProperties: false`) would reject the field when users add it to their config based on the README instructions.

## Changes

- Add `disableDefaultNoisePatterns` (boolean, default false) to `configSchema.properties`
- Add matching `uiHints` entry with label, advanced flag, and help text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new advanced configuration option to disable default noise patterns. When enabled, the system uses exclusively user-provided noise patterns instead of combining them with built-in defaults, giving you complete control over noise filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->