### PR TITLE
ci: auto-publish to npm on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
     paths:
       - "package.json"
-      - "src/**"
-      - "*.ts"
+      - "**/*.ts"
 
 jobs:
   publish:
@@ -30,19 +29,34 @@ jobs:
 
       - run: pnpm build
 
-      # Check if this version is already published
-      - name: Check if version exists on npm
+      # Validate version and ensure it advances npm latest
+      - name: Validate package version against npm
         id: version-check
         run: |
           LOCAL_VERSION=$(node -p "require('./package.json').version")
           echo "local=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
-          PUBLISHED=$(npm view "@honcho-ai/openclaw-honcho@${LOCAL_VERSION}" version 2>/dev/null || echo "")
-          if [ "$PUBLISHED" = "$LOCAL_VERSION" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Version $LOCAL_VERSION already on npm — skipping publish"
-          else
+
+          LATEST_VERSION=$(npm view "@honcho-ai/openclaw-honcho" version 2>/dev/null || echo "")
+          echo "latest=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+
+          npx semver "$LOCAL_VERSION" >/dev/null || {
+            echo "::error::package.json version \"$LOCAL_VERSION\" is not valid semver"
+            exit 1
+          }
+
+          if [ -z "$LATEST_VERSION" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Version $LOCAL_VERSION not on npm — will publish"
+            echo "No published version found on npm — will publish $LOCAL_VERSION"
+            exit 0
+          fi
+
+          if npx semver "$LOCAL_VERSION" -r ">$LATEST_VERSION" >/dev/null; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version $LOCAL_VERSION is greater than npm latest $LATEST_VERSION — will publish"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Version $LOCAL_VERSION must be greater than npm latest $LATEST_VERSION"
+            exit 1
           fi
 
       - name: Publish to npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - "package.json"
-      - "**/*.ts"
 
 jobs:
   publish:
@@ -39,7 +38,7 @@ jobs:
           LATEST_VERSION=$(npm view "@honcho-ai/openclaw-honcho" version 2>/dev/null || echo "")
           echo "latest=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
 
-          npx semver "$LOCAL_VERSION" >/dev/null || {
+          npx semver@7.7.4 "$LOCAL_VERSION" >/dev/null || {
             echo "::error::package.json version \"$LOCAL_VERSION\" is not valid semver"
             exit 1
           }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "package.json"
+      - "src/**"
+      - "*.ts"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      # Check if this version is already published
+      - name: Check if version exists on npm
+        id: version-check
+        run: |
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          echo "local=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+          PUBLISHED=$(npm view "@honcho-ai/openclaw-honcho@${LOCAL_VERSION}" version 2>/dev/null || echo "")
+          if [ "$PUBLISHED" = "$LOCAL_VERSION" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version $LOCAL_VERSION already on npm — skipping publish"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version $LOCAL_VERSION not on npm — will publish"
+          fi
+
+      - name: Publish to npm
+        if: steps.version-check.outputs.changed == 'true'
+        run: pnpm publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag release
+        run: |
+          VERSION=${{ steps.version-check.outputs.local }}
+          TAG="v${VERSION}"
+          if git ls-remote --exit-code --tags origin "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — skipping"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "${TAG}"
+          git push origin "${TAG}"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "extensions": [
       "./dist/index.js"
     ],
+    "build": {
+      "openclawVersion": ">=2026.3.22"
+    },
     "compat": {
       "pluginApi": ">=2026.3.22"
     }


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically publishes to npm when a PR is merged to main with a version bump.

### How it works

1. Triggers on push to main when `.ts` files or `package.json` change
2. Compares the version in `package.json` against what's currently on npm
3. If the version is new: builds, publishes to npm, creates a git tag (`vX.Y.Z`)
4. If the version already exists on npm: skips (no duplicate publish)

### Workflow for merging PRs

- **Bug fix PR**: bump version in package.json as part of the PR (patch: 1.2.2 -> 1.2.3), merge, auto-publishes
- **Feature PR**: bump minor (1.2.x -> 1.3.0), merge, auto-publishes
- **Docs/CI-only PR**: don't bump version, merge, nothing publishes

### One-time setup required

Add `NPM_TOKEN` as a repository secret:

1. Generate token at npmjs.com -> Access Tokens -> Granular Access Token (scoped to `@honcho-ai/openclaw-honcho`, read+write)
2. Add to GitHub: Settings -> Secrets and variables -> Actions -> New repository secret -> Name: `NPM_TOKEN`

### Files changed

- `.github/workflows/publish.yml` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated publishing: CI now builds and publishes new package versions pushed to main only when the local version is newer than the published one, and creates/pushes the matching git tag.
  * Package metadata updated: the plugin's build metadata now includes an additional version constraint, tightening compatibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->