### PR TITLE
fix: update workspace_md/AGENTS.md tool names to match registered tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@honcho-ai/openclaw-honcho` will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- **Stale tool names in `workspace_md/AGENTS.md` (#49)**: Default agent template referenced deprecated tool names (`honcho_profile`, `honcho_search`, `honcho_recall`, `honcho_analyze`) that no longer exist since v1.2.0. Agents bootstrapped with the template would fail when calling memory tools. Updated all references to match registered tools and added parameter hints.
+
 ## [1.2.2] - 2026-03-31
 
 ### Fixed

--- a/workspace_md/AGENTS.md
+++ b/workspace_md/AGENTS.md
@@ -10,24 +10,26 @@ If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out w
 
 Before doing anything else:
 1. Read `SOUL.md` — this is who you are
-2. Use `honcho_profile` for who you're helping
-3. Use `honcho_context` or `honcho_search` for broader context
-4. Use `honcho_recall` (simple Q&A) or `honcho_analyze` (synthesis) as needed
+2. Use `honcho_context` (detail='card') for key facts about who you're helping
+3. Use `honcho_search_conclusions` or `honcho_search_messages` for broader context
+4. Use `honcho_ask` (depth='quick' for simple facts, depth='thorough' for synthesis) as needed
 
 Don't ask permission. Just do it.
 
 ## Honcho Tools (from `index.ts`)
 
-Use the Honcho tools for all memory and context needs. 
+Use the Honcho tools for all memory and context needs.
 
-**Data tools (raw facts, you interpret):**
-- `honcho_profile` — key facts about the user
-- `honcho_search` — targeted semantic search of past context
-- `honcho_context` — broad context snapshot
+**Data tools (raw results, you interpret):**
+- `honcho_context` — key user facts (detail='card') or full representation (detail='full'). Cheap, no LLM.
+- `honcho_search_conclusions` — semantic search over stored conclusions about the user. Raw results ranked by relevance.
+- `honcho_search_messages` — hybrid semantic + full-text search across all sessions. Filter by sender (user/agent/all), date range, or metadata.
+- `honcho_session` — current session history and summary. Not cross-session.
 
 **Q&A tools (Honcho interprets):**
-- `honcho_recall` — simple factual question
-- `honcho_analyze` — synthesized answer across multiple facts
+- `honcho_ask` — ask a question about the user and get a direct answer. depth='quick' for simple factual lookups, depth='thorough' for synthesis across multiple interactions.
+
+Prefer data tools (context, search) when you can reason over the results yourself. Use `honcho_ask` when you need Honcho to synthesize an answer.
 
 ## Safety
 
@@ -146,8 +148,8 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 - You just checked &lt;30 minutes ago
 
 **Proactive work you can do without asking:**
-- Refresh context with `honcho_profile` and `honcho_context`
-- Use `honcho_search` before asking for background details
+- Refresh context with `honcho_context` (detail='card' or detail='full')
+- Use `honcho_search_conclusions` or `honcho_search_messages` before asking for background details
 - Check on projects (git status, etc.)
 - Update documentation
 - Commit and push your own changes


### PR DESCRIPTION
## Problem

`workspace_md/AGENTS.md` references stale tool names that no longer match what the plugin actually registers. The plugin's system prompt injection in `index.ts` already uses the correct new names, but the workspace template was never updated to match.

**Old names in AGENTS.md (non-existent):**
- `honcho_profile`
- `honcho_search`
- `honcho_recall`
- `honcho_analyze`

**Actual registered tool names (from index.ts):**
- `honcho_context` — key user facts (detail='card') or full representation (detail='full')
- `honcho_search_conclusions` — semantic search over stored conclusions
- `honcho_search_messages` — hybrid semantic + full-text search across all sessions
- `honcho_ask` — direct Q&A (depth='quick' for facts, depth='thorough' for synthesis)
- `honcho_session` — current session history and summary

Only 1 of 5 tool names in the template (`honcho_context`) matched what the plugin actually exposes. This causes agents bootstrapped with the default AGENTS.md to reference non-existent tools.

## Changes

Updated all three sections of `workspace_md/AGENTS.md` that reference Honcho tools:

1. **"Every Session" startup steps** — updated tool names and added parameter hints
2. **"Honcho Tools" reference section** — replaced old tool list with current tools, added descriptions matching index.ts, added `honcho_session` and `honcho_search_messages`
3. **Heartbeat proactive work bullets** — updated tool names

Also added the usage guidance from index.ts: "Prefer data tools (context, search) when you can reason over the results yourself. Use `honcho_ask` when you need Honcho to synthesize an answer."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated agent instructions and template to use the current memory/context workflow, added parameter hints, removed deprecated references, and clarified steps for refreshing context and searching past sessions to prevent failures when agents request background information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->