### PR TITLE
fix: register memory runtime + scope api-key warning for self-hosted

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,7 @@ import { registerAskTool } from "./tools/ask.js";
 import { registerMemoryPassthrough } from "./tools/memory-passthrough.js";
 import { registerMessageSearchTool } from "./tools/message-search.js";
 import { registerCli } from "./commands/cli.js";
+import { registerHonchoMemoryRuntime } from "./runtime.js";
 
 /**
  * Memory prompt section builder for Honcho tools.
@@ -94,6 +95,9 @@ export default definePluginEntry({
     // Register memory prompt section — tool selection guidance lives here,
     // not in individual tool descriptions.
     api.registerMemoryPromptSection(buildPromptSection);
+
+    // Memory runtime adapter — wires Honcho into OpenClaw's memory-core slot.
+    registerHonchoMemoryRuntime(api, state);
 
     // Hooks
     registerGatewayHook(api, state);

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,6 +1,18 @@
 import { buildSessionKey } from "./helpers.js";
 import type { PluginState } from "./state.js";
 
+const DEFAULT_SEARCH_RESULTS = 10;
+const MAX_SEARCH_RESULTS = 50;
+
+function isLocalBaseUrl(baseUrl?: string): boolean {
+  try {
+    const host = new URL(baseUrl ?? "").hostname;
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
 function normalizeSessionPath(sessionId: string): string {
   return `sessions/${sessionId}.txt`;
 }
@@ -68,9 +80,13 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
         manager: {
           async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
             await state.ensureInitialized();
+            const requested = Number.isFinite(opts.maxResults)
+              ? Number(opts.maxResults)
+              : DEFAULT_SEARCH_RESULTS;
+            const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
 
             const raw = await state.ownerPeer.search(query, {
-              limit: opts.maxResults ?? 10,
+              limit,
             });
 
             const requestedSessionKey =
@@ -110,10 +126,7 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
           status() {
             return {
               backend: "qmd",
-              provider:
-                state.cfg.baseUrl?.includes("localhost") || state.cfg.baseUrl?.includes("127.0.0.1")
-                  ? "honcho-selfhosted"
-                  : "honcho",
+              provider: isLocalBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
               model: "n/a",
               sources: ["sessions"],
               custom: {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,17 +1,8 @@
 import { buildSessionKey } from "./helpers.js";
-import type { PluginState } from "./state.js";
+import { isLocalHonchoBaseUrl, type PluginState } from "./state.js";
 
 const DEFAULT_SEARCH_RESULTS = 10;
 const MAX_SEARCH_RESULTS = 50;
-
-function isLocalBaseUrl(baseUrl?: string): boolean {
-  try {
-    const host = new URL(baseUrl ?? "").hostname;
-    return host === "localhost" || host === "127.0.0.1" || host === "::1";
-  } catch {
-    return false;
-  }
-}
 
 function normalizeSessionPath(sessionId: string): string {
   return `sessions/${sessionId}.txt`;
@@ -69,6 +60,38 @@ async function buildSessionTranscript(
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
+function findSnippetLineRange(transcript: string, snippet: string): { startLine: number; endLine: number } {
+  const transcriptLines = transcript.split(/\r?\n/);
+  const snippetLines = snippet.split(/\r?\n/);
+
+  if (!snippet.trim()) {
+    return { startLine: 1, endLine: 1 };
+  }
+
+  for (let i = 0; i <= transcriptLines.length - snippetLines.length; i += 1) {
+    let matches = true;
+    for (let j = 0; j < snippetLines.length; j += 1) {
+      if (transcriptLines[i + j] !== snippetLines[j]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return { startLine: i + 1, endLine: i + snippetLines.length };
+    }
+  }
+
+  const firstNeedle = snippetLines.find((line) => line.trim().length > 0);
+  if (firstNeedle) {
+    const idx = transcriptLines.findIndex((line) => line.includes(firstNeedle));
+    if (idx >= 0) {
+      return { startLine: idx + 1, endLine: idx + snippetLines.length };
+    }
+  }
+
+  return { startLine: 1, endLine: Math.max(1, snippetLines.length) };
+}
+
 export function registerHonchoMemoryRuntime(api: any, state: PluginState): void {
   api.registerMemoryRuntime({
     async getMemorySearchManager(params: { agentId?: string }) {
@@ -84,30 +107,42 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
               ? Number(opts.maxResults)
               : DEFAULT_SEARCH_RESULTS;
             const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
-
-            const raw = await state.ownerPeer.search(query, {
-              limit,
-            });
-
             const requestedSessionKey =
               typeof opts.sessionKey === "string" && opts.sessionKey.length > 0 ? opts.sessionKey : null;
 
-            return raw
+            const raw = await state.ownerPeer.search(query, {
+              limit: requestedSessionKey ? MAX_SEARCH_RESULTS : limit,
+            });
+
+            const filtered = raw
               .filter((msg: any) => {
                 if (!requestedSessionKey) return true;
                 return msg.sessionId === requestedSessionKey || msg.sessionId.startsWith(`${requestedSessionKey}-`);
               })
-              .map((msg: any) => {
+              .slice(0, limit);
+
+            const transcriptCache = new Map<string, Promise<string>>();
+
+            return Promise.all(
+              filtered.map(async (msg: any) => {
                 const snippet = typeof msg.content === "string" ? msg.content : "";
+                let transcriptPromise = transcriptCache.get(msg.sessionId);
+                if (!transcriptPromise) {
+                  transcriptPromise = buildSessionTranscript(state, agentId, msg.sessionId);
+                  transcriptCache.set(msg.sessionId, transcriptPromise);
+                }
+                const transcript = await transcriptPromise;
+                const { startLine, endLine } = findSnippetLineRange(transcript, snippet);
                 return {
                   path: normalizeSessionPath(msg.sessionId),
-                  startLine: 1,
-                  endLine: countLines(snippet),
+                  startLine,
+                  endLine,
                   score: 1,
                   snippet,
                   source: "sessions",
                 };
-              });
+              })
+            );
           },
 
           async readFile(params: { relPath: string; from?: number; lines?: number }) {
@@ -126,7 +161,7 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
           status() {
             return {
               backend: "qmd",
-              provider: isLocalBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
+              provider: isLocalHonchoBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
               model: "n/a",
               sources: ["sessions"],
               custom: {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,0 +1,147 @@
+import { buildSessionKey } from "./helpers.js";
+import type { PluginState } from "./state.js";
+
+function normalizeSessionPath(sessionId: string): string {
+  return `sessions/${sessionId}.txt`;
+}
+
+function parseSessionPath(relPath: string): string | null {
+  const m = /^sessions\/(.+)\.txt$/.exec(relPath);
+  return m ? m[1] : null;
+}
+
+function countLines(text: string): number {
+  return text.length === 0 ? 1 : text.split(/\r?\n/).length;
+}
+
+function sliceLines(text: string, from = 1, lines?: number): string {
+  const all = text.split(/\r?\n/);
+  const start = Math.max(1, from) - 1;
+  const end = lines == null ? all.length : Math.max(start, start + Math.max(0, lines));
+  return all.slice(start, end).join("\n");
+}
+
+async function buildSessionTranscript(
+  state: PluginState,
+  agentId: string,
+  sessionId: string
+): Promise<string> {
+  await state.ensureInitialized();
+
+  const agentPeer = await state.getAgentPeer(agentId);
+  const session = await state.honcho.session(sessionId, { metadata: { agentId } });
+  const context = await session.context({
+    summary: true,
+    tokens: 20000,
+    peerTarget: state.ownerPeer,
+    peerPerspective: agentPeer,
+  });
+
+  const lines: string[] = [];
+
+  if (context.summary?.content) {
+    lines.push("# Summary", context.summary.content, "");
+  }
+
+  for (const msg of context.messages ?? []) {
+    const speaker =
+      msg.peerId === state.ownerPeer.id
+        ? "User"
+        : msg.peerId === agentPeer.id
+          ? `Agent(${agentId})`
+          : `Peer(${msg.peerId})`;
+    const ts = msg.createdAt ? ` ${msg.createdAt}` : "";
+    lines.push(`## ${speaker}${ts}`, msg.content ?? "", "");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function registerHonchoMemoryRuntime(api: any, state: PluginState): void {
+  api.registerMemoryRuntime({
+    async getMemorySearchManager(params: { agentId?: string }) {
+      const { agentId = state.resolveDefaultAgentId() } = params ?? {};
+
+      await state.ensureInitialized();
+
+      return {
+        manager: {
+          async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
+            await state.ensureInitialized();
+
+            const raw = await state.ownerPeer.search(query, {
+              limit: opts.maxResults ?? 10,
+            });
+
+            const requestedSessionKey =
+              typeof opts.sessionKey === "string" && opts.sessionKey.length > 0 ? opts.sessionKey : null;
+
+            return raw
+              .filter((msg: any) => {
+                if (!requestedSessionKey) return true;
+                return msg.sessionId === requestedSessionKey || msg.sessionId.startsWith(`${requestedSessionKey}-`);
+              })
+              .map((msg: any) => {
+                const snippet = typeof msg.content === "string" ? msg.content : "";
+                return {
+                  path: normalizeSessionPath(msg.sessionId),
+                  startLine: 1,
+                  endLine: countLines(snippet),
+                  score: 1,
+                  snippet,
+                  source: "sessions",
+                };
+              });
+          },
+
+          async readFile(params: { relPath: string; from?: number; lines?: number }) {
+            const sessionId = parseSessionPath(params.relPath);
+            if (!sessionId) {
+              throw new Error(`Unsupported Honcho memory path: ${params.relPath}`);
+            }
+
+            const transcript = await buildSessionTranscript(state, agentId, sessionId);
+            return {
+              path: params.relPath,
+              text: sliceLines(transcript, params.from, params.lines),
+            };
+          },
+
+          status() {
+            return {
+              backend: "qmd",
+              provider:
+                state.cfg.baseUrl?.includes("localhost") || state.cfg.baseUrl?.includes("127.0.0.1")
+                  ? "honcho-selfhosted"
+                  : "honcho",
+              model: "n/a",
+              sources: ["sessions"],
+              custom: {
+                searchMode: "semantic",
+                workspaceId: state.cfg.workspaceId,
+                baseUrl: state.cfg.baseUrl,
+              },
+            };
+          },
+
+          async probeEmbeddingAvailability() {
+            return { ok: true };
+          },
+
+          async probeVectorAvailability() {
+            return true;
+          },
+        },
+      };
+    },
+
+    resolveMemoryBackendConfig(params: { sessionKey?: string; messageProvider?: string } = {}) {
+      const sessionKey = buildSessionKey(params);
+      return {
+        backend: "qmd",
+        qmd: {},
+        sessionKey,
+      };
+    },
+  });
+}

--- a/state.ts
+++ b/state.ts
@@ -32,7 +32,15 @@ export type PluginState = {
 export function createPluginState(api: OpenClawPluginApi): PluginState {
   const cfg = honchoConfigSchema.parse(api.pluginConfig);
 
-  if (!cfg.apiKey) {
+  const base = String(cfg.baseUrl ?? "").toLowerCase();
+  const selfHosted =
+    base.startsWith("http://localhost") ||
+    base.startsWith("http://127.0.0.1") ||
+    base.startsWith("http://") ||
+    base.startsWith("https://localhost") ||
+    base.startsWith("https://127.0.0.1");
+
+  if (!cfg.apiKey && !selfHosted) {
     api.logger.warn(
       "openclaw-honcho: No API key configured. Set HONCHO_API_KEY or configure apiKey in plugin config."
     );

--- a/state.ts
+++ b/state.ts
@@ -12,6 +12,20 @@ import { honchoConfigSchema, type HonchoConfig } from "./config.js";
 export const OWNER_ID = "owner";
 export const LEGACY_PEER_ID = "openclaw";
 
+export function isLocalHonchoBaseUrl(baseUrl?: string): boolean {
+  const base = String(baseUrl ?? "").trim();
+  if (!base) return false;
+
+  try {
+    const { hostname, protocol } = new URL(base);
+    if (protocol !== "http:" && protocol !== "https:") return false;
+    const normalizedHost = hostname.replace(/^\[(.*)\]$/, "$1");
+    return normalizedHost === "localhost" || normalizedHost === "127.0.0.1" || normalizedHost === "::1";
+  } catch {
+    return false;
+  }
+}
+
 export type PluginState = {
   honcho: Honcho;
   cfg: HonchoConfig;
@@ -32,18 +46,7 @@ export type PluginState = {
 export function createPluginState(api: OpenClawPluginApi): PluginState {
   const cfg = honchoConfigSchema.parse(api.pluginConfig);
 
-  const base = String(cfg.baseUrl ?? "").trim();
-  let selfHosted = false;
-  if (base) {
-    try {
-      const { hostname, protocol } = new URL(base);
-      selfHosted =
-        (protocol === "http:" || protocol === "https:") &&
-        (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1");
-    } catch {
-      selfHosted = false;
-    }
-  }
+  const selfHosted = isLocalHonchoBaseUrl(cfg.baseUrl);
 
   if (!cfg.apiKey && !selfHosted) {
     api.logger.warn(

--- a/state.ts
+++ b/state.ts
@@ -32,13 +32,18 @@ export type PluginState = {
 export function createPluginState(api: OpenClawPluginApi): PluginState {
   const cfg = honchoConfigSchema.parse(api.pluginConfig);
 
-  const base = String(cfg.baseUrl ?? "").toLowerCase();
-  const selfHosted =
-    base.startsWith("http://localhost") ||
-    base.startsWith("http://127.0.0.1") ||
-    base.startsWith("http://") ||
-    base.startsWith("https://localhost") ||
-    base.startsWith("https://127.0.0.1");
+  const base = String(cfg.baseUrl ?? "").trim();
+  let selfHosted = false;
+  if (base) {
+    try {
+      const { hostname, protocol } = new URL(base);
+      selfHosted =
+        (protocol === "http:" || protocol === "https:") &&
+        (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1");
+    } catch {
+      selfHosted = false;
+    }
+  }
 
   if (!cfg.apiKey && !selfHosted) {
     api.logger.warn(


### PR DESCRIPTION
## Summary

The plugin initializes Honcho successfully and logs reach "Honcho memory ready", but OpenClaw still reports no active memory runtime because the plugin never calls `api.registerMemoryRuntime(...)`.

A secondary issue: the "No API key configured" warning fires unconditionally, misleading self-hosted users who don't need or have an apiKey.

## What this PR does

### 1. Register a memory runtime adapter (`runtime.ts`)

Adds `registerHonchoMemoryRuntime(api, state)` which calls `api.registerMemoryRuntime(...)` with a Honcho-backed adapter implementing:

- `getMemorySearchManager().manager.search()` — Honcho owner peer semantic search
- `getMemorySearchManager().manager.readFile()` — session transcript read
- `getMemorySearchManager().manager.status()` — backend status (reports `honcho-selfhosted` for localhost)
- `getMemorySearchManager().manager.probeEmbeddingAvailability()` — always ok for Honcho
- `getMemorySearchManager().manager.probeVectorAvailability()` — always ok
- `resolveMemoryBackendConfig()` — backend config resolution

This wires the Honcho plugin into OpenClaw's memory-core slot so `openclaw status` and `openclaw doctor --non-interactive` no longer report missing active memory.

### 2. Scope the api-key warning for self-hosted (`state.ts`)

The warning now only fires when:
- `apiKey` is unset AND
- `baseUrl` is NOT localhost/127.0.0.1

Self-hosted users on `http://localhost:8000` no longer see a misleading auth warning.

## Verification

After the local fix applied to the installed plugin:

- `openclaw status` showed `Memory ... plugin openclaw-honcho` (previously: unavailable)
- `openclaw doctor --non-interactive` stopped reporting missing active memory runtime
- a controlled write-read sentinel test succeeded through the live Honcho memory path
- the false localhost api-key warning disappeared from fresh restart logs

## Files changed

- `index.ts` — import and call `registerHonchoMemoryRuntime()` after state init
- `state.ts` — gate the api-key warning on `!selfHosted`
- `runtime.ts` — new file: the Honcho-backed memory runtime adapter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory search: query session history and receive ranked session "files" with line ranges and snippets.
  * Session transcript reader: fetch sliced transcript views for specific sessions.
  * Runtime integration: a new memory runtime is wired into the plugin to provide these capabilities.

* **Behavior Change**
  * Self-hosted handling: improved local backend detection and suppressed API-key warnings for local endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Tested on

- `openclaw --version`

```text
OpenClaw 2026.3.31 (213a704)
```

- `@honcho-ai/openclaw-honcho` version used for this work: `1.2.2`
