### PR TITLE
feat: Multi-peer support for group chat sender attribution

### DIFF
--- a/clawdbot.plugin.json
+++ b/clawdbot.plugin.json
@@ -16,6 +16,12 @@
       "baseUrl": {
         "type": "string",
         "default": "https://api.honcho.dev"
+      },
+      "ownerSenderIds": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": [],
+        "description": "Platform-specific sender IDs that identify the owner. When set, group chat messages from non-owner senders are attributed to separate Honcho peers."
       }
     }
   },

--- a/config.ts
+++ b/config.ts
@@ -16,6 +16,7 @@ export type HonchoConfig = {
   noisePatterns: string[];
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
+  ownerSenderIds: string[];
 };
 
 /**
@@ -68,6 +69,9 @@ export const honchoConfigSchema = {
       noisePatterns,
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
+      ownerSenderIds: Array.isArray(cfg.ownerSenderIds)
+        ? (cfg.ownerSenderIds as unknown[]).filter((s): s is string => typeof s === "string" && s.length > 0)
+        : [],
     };
   },
 };

--- a/helpers.ts
+++ b/helpers.ts
@@ -2,7 +2,7 @@
  * Pure helper functions — no mutable state dependencies.
  */
 
-import type { Peer, MessageInput } from "@honcho-ai/sdk";
+import type { Peer, MessageInput, Honcho } from "@honcho-ai/sdk";
 
 /**
  * Build a Honcho session key from OpenClaw context.
@@ -165,11 +165,71 @@ export function shouldSkipMessage(content: string, noisePatterns: string[]): boo
   });
 }
 
+/**
+ * Parse sender identity from raw message content before metadata is stripped.
+ * Tries (in order): Sender JSON block > Conversation info JSON > System: line.
+ * Returns { id, name } or null if no sender info is found.
+ */
+export function parseSenderInfo(rawContent: string): { id: string | null; name: string | null } | null {
+  if (!rawContent) return null;
+
+  // 1. Try Sender (untrusted metadata) JSON block — most reliable, has id + name
+  const senderBlockMatch = rawContent.match(
+    /Sender \(untrusted metadata\):\s*```json\s*([\s\S]*?)```/
+  );
+  if (senderBlockMatch) {
+    try {
+      const parsed = JSON.parse(senderBlockMatch[1].trim());
+      if (parsed.id) {
+        return { id: String(parsed.id), name: parsed.name || parsed.label || null };
+      }
+    } catch { /* continue to fallbacks */ }
+  }
+
+  // 2. Try Conversation info JSON — has sender_id field
+  const convoBlockMatch = rawContent.match(
+    /Conversation info \(untrusted metadata\):\s*```json\s*([\s\S]*?)```/
+  );
+  if (convoBlockMatch) {
+    try {
+      const parsed = JSON.parse(convoBlockMatch[1].trim());
+      if (parsed.sender_id) {
+        return { id: String(parsed.sender_id), name: parsed.sender || null };
+      }
+    } catch { /* continue to fallbacks */ }
+  }
+
+  // 3. Fallback: System: [timestamp] Platform message in #channel from Name:
+  const systemMatch = rawContent.match(
+    /^System:\s*\[.*?\]\s*\S+\s+message\s+in\s+\S+\s+from\s+([^:]+):/m
+  );
+  if (systemMatch) {
+    return { id: null, name: systemMatch[1].trim() };
+  }
+
+  return null;
+}
+
+export interface MultiPeerOptions {
+  ownerSenderIds: string[];
+  getPeerForSender: (senderId: string, senderName: string | null) => Promise<Peer>;
+}
+
 export function extractMessages(
   rawMessages: unknown[],
   ownerPeer: Peer,
   agentPeer: Peer,
   noisePatterns: string[] = []
+): MessageInput[] {
+  // Synchronous path for backward compatibility (no multi-peer)
+  return extractMessagesSync(rawMessages, ownerPeer, agentPeer, noisePatterns);
+}
+
+function extractMessagesSync(
+  rawMessages: unknown[],
+  ownerPeer: Peer,
+  agentPeer: Peer,
+  noisePatterns: string[]
 ): MessageInput[] {
   const result: MessageInput[] = [];
 
@@ -204,6 +264,80 @@ export function extractMessages(
 
     if (content) {
       const peer = role === "user" ? ownerPeer : agentPeer;
+      const ts = typeof m.timestamp === "number" ? new Date(m.timestamp) : undefined;
+      result.push(peer.message(content, ts ? { createdAt: ts } : undefined));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Extended message extraction with multi-peer support for group chats.
+ * Parses sender identity from OpenClaw's inbound metadata before cleaning,
+ * then routes messages to the correct peer based on ownerSenderIds.
+ *
+ * When ownerSenderIds is configured:
+ * - Messages from matching sender IDs → ownerPeer
+ * - Messages from unknown senders → dynamically created peer via getPeerForSender
+ * - Assistant messages → agentPeer (unchanged)
+ *
+ * When ownerSenderIds is empty, falls back to extractMessages() behavior.
+ */
+export async function extractMessagesWithPeers(
+  rawMessages: unknown[],
+  ownerPeer: Peer,
+  agentPeer: Peer,
+  noisePatterns: string[] = [],
+  options: MultiPeerOptions
+): Promise<MessageInput[]> {
+  const { ownerSenderIds, getPeerForSender } = options;
+  const result: MessageInput[] = [];
+
+  for (const msg of rawMessages) {
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg as Record<string, unknown>;
+    const role = m.role as string | undefined;
+
+    if (role !== "user" && role !== "assistant") continue;
+
+    let content = "";
+    if (typeof m.content === "string") {
+      content = m.content;
+    } else if (Array.isArray(m.content)) {
+      content = m.content
+        .filter(
+          (block: unknown) =>
+            typeof block === "object" &&
+            block !== null &&
+            (block as Record<string, unknown>).type === "text"
+        )
+        .map((block: unknown) => (block as Record<string, unknown>).text)
+        .filter((t): t is string => typeof t === "string")
+        .join("\n");
+    }
+
+    // Parse sender identity BEFORE cleaning strips the metadata
+    let peer: Peer;
+    if (role === "assistant") {
+      peer = agentPeer;
+    } else {
+      const sender = parseSenderInfo(content);
+      if (!sender || !sender.id || ownerSenderIds.includes(sender.id)) {
+        // Owner or unidentifiable sender (default to owner for backward compat)
+        peer = ownerPeer;
+      } else {
+        peer = await getPeerForSender(sender.id, sender.name);
+      }
+    }
+
+    content = cleanMessageContent(content);
+    content = content.trim();
+
+    if (!content) continue;
+    if (shouldSkipMessage(content, noisePatterns)) continue;
+
+    if (content) {
       const ts = typeof m.timestamp === "number" ? new Date(m.timestamp) : undefined;
       result.push(peer.message(content, ts ? { createdAt: ts } : undefined));
     }

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -2,10 +2,12 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { OWNER_ID } from "../state.js";
+import type { Peer } from "@honcho-ai/sdk";
 import {
   buildSessionKey,
   isSubagentSession,
   extractMessages,
+  extractMessagesWithPeers,
 } from "../helpers.js";
 import { subagentParentMap } from "./subagent.js";
 
@@ -63,6 +65,19 @@ async function flushMessages(
     peerConfigs.push([parentPeer.id, { observeMe: false, observeOthers: true }]);
   }
 
+  // Dynamic peer cache for multi-peer group chat support
+  const dynamicPeers = new Map<string, Peer>();
+  const getPeerForSender = async (senderId: string, senderName: string | null): Promise<Peer> => {
+    let peer = dynamicPeers.get(senderId);
+    if (peer) return peer;
+    const peerId = `user-${senderId}`;
+    peer = await state.honcho.peer(peerId, {
+      metadata: { senderId, senderName: senderName || senderId, type: "external" },
+    });
+    dynamicPeers.set(senderId, peer);
+    return peer;
+  };
+
   await session.addPeers(peerConfigs);
 
   if (messages.length <= startIndex) {
@@ -70,11 +85,28 @@ async function flushMessages(
   }
 
   const newRawMessages = messages.slice(startIndex);
-  const extracted = extractMessages(newRawMessages, state.ownerPeer!, agentPeer, state.cfg.noisePatterns);
+  const multiPeerEnabled = state.cfg.ownerSenderIds.length > 0;
+  const extracted = multiPeerEnabled
+    ? await extractMessagesWithPeers(
+        newRawMessages,
+        state.ownerPeer!,
+        agentPeer,
+        state.cfg.noisePatterns,
+        { ownerSenderIds: state.cfg.ownerSenderIds, getPeerForSender },
+      )
+    : extractMessages(newRawMessages, state.ownerPeer!, agentPeer, state.cfg.noisePatterns);
 
   if (extracted.length === 0) {
     await session.setMetadata({ ...existingMeta, ...sessionMeta, lastSavedIndex: messages.length });
     return 0;
+  }
+
+  // Add any dynamically created peers to the session before saving messages
+  for (const [, dynPeer] of dynamicPeers) {
+    peerConfigs.push([dynPeer.id, { observeMe: true, observeOthers: false }]);
+  }
+  if (dynamicPeers.size > 0) {
+    await session.addPeers(peerConfigs);
   }
 
   await session.addMessages(extracted);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -31,6 +31,12 @@
         "type": "boolean",
         "default": false,
         "description": "When true, built-in noise patterns are not applied — only noisePatterns entries are used."
+      },
+      "ownerSenderIds": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": [],
+        "description": "Platform-specific sender IDs that identify the owner (e.g. Slack user IDs). When set, group chat messages from non-owner senders are attributed to separate Honcho peers instead of the owner."
       }
     }
   },
@@ -65,6 +71,11 @@
       "label": "Disable Default Noise Patterns",
       "advanced": true,
       "help": "When enabled, only custom noisePatterns entries are used — built-in defaults are skipped."
+    },
+    "ownerSenderIds": {
+      "label": "Owner Sender IDs",
+      "advanced": true,
+      "help": "Your platform user IDs (e.g. Slack U...). Messages from other senders in group chats get their own Honcho peer instead of being attributed to you."
     }
   }
 }


### PR DESCRIPTION
## Problem

When the OpenClaw Honcho plugin operates in group chats (Slack channels, Telegram groups, Discord servers, etc.), all `role: "user"` messages are attributed to the `owner` peer — regardless of who actually sent them.

This means if a coworker says "I prefer dark mode for all our tools" in a shared Slack channel, Honcho's Deriver processes it as if the owner said it. Over time, this contaminates the owner's user model with other people's opinions, preferences, and facts.

This contamination appears unintended — Honcho already has full multi-peer support (`honcho.peer()`, `session.addPeers()`, per-peer message attribution). The plugin simply doesn't wire it up for group chat participants.

## Root cause

`extractMessages()` in `helpers.ts` maps `role: "user"` → `ownerPeer` and `role: "assistant"` → `agentPeer`. There's no sender-level disambiguation:

```ts
// helpers.ts (current)
const peer = role === "user" ? ownerPeer : agentPeer;
```

Meanwhile, `cleanMessageContent()` intentionally strips the sender metadata blocks before persisting — the `Sender (untrusted metadata)` and `Conversation info (untrusted metadata)` JSON blocks that contain `sender_id` and `sender_name`. The design rationale ("AI-facing only, must not be stored") makes sense for content storage, but it discards the identity signal needed for peer routing.

## The data exists but gets discarded

OpenClaw injects structured sender metadata into every message, regardless of channel type:

```
Sender (untrusted metadata):
```json
{
  "id": "U08HLS86GJK",
  "name": "Alice"
}
```

Conversation info (untrusted metadata):
```json
{
  "sender_id": "U08HLS86GJK",
  "sender": "Alice",
  "chat_type": "channel",
  ...
}
```
```

This format is consistent across all OpenClaw channel plugins (Slack, Telegram, Discord, etc.). The sender identity is available — it just needs to be parsed before `cleanMessageContent()` strips it.

## Changes

~60 lines of new logic across 5 files:

### `config.ts`
- Add `ownerSenderIds: string[]` to `HonchoConfig` — platform-specific sender IDs that identify the owner (e.g., Slack user IDs). Needed because OpenClaw doesn't expose an `ownerId` concept to plugins.

### `helpers.ts`
- Add `parseSenderInfo(rawContent)` — extracts `{id, name}` from the `Sender (untrusted metadata)` JSON block before `cleanMessageContent()` strips it, with fallbacks to `Conversation info` block and `System:` line.
- Add `extractMessagesWithPeers()` — async version of `extractMessages()` that routes messages to the correct peer based on parsed sender identity and `ownerSenderIds`.
- Original `extractMessages()` preserved unchanged for backward compatibility.

### `hooks/capture.ts`
- Dynamic peer creation via `state.honcho.peer("user-{senderId}")` with metadata `{ senderId, senderName, type: "external" }`.
- Per-flush peer cache (Map) to avoid redundant API calls within a single capture cycle.
- Dynamic peers added to session via `session.addPeers()` with `{ observeMe: true, observeOthers: false }`.

### `openclaw.plugin.json` + `clawdbot.plugin.json`
- Add `ownerSenderIds` to JSON schema and UI hints.

## Behavior

- When `ownerSenderIds` is empty (default): **identical to current behavior**. Zero breaking changes.
- When configured (e.g., `["U08HLS86GJK"]`):
  - Messages from matching sender IDs → `ownerPeer` (existing behavior)
  - Messages from unknown senders → dynamically created peer `user-{senderId}`
  - Assistant messages → `agentPeer` (unchanged)

## Benefits

- Owner's user model stays clean — only their messages train their representation
- Honcho builds separate models for each group chat participant
- `peer.conclusionsOf("user-{id}")` enables querying what the agent knows about specific people
- Fully backward compatible

## Follow-up suggestions

- **Documentation**: An example showing multi-peer group chat integration would be valuable for other OpenClaw users.
- **Aspirational**: A built-in implementation that auto-detects sender identity from OpenClaw's envelope format would eliminate the need for manual `ownerSenderIds` config — though this is understandably complex given the variety of chat platforms and message formats. Ideally OpenClaw itself would expose `owner.senderIds` to plugins, making the config unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-peer group chat support. New `ownerSenderIds` configuration option allows you to designate which senders are the owner. Messages from non-owner senders are now automatically attributed to separate peer identities for improved conversation organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->