### PR TITLE
feat: multi-peer group chat support with review fixes from #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `noisePatterns`        | `string[]` | built-in defaults          | Patterns to skip messages. User-provided patterns are merged with built-in defaults (unless `disableDefaultNoisePatterns` is set). |
 | `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
+| `peerMappings`         | `object`   | `{}`                       | Maps channel peer IDs (e.g., Slack user IDs) to Honcho peer IDs. Unmapped senders are auto-created. |
+| `agentPeerMappings`    | `object`   | `{}`                       | Maps OpenClaw agent IDs to Honcho peer IDs. Default: agent `foo` gets peer ID `agent-foo`. |
 
 ### Self-Hosted / Local Honcho
 
@@ -109,13 +111,48 @@ Honcho's `observeOthers` controls whether a peer forms representations of other 
 
 Set `ownerObserveOthers: true` to let the owner peer also observe agent messages. This gives Honcho perspective-aware memory: the owner stores conclusions about the agent based only on what it witnessed, enabling the user's representation to reflect the full conversational context rather than just their own side of it.
 
+### Peer Mappings
+
+In group chats (Discord, Slack, etc.), the plugin extracts the sender's platform ID from each inbound message and maps it to a Honcho peer. This gives each human participant their own memory and representation in Honcho, rather than attributing all user messages to a single generic peer.
+
+Configure `peerMappings` to map known channel peer IDs to specific Honcho peer IDs:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw-honcho": {
+        "config": {
+          "peerMappings": {
+            "U01ZB5DG019": "owner"
+          },
+          "agentPeerMappings": {
+            "agent-slack": "demerzel"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**How it works:**
+- The plugin reads the `sender_id` field from OpenClaw's "Conversation info (untrusted metadata):" block, which is injected into group chat messages.
+- If the sender ID has a `peerMappings` entry, the mapped Honcho peer ID is used.
+- If no mapping exists, a Honcho peer is auto-created using the channel peer ID directly (e.g., `U07KX7DG002` becomes the Honcho peer ID).
+- In DMs, no sender metadata is present, so the default `owner` peer is used (existing behavior preserved).
+- `agentPeerMappings` works the same way for agent peers — by default, an agent with ID `slack` gets Honcho peer ID `agent-slack`, but you can override it (e.g., to `demerzel`).
+- All tools (`honcho_context`, `honcho_ask`, etc.) automatically resolve the correct peer for the current session.
+
+Auto-created peer mappings are persisted in workspace metadata so they survive gateway restarts.
+
 ## How it works
 
 Once installed, the plugin works automatically:
 
 - **Message Observation** — After every AI turn, the conversation is persisted to Honcho. Both user and agent messages are observed, allowing Honcho to build and refine its models. Message capture starts when the plugin is active for a session, and preserves original timestamps for captured messages. Messages are also flushed before session compaction and `/new`/`/reset`, so no conversation data is lost.
 - **Tool-Based Context Access** — The AI can query Honcho mid-conversation using tools like `honcho_context`, `honcho_search_conclusions`, and `honcho_ask` to retrieve relevant context about the user. Context is injected during OpenClaw's `before_prompt_build` phase, ensuring accurate turn boundaries.
-- **Dual Peer Model** — Honcho maintains separate representations: one for the user (preferences, facts, communication style) and one for the agent (personality, learned behaviors). Each OpenClaw agent gets its own Honcho peer (`agent-{id}`), so multi-agent workspaces maintain isolated memory.
+- **Multi-Peer Model** — Honcho maintains separate representations for each participant. In group chats, each human sender gets their own peer (mapped via `peerMappings` or auto-created from their platform ID). Each OpenClaw agent gets its own Honcho peer (default `agent-{id}`, overridable via `agentPeerMappings`). In DMs, the default `owner` peer is used. This gives every participant isolated, personalized memory.
 - **Clean Persistence** — Platform metadata (conversation info, sender headers, thread context, forwarded messages) is stripped before saving to Honcho, ensuring only meaningful content is persisted. Noise messages (heartbeat acks, cron boilerplate, startup commands) are dropped entirely via configurable pattern filters.
 
 Honcho handles all reasoning and synthesis in the cloud.

--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -8,6 +9,31 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { OWNER_ID } from "../state.js";
 
+/* ── Upload manifest ─────────────────────────────────────────────────── */
+
+type ManifestEntry = { sha256: string; uploadedAt: string; baseUrl: string; workspaceId: string };
+type UploadManifest = Record<string, ManifestEntry>;
+
+const MANIFEST_PATH = () => path.join(os.homedir(), ".openclaw", ".upload-manifest.json");
+
+function loadManifest(): UploadManifest {
+  try {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH(), "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+function saveManifest(manifest: UploadManifest): void {
+  const dir = path.dirname(MANIFEST_PATH());
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(MANIFEST_PATH(), JSON.stringify(manifest, null, 2));
+}
+
+function contentHash(content: Buffer): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
 export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
   api.registerCli(
     ({ program, workspaceDir }) => {
@@ -16,61 +42,111 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
       cmd
         .command("setup")
         .description("Configure Honcho API key and upload memory files to Honcho")
-        .action(async () => {
+        .option("--reconfigure", "Force re-entry of all configuration values")
+        .action(async (options: { reconfigure?: boolean }) => {
           const configDir = path.join(os.homedir(), ".openclaw");
           const configPath = path.join(configDir, "openclaw.json");
 
+          // Load existing config to use as defaults
+          let config: Record<string, unknown> = {};
+          if (fs.existsSync(configPath)) {
+            try { config = JSON.parse(fs.readFileSync(configPath, "utf-8")); } catch { /* use empty */ }
+          }
+          const existingPluginCfg = (
+            ((config.plugins as Record<string, unknown>)
+              ?.entries as Record<string, unknown>)
+              ?.["openclaw-honcho"] as Record<string, unknown>
+          )?.config as Record<string, unknown> | undefined;
+
+          const savedApiKey = (existingPluginCfg?.apiKey as string) ?? "";
+          const savedBaseUrl = (existingPluginCfg?.baseUrl as string) || "https://api.honcho.dev";
+          const savedWorkspaceId = (existingPluginCfg?.workspaceId as string) || "openclaw";
+          const hasExistingConfig = !!existingPluginCfg && !!savedApiKey;
+
           console.log("\nHoncho Setup\n");
           console.log("Get your API key from: https://app.honcho.dev\n");
-          console.log('Press Enter to use the default shown in [brackets].\n');
 
           const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
           const ask = (q: string): Promise<string> => new Promise((resolve) => rl.question(q, resolve));
 
           try {
-            const apiKeyInput = await ask("Honcho API key (press Enter for self-hosted mode): ");
-            const baseUrlInput = await ask("Base URL [https://api.honcho.dev]: ");
-            const workspaceIdInput = await ask("Workspace ID [openclaw]: ");
+            let resolvedApiKey: string;
+            let resolvedBaseUrl: string;
+            let resolvedWorkspaceId: string;
 
-            const resolvedBaseUrl = baseUrlInput.trim() || "https://api.honcho.dev";
-            const resolvedWorkspaceId = workspaceIdInput.trim() || "openclaw";
+            if (hasExistingConfig && !options.reconfigure) {
+              const maskedKey = savedApiKey.length > 8
+                ? savedApiKey.slice(0, 4) + "..." + savedApiKey.slice(-4)
+                : "****";
+              console.log("Existing configuration found:");
+              console.log(`  API key:      ${maskedKey}`);
+              console.log(`  Base URL:     ${savedBaseUrl}`);
+              console.log(`  Workspace ID: ${savedWorkspaceId}`);
+              console.log('\nPress Enter to keep existing values, or use --reconfigure to change.\n');
 
-            // Write config
-            let config: Record<string, unknown> = {};
-            if (fs.existsSync(configPath)) {
-              try { config = JSON.parse(fs.readFileSync(configPath, "utf-8")); } catch { /* use empty */ }
+              resolvedApiKey = savedApiKey;
+              resolvedBaseUrl = savedBaseUrl;
+              resolvedWorkspaceId = savedWorkspaceId;
+              console.log("✓ Using existing configuration\n");
+            } else {
+              console.log('Press Enter to use the default shown in [brackets].\n');
+
+              const apiKeyDefault = savedApiKey ? ` [${savedApiKey.slice(0, 4)}...${savedApiKey.slice(-4)}]` : "";
+              const apiKeyInput = await ask(`Honcho API key${apiKeyDefault || " (press Enter for self-hosted mode)"}: `);
+              const baseUrlInput = await ask(`Base URL [${savedBaseUrl}]: `);
+              const workspaceIdInput = await ask(`Workspace ID [${savedWorkspaceId}]: `);
+
+              resolvedApiKey = apiKeyInput.trim() || savedApiKey;
+              resolvedBaseUrl = baseUrlInput.trim() || savedBaseUrl;
+              resolvedWorkspaceId = workspaceIdInput.trim() || savedWorkspaceId;
+
+              // Write config
+              if (!config.plugins) config.plugins = {};
+              const pluginsSection = config.plugins as Record<string, unknown>;
+              if (!pluginsSection.entries) pluginsSection.entries = {};
+              const entriesSection = pluginsSection.entries as Record<string, unknown>;
+              const existingEntry = (entriesSection["openclaw-honcho"] as Record<string, unknown>) ?? {};
+              const pluginCfg: Record<string, unknown> = {
+                ...(existingEntry.config as Record<string, unknown> ?? {}),
+              };
+              if (resolvedApiKey) pluginCfg.apiKey = resolvedApiKey;
+              else delete pluginCfg.apiKey;
+              pluginCfg.baseUrl = resolvedBaseUrl;
+              pluginCfg.workspaceId = resolvedWorkspaceId;
+              entriesSection["openclaw-honcho"] = { ...existingEntry, config: pluginCfg };
+
+              if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
+              fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+              console.log("\n✓ Configuration saved to ~/.openclaw/openclaw.json");
             }
-            if (!config.plugins) config.plugins = {};
-            const pluginsSection = config.plugins as Record<string, unknown>;
-            if (!pluginsSection.entries) pluginsSection.entries = {};
-            const entriesSection = pluginsSection.entries as Record<string, unknown>;
-            const existingEntry = (entriesSection["openclaw-honcho"] as Record<string, unknown>) ?? {};
-            const pluginCfg: Record<string, unknown> = {
-              ...(existingEntry.config as Record<string, unknown> ?? {}),
-            };
-            const trimmedApiKey = apiKeyInput.trim();
-            if (trimmedApiKey) pluginCfg.apiKey = trimmedApiKey;
-            else delete pluginCfg.apiKey;
-            const trimmedBaseUrl = baseUrlInput.trim();
-            if (trimmedBaseUrl) pluginCfg.baseUrl = trimmedBaseUrl;
-            else delete pluginCfg.baseUrl;
-            const trimmedWorkspaceId = workspaceIdInput.trim();
-            if (trimmedWorkspaceId) pluginCfg.workspaceId = trimmedWorkspaceId;
-            else delete pluginCfg.workspaceId;
-            entriesSection["openclaw-honcho"] = { ...existingEntry, config: pluginCfg };
 
-            if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
-            fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-            console.log("\n✓ Configuration saved to ~/.openclaw/openclaw.json");
-
-            // Resolve default agent and its workspace from config
+            // Resolve configured agents and their workspaces from config
             let savedConfig: Record<string, unknown> = {};
             try { savedConfig = JSON.parse(fs.readFileSync(configPath, "utf-8")); } catch { /* use empty */ }
 
             const agentsList = Array.isArray((savedConfig?.agents as Record<string, unknown>)?.list)
               ? ((savedConfig.agents as Record<string, unknown>).list as Array<Record<string, unknown>>)
               : [];
-            const defaultAgent = agentsList.find((a) => a?.default) ?? agentsList[0] ?? null;
+            const hasExplicitDefault = agentsList.some((a) => a?.default === true);
+            const normalizedAgents = (agentsList.length > 0 ? agentsList : [{ id: "main", default: true }])
+              .map((agent, index) => {
+                const agentId = ((agent?.id as string) ?? (index === 0 ? "main" : `a${index + 1}`)).toLowerCase().trim() || "main";
+                return {
+                  id: agentId,
+                  workspace: agent?.workspace as string | undefined,
+                  workspaceDir: agent?.workspaceDir as string | undefined,
+                  isDefault: agent?.default === true || (index === 0 && !hasExplicitDefault),
+                };
+              })
+              .filter((agent, index, all) => {
+                const firstIndex = all.findIndex((candidate) => candidate.id === agent.id);
+                if (firstIndex !== index) {
+                  console.log(`  ! Duplicate normalized agent ID "${agent.id}" — skipping later entry during migration setup`);
+                  return false;
+                }
+                return true;
+              });
+            const defaultAgent = normalizedAgents.find((a) => a.isDefault) ?? normalizedAgents[0];
             const defaultAgentId = ((defaultAgent?.id as string) ?? "main").toLowerCase().trim() || "main";
             const defaultAgentPeerId = `agent-${defaultAgentId}`;
 
@@ -78,66 +154,98 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
             const AGENT_FILES = ["SOUL.md", "IDENTITY.md", "AGENTS.md", "TOOLS.md", "BOOTSTRAP.md"];
             const OWNER_DIRS = ["memory", "canvas"];
 
-            type FileEntry = { filePath: string; peer: "owner" | "agent" };
+            type FileEntry = { filePath: string; peer: "owner" | "agent"; peerId: string; agentId?: string };
             const detected: FileEntry[] = [];
 
-            function collectDir(dirPath: string, peerType: "owner" | "agent"): void {
+            function hasDetected(filePath: string, peerId: string): boolean {
+              return detected.some((entry) => entry.filePath === filePath && entry.peerId === peerId);
+            }
+
+            function collectDir(dirPath: string, peerType: "owner" | "agent", agentId?: string): void {
               if (!fs.existsSync(dirPath)) return;
               const dirEntries = fs.readdirSync(dirPath, { withFileTypes: true });
+              const peerId = peerType === "owner" ? OWNER_ID : `agent-${agentId ?? defaultAgentId}`;
               for (const e of dirEntries) {
                 const full = path.join(dirPath, e.name);
-                if (e.isDirectory()) collectDir(full, peerType);
-                else detected.push({ filePath: full, peer: peerType });
+                if (e.isDirectory()) collectDir(full, peerType, agentId);
+                else if (!hasDetected(full, peerId)) detected.push({ filePath: full, peer: peerType, peerId, agentId });
               }
             }
 
-            function scanWorkspace(wsDir: string): void {
+            function scanWorkspace(wsDir: string, agentId?: string): void {
               for (const file of OWNER_FILES) {
                 const p = path.join(wsDir, file);
-                if (fs.existsSync(p) && !detected.find((d) => d.filePath === p))
-                  detected.push({ filePath: p, peer: "owner" });
+                if (fs.existsSync(p) && !hasDetected(p, OWNER_ID))
+                  detected.push({ filePath: p, peer: "owner", peerId: OWNER_ID });
               }
-              for (const file of AGENT_FILES) {
-                const p = path.join(wsDir, file);
-                if (fs.existsSync(p) && !detected.find((d) => d.filePath === p))
-                  detected.push({ filePath: p, peer: "agent" });
+              if (agentId) {
+                const peerId = `agent-${agentId}`;
+                for (const file of AGENT_FILES) {
+                  const p = path.join(wsDir, file);
+                  if (fs.existsSync(p) && !hasDetected(p, peerId))
+                    detected.push({ filePath: p, peer: "agent", peerId, agentId });
+                }
               }
               for (const dir of OWNER_DIRS) {
                 collectDir(path.join(wsDir, dir), "owner");
               }
             }
 
-            // Build ordered candidate workspace paths, deduplicated by real path.
             const ocHome = path.join(os.homedir(), ".openclaw");
+            const defaultWorkspace = ((savedConfig?.agents as Record<string, unknown>)?.defaults as Record<string, unknown>)?.workspace as string | undefined;
 
-            const candidateWsPaths: string[] = [
+            function uniqueWorkspacePaths(paths: Array<string | undefined>): string[] {
+              const seen = new Set<string>();
+              return paths.filter((p): p is string => typeof p === "string" && p.length > 0).filter((p) => {
+                const real = fs.existsSync(p) ? fs.realpathSync(p) : p;
+                if (seen.has(real)) return false;
+                seen.add(real);
+                return true;
+              });
+            }
+
+            const ownerCandidateWsPaths = uniqueWorkspacePaths([
               workspaceDir as string,
               defaultAgent?.workspace as string,
               defaultAgent?.workspaceDir as string,
-              ((savedConfig?.agents as Record<string, unknown>)?.defaults as Record<string, unknown>)?.workspace as string,
-              path.join(ocHome, "agents", defaultAgentId, "workspace"),
+              defaultWorkspace,
               path.join(ocHome, "workspace"),
               path.join(os.homedir(), ".clawdbot", "workspace"),
-            ].filter(Boolean);
+            ]);
 
-            // Deduplicate by resolved real path so symlinks / duplicate entries don't double-scan
-            const seen = new Set<string>();
-            const uniqueCandidates = candidateWsPaths.filter((p) => {
-              const real = fs.existsSync(p) ? fs.realpathSync(p) : p;
-              if (seen.has(real)) return false;
-              seen.add(real);
-              return true;
-            });
+            const agentWorkspaceCandidates = normalizedAgents.map((agent) => ({
+              agentId: agent.id,
+              peerId: `agent-${agent.id}`,
+              workspacePaths: uniqueWorkspacePaths([
+                agent.workspace,
+                agent.workspaceDir,
+                agent.isDefault ? (workspaceDir as string) : undefined,
+                agent.isDefault ? defaultWorkspace : undefined,
+                path.join(ocHome, "agents", agent.id, "workspace"),
+                agent.isDefault ? path.join(ocHome, "workspace") : undefined,
+                agent.isDefault ? path.join(os.homedir(), ".clawdbot", "workspace") : undefined,
+              ]),
+            }));
 
-            for (const candidate of uniqueCandidates) {
+            // Scan shared/default workspace roots only for owner files. Agent files
+            // must come from an agent-specific workspace path so they can be
+            // assigned to the correct `agent-{id}` peer.
+            for (const candidate of ownerCandidateWsPaths) {
               scanWorkspace(candidate);
-              if (detected.length > 0) break;
+            }
+            for (const agent of agentWorkspaceCandidates) {
+              for (const candidate of agent.workspacePaths) {
+                scanWorkspace(candidate, agent.agentId);
+              }
             }
 
             // Still nothing — prompt user to enter additional paths manually
             if (detected.length === 0) {
               console.log("\nNo memory files found. Searched:");
-              for (const c of uniqueCandidates) console.log(`  ${c}`);
+              for (const c of ownerCandidateWsPaths) console.log(`  ${c}`);
+              for (const agent of agentWorkspaceCandidates) {
+                for (const c of agent.workspacePaths) console.log(`  ${c} (agent: ${agent.agentId})`);
+              }
               console.log('\nEnter file or directory paths to upload (one per line, empty line to finish):');
               console.log('Format: /path/to/file-or-dir [owner|agent]  (peer defaults to "owner" if omitted)\n');
               while (true) {
@@ -156,10 +264,15 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
                   continue;
                 }
                 if (fs.statSync(inputPath).isDirectory()) {
-                  collectDir(inputPath, peerType);
+                  collectDir(inputPath, peerType, peerType === "agent" ? defaultAgentId : undefined);
                   console.log(`  + ${inputPath}/ (directory) → ${peerType === "owner" ? OWNER_ID : defaultAgentPeerId}`);
                 } else {
-                  detected.push({ filePath: inputPath, peer: peerType });
+                  detected.push({
+                    filePath: inputPath,
+                    peer: peerType,
+                    peerId: peerType === "owner" ? OWNER_ID : defaultAgentPeerId,
+                    agentId: peerType === "agent" ? defaultAgentId : undefined,
+                  });
                   console.log(`  + ${inputPath} → ${peerType === "owner" ? OWNER_ID : defaultAgentPeerId}`);
                 }
               }
@@ -173,10 +286,12 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
 
             console.log(`\nFound ${detected.length} memory file(s):`);
             console.log(`Default agent: ${defaultAgentId} (peer: ${defaultAgentPeerId})`);
-            for (const { filePath, peer } of detected) {
+            if (normalizedAgents.length > 1) {
+              console.log(`Configured agents: ${normalizedAgents.map((agent) => `${agent.id} (peer: agent-${agent.id})`).join(", ")}`);
+            }
+            for (const { filePath, peerId } of detected) {
               const size = fs.statSync(filePath).size;
-              const peerLabel = peer === "owner" ? OWNER_ID : defaultAgentPeerId;
-              console.log(`  ${filePath} (${(size / 1024).toFixed(1)} KB) → ${peerLabel}`);
+              console.log(`  ${filePath} (${(size / 1024).toFixed(1)} KB) → ${peerId}`);
             }
             console.log(`\nData destination: ${resolvedBaseUrl}`);
 
@@ -189,7 +304,7 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
 
             // Upload files to Honcho
             const setupHoncho = new Honcho({
-              apiKey: apiKeyInput.trim() || undefined,
+              apiKey: resolvedApiKey || undefined,
               baseURL: resolvedBaseUrl,
               workspaceId: resolvedWorkspaceId,
             });
@@ -197,38 +312,108 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
             const existingMeta = await setupHoncho.getMetadata();
             await setupHoncho.setMetadata({ ...existingMeta });
             const ownerPeerSetup = await setupHoncho.peer(OWNER_ID, { metadata: {} });
-            const agentPeerSetup = await setupHoncho.peer(defaultAgentPeerId, { metadata: { agentId: defaultAgentId } });
+            const agentPeerSetupMap = new Map<string, Awaited<ReturnType<typeof setupHoncho.peer>>>();
+            for (const agent of normalizedAgents) {
+              const peerId = `agent-${agent.id}`;
+              const peer = await setupHoncho.peer(peerId, { metadata: { agentId: agent.id } });
+              agentPeerSetupMap.set(agent.id, peer);
+            }
             const migrationSession = await setupHoncho.session("migration-setup", { metadata: {} });
-            await migrationSession.addPeers([
-              [ownerPeerSetup, { observeMe: true, observeOthers: false }],
-              [agentPeerSetup, { observeMe: true, observeOthers: true }],
-            ]);
+            await migrationSession.addPeers([ownerPeerSetup, { observeMe: true, observeOthers: false }]);
+            for (const agent of normalizedAgents) {
+              await migrationSession.addPeers([
+                agentPeerSetupMap.get(agent.id)!,
+                { observeMe: true, observeOthers: true },
+              ]);
+            }
+
+            // Cooldown after setup calls — the hosted platform (groudon) enforces
+            // 5 req/sec per tenant; the 6 calls above consume most of that budget.
+            await new Promise((r) => setTimeout(r, 1500));
 
             const MAX_UPLOAD_BYTES = 5 * 1024 * 1024; // 5MB safety cap
+            const UPLOAD_DELAY_MS = 400; // stay under 5 req/sec platform limit
 
+            const manifest = loadManifest();
             let uploadCount = 0;
-            for (const { filePath, peer } of detected) {
+            let unchangedCount = 0;
+            const skipped: string[] = [];
+            const failed: { filePath: string; error: string }[] = [];
+            const total = detected.length;
+
+            for (let i = 0; i < detected.length; i++) {
+              const { filePath, peer, agentId } = detected[i];
+              const progress = `[${i + 1}/${total}]`;
+
               const stat = await fs.promises.stat(filePath).catch(() => null);
               if (!stat?.isFile()) continue;
               if (stat.size > MAX_UPLOAD_BYTES) {
-                console.log(`  ! Skipping (too large): ${filePath}`);
+                console.log(`  ${progress} ! Skipping (larger than 5MB): ${filePath}`);
+                skipped.push(filePath);
                 continue;
               }
               const filename = path.basename(filePath);
               const ext = path.extname(filename).toLowerCase();
               const content_type = ext === ".json" ? "application/json" : ext === ".md" ? "text/markdown" : null;
               if (!content_type) {
-                console.log(`  ! Skipping unsupported file type: ${filePath}`);
+                console.log(`  ${progress} ! Skipping unsupported type: ${filePath}`);
+                skipped.push(filePath);
                 continue;
               }
-              const content = await fs.promises.readFile(filePath);
-              const targetPeer = peer === "owner" ? ownerPeerSetup : agentPeerSetup;
-              await new Promise((r) => setTimeout(r, 250)); // stay under 5 req/sec limit
-              await migrationSession.uploadFile({ filename, content, content_type }, targetPeer, {});
-              console.log(`  ✓ Uploaded: ${filePath}`);
-              uploadCount++;
+
+              const targetPeer = peer === "owner"
+                ? ownerPeerSetup
+                : agentPeerSetupMap.get(agentId ?? defaultAgentId);
+              if (!targetPeer) {
+                console.log(`  ${progress} ✗ Failed: ${filePath}`);
+                failed.push({ filePath, error: `Missing Honcho peer for agent ${agentId ?? defaultAgentId}` });
+                continue;
+              }
+              try {
+                const content = await fs.promises.readFile(filePath);
+                const hash = contentHash(content);
+
+                // Skip files already uploaded with identical content to the same destination
+                const prev = manifest[filePath];
+                if (prev && prev.sha256 === hash && prev.baseUrl === resolvedBaseUrl && prev.workspaceId === resolvedWorkspaceId) {
+                  console.log(`  ${progress} ~ Unchanged: ${filePath}`);
+                  unchangedCount++;
+                  continue;
+                }
+
+                await new Promise((r) => setTimeout(r, UPLOAD_DELAY_MS));
+                await migrationSession.uploadFile({ filename, content, content_type }, targetPeer, {});
+                console.log(`  ${progress} ✓ Uploaded: ${filePath}`);
+                uploadCount++;
+
+                // Record success
+                manifest[filePath] = { sha256: hash, uploadedAt: new Date().toISOString(), baseUrl: resolvedBaseUrl, workspaceId: resolvedWorkspaceId };
+                saveManifest(manifest);
+              } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.log(`  ${progress} ✗ Failed: ${filePath}`);
+                failed.push({ filePath, error: msg });
+              }
             }
-            console.log(`\n✓ Uploaded ${uploadCount} file(s) to Honcho`);
+
+            // Clean stale manifest entries
+            for (const key of Object.keys(manifest)) {
+              if (!fs.existsSync(key)) delete manifest[key];
+            }
+            saveManifest(manifest);
+
+            // Summary
+            console.log(`\nUpload summary:`);
+            console.log(`  Uploaded:  ${uploadCount}/${total}`);
+            if (unchangedCount > 0) console.log(`  Unchanged: ${unchangedCount}`);
+            if (skipped.length > 0) console.log(`  Skipped:   ${skipped.length}`);
+            if (failed.length > 0) {
+              console.log(`  Failed:    ${failed.length}`);
+              for (const f of failed) {
+                console.log(`    ! ${f.filePath} — ${f.error}`);
+              }
+              console.log(`\nRun \`openclaw honcho setup\` again to retry failed files.`);
+            }
 
             console.log("\n✓ Setup complete. Run `openclaw gateway --force` to activate.\n");
           } finally {

--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -1,4 +1,3 @@
-import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -9,31 +8,6 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { OWNER_ID } from "../state.js";
 
-/* ── Upload manifest ─────────────────────────────────────────────────── */
-
-type ManifestEntry = { sha256: string; uploadedAt: string; baseUrl: string; workspaceId: string };
-type UploadManifest = Record<string, ManifestEntry>;
-
-const MANIFEST_PATH = () => path.join(os.homedir(), ".openclaw", ".upload-manifest.json");
-
-function loadManifest(): UploadManifest {
-  try {
-    return JSON.parse(fs.readFileSync(MANIFEST_PATH(), "utf-8"));
-  } catch {
-    return {};
-  }
-}
-
-function saveManifest(manifest: UploadManifest): void {
-  const dir = path.dirname(MANIFEST_PATH());
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(MANIFEST_PATH(), JSON.stringify(manifest, null, 2));
-}
-
-function contentHash(content: Buffer): string {
-  return crypto.createHash("sha256").update(content).digest("hex");
-}
-
 export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
   api.registerCli(
     ({ program, workspaceDir }) => {
@@ -42,83 +16,52 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
       cmd
         .command("setup")
         .description("Configure Honcho API key and upload memory files to Honcho")
-        .option("--reconfigure", "Force re-entry of all configuration values")
-        .action(async (options: { reconfigure?: boolean }) => {
+        .action(async () => {
           const configDir = path.join(os.homedir(), ".openclaw");
           const configPath = path.join(configDir, "openclaw.json");
 
-          // Load existing config to use as defaults
-          let config: Record<string, unknown> = {};
-          if (fs.existsSync(configPath)) {
-            try { config = JSON.parse(fs.readFileSync(configPath, "utf-8")); } catch { /* use empty */ }
-          }
-          const existingPluginCfg = (
-            ((config.plugins as Record<string, unknown>)
-              ?.entries as Record<string, unknown>)
-              ?.["openclaw-honcho"] as Record<string, unknown>
-          )?.config as Record<string, unknown> | undefined;
-
-          const savedApiKey = (existingPluginCfg?.apiKey as string) ?? "";
-          const savedBaseUrl = (existingPluginCfg?.baseUrl as string) || "https://api.honcho.dev";
-          const savedWorkspaceId = (existingPluginCfg?.workspaceId as string) || "openclaw";
-          const hasExistingConfig = !!existingPluginCfg && !!savedApiKey;
-
           console.log("\nHoncho Setup\n");
           console.log("Get your API key from: https://app.honcho.dev\n");
+          console.log('Press Enter to use the default shown in [brackets].\n');
 
           const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
           const ask = (q: string): Promise<string> => new Promise((resolve) => rl.question(q, resolve));
 
           try {
-            let resolvedApiKey: string;
-            let resolvedBaseUrl: string;
-            let resolvedWorkspaceId: string;
+            const apiKeyInput = await ask("Honcho API key (press Enter for self-hosted mode): ");
+            const baseUrlInput = await ask("Base URL [https://api.honcho.dev]: ");
+            const workspaceIdInput = await ask("Workspace ID [openclaw]: ");
 
-            if (hasExistingConfig && !options.reconfigure) {
-              const maskedKey = savedApiKey.length > 8
-                ? savedApiKey.slice(0, 4) + "..." + savedApiKey.slice(-4)
-                : "****";
-              console.log("Existing configuration found:");
-              console.log(`  API key:      ${maskedKey}`);
-              console.log(`  Base URL:     ${savedBaseUrl}`);
-              console.log(`  Workspace ID: ${savedWorkspaceId}`);
-              console.log('\nPress Enter to keep existing values, or use --reconfigure to change.\n');
+            const resolvedBaseUrl = baseUrlInput.trim() || "https://api.honcho.dev";
+            const resolvedWorkspaceId = workspaceIdInput.trim() || "openclaw";
 
-              resolvedApiKey = savedApiKey;
-              resolvedBaseUrl = savedBaseUrl;
-              resolvedWorkspaceId = savedWorkspaceId;
-              console.log("✓ Using existing configuration\n");
-            } else {
-              console.log('Press Enter to use the default shown in [brackets].\n');
-
-              const apiKeyDefault = savedApiKey ? ` [${savedApiKey.slice(0, 4)}...${savedApiKey.slice(-4)}]` : "";
-              const apiKeyInput = await ask(`Honcho API key${apiKeyDefault || " (press Enter for self-hosted mode)"}: `);
-              const baseUrlInput = await ask(`Base URL [${savedBaseUrl}]: `);
-              const workspaceIdInput = await ask(`Workspace ID [${savedWorkspaceId}]: `);
-
-              resolvedApiKey = apiKeyInput.trim() || savedApiKey;
-              resolvedBaseUrl = baseUrlInput.trim() || savedBaseUrl;
-              resolvedWorkspaceId = workspaceIdInput.trim() || savedWorkspaceId;
-
-              // Write config
-              if (!config.plugins) config.plugins = {};
-              const pluginsSection = config.plugins as Record<string, unknown>;
-              if (!pluginsSection.entries) pluginsSection.entries = {};
-              const entriesSection = pluginsSection.entries as Record<string, unknown>;
-              const existingEntry = (entriesSection["openclaw-honcho"] as Record<string, unknown>) ?? {};
-              const pluginCfg: Record<string, unknown> = {
-                ...(existingEntry.config as Record<string, unknown> ?? {}),
-              };
-              if (resolvedApiKey) pluginCfg.apiKey = resolvedApiKey;
-              else delete pluginCfg.apiKey;
-              pluginCfg.baseUrl = resolvedBaseUrl;
-              pluginCfg.workspaceId = resolvedWorkspaceId;
-              entriesSection["openclaw-honcho"] = { ...existingEntry, config: pluginCfg };
-
-              if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
-              fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-              console.log("\n✓ Configuration saved to ~/.openclaw/openclaw.json");
+            // Write config
+            let config: Record<string, unknown> = {};
+            if (fs.existsSync(configPath)) {
+              try { config = JSON.parse(fs.readFileSync(configPath, "utf-8")); } catch { /* use empty */ }
             }
+            if (!config.plugins) config.plugins = {};
+            const pluginsSection = config.plugins as Record<string, unknown>;
+            if (!pluginsSection.entries) pluginsSection.entries = {};
+            const entriesSection = pluginsSection.entries as Record<string, unknown>;
+            const existingEntry = (entriesSection["openclaw-honcho"] as Record<string, unknown>) ?? {};
+            const pluginCfg: Record<string, unknown> = {
+              ...(existingEntry.config as Record<string, unknown> ?? {}),
+            };
+            const trimmedApiKey = apiKeyInput.trim();
+            if (trimmedApiKey) pluginCfg.apiKey = trimmedApiKey;
+            else delete pluginCfg.apiKey;
+            const trimmedBaseUrl = baseUrlInput.trim();
+            if (trimmedBaseUrl) pluginCfg.baseUrl = trimmedBaseUrl;
+            else delete pluginCfg.baseUrl;
+            const trimmedWorkspaceId = workspaceIdInput.trim();
+            if (trimmedWorkspaceId) pluginCfg.workspaceId = trimmedWorkspaceId;
+            else delete pluginCfg.workspaceId;
+            entriesSection["openclaw-honcho"] = { ...existingEntry, config: pluginCfg };
+
+            if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
+            fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+            console.log("\n✓ Configuration saved to ~/.openclaw/openclaw.json");
 
             // Resolve default agent and its workspace from config
             let savedConfig: Record<string, unknown> = {};
@@ -246,7 +189,7 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
 
             // Upload files to Honcho
             const setupHoncho = new Honcho({
-              apiKey: resolvedApiKey || undefined,
+              apiKey: apiKeyInput.trim() || undefined,
               baseURL: resolvedBaseUrl,
               workspaceId: resolvedWorkspaceId,
             });
@@ -261,86 +204,31 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
               [agentPeerSetup, { observeMe: true, observeOthers: true }],
             ]);
 
-            // Cooldown after setup calls — the hosted platform (groudon) enforces
-            // 5 req/sec per tenant; the 6 calls above consume most of that budget.
-            await new Promise((r) => setTimeout(r, 1500));
-
             const MAX_UPLOAD_BYTES = 5 * 1024 * 1024; // 5MB safety cap
-            const UPLOAD_DELAY_MS = 400; // stay under 5 req/sec platform limit
 
-            const manifest = loadManifest();
             let uploadCount = 0;
-            let unchangedCount = 0;
-            const skipped: string[] = [];
-            const failed: { filePath: string; error: string }[] = [];
-            const total = detected.length;
-
-            for (let i = 0; i < detected.length; i++) {
-              const { filePath, peer } = detected[i];
-              const progress = `[${i + 1}/${total}]`;
-
+            for (const { filePath, peer } of detected) {
               const stat = await fs.promises.stat(filePath).catch(() => null);
               if (!stat?.isFile()) continue;
               if (stat.size > MAX_UPLOAD_BYTES) {
-                console.log(`  ${progress} ! Skipping (larger than 5MB): ${filePath}`);
-                skipped.push(filePath);
+                console.log(`  ! Skipping (too large): ${filePath}`);
                 continue;
               }
               const filename = path.basename(filePath);
               const ext = path.extname(filename).toLowerCase();
               const content_type = ext === ".json" ? "application/json" : ext === ".md" ? "text/markdown" : null;
               if (!content_type) {
-                console.log(`  ${progress} ! Skipping unsupported type: ${filePath}`);
-                skipped.push(filePath);
+                console.log(`  ! Skipping unsupported file type: ${filePath}`);
                 continue;
               }
-
+              const content = await fs.promises.readFile(filePath);
               const targetPeer = peer === "owner" ? ownerPeerSetup : agentPeerSetup;
-              try {
-                const content = await fs.promises.readFile(filePath);
-                const hash = contentHash(content);
-
-                // Skip files already uploaded with identical content to the same destination
-                const prev = manifest[filePath];
-                if (prev && prev.sha256 === hash && prev.baseUrl === resolvedBaseUrl && prev.workspaceId === resolvedWorkspaceId) {
-                  console.log(`  ${progress} ~ Unchanged: ${filePath}`);
-                  unchangedCount++;
-                  continue;
-                }
-
-                await new Promise((r) => setTimeout(r, UPLOAD_DELAY_MS));
-                await migrationSession.uploadFile({ filename, content, content_type }, targetPeer, {});
-                console.log(`  ${progress} ✓ Uploaded: ${filePath}`);
-                uploadCount++;
-
-                // Record success
-                manifest[filePath] = { sha256: hash, uploadedAt: new Date().toISOString(), baseUrl: resolvedBaseUrl, workspaceId: resolvedWorkspaceId };
-                saveManifest(manifest);
-              } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                console.log(`  ${progress} ✗ Failed: ${filePath}`);
-                failed.push({ filePath, error: msg });
-              }
+              await new Promise((r) => setTimeout(r, 250)); // stay under 5 req/sec limit
+              await migrationSession.uploadFile({ filename, content, content_type }, targetPeer, {});
+              console.log(`  ✓ Uploaded: ${filePath}`);
+              uploadCount++;
             }
-
-            // Clean stale manifest entries
-            for (const key of Object.keys(manifest)) {
-              if (!fs.existsSync(key)) delete manifest[key];
-            }
-            saveManifest(manifest);
-
-            // Summary
-            console.log(`\nUpload summary:`);
-            console.log(`  Uploaded:  ${uploadCount}/${total}`);
-            if (unchangedCount > 0) console.log(`  Unchanged: ${unchangedCount}`);
-            if (skipped.length > 0) console.log(`  Skipped:   ${skipped.length}`);
-            if (failed.length > 0) {
-              console.log(`  Failed:    ${failed.length}`);
-              for (const f of failed) {
-                console.log(`    ! ${f.filePath} — ${f.error}`);
-              }
-              console.log(`\nRun \`openclaw honcho setup\` again to retry failed files.`);
-            }
+            console.log(`\n✓ Uploaded ${uploadCount} file(s) to Honcho`);
 
             console.log("\n✓ Setup complete. Run `openclaw gateway --force` to activate.\n");
           } finally {
@@ -369,11 +257,13 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
         .command("ask <question>")
         .description("Ask Honcho about the user")
         .option("-a, --agent <id>", "Agent ID to query as (default: primary agent)")
-        .action(async (question: string, options: { agent?: string }) => {
+        .option("-p, --peer <id>", "Channel peer ID or Honcho peer ID to target (default: owner)")
+        .action(async (question: string, options: { agent?: string; peer?: string }) => {
           try {
             await state.ensureInitialized();
             const agentPeer = await state.getAgentPeer(options.agent ?? state.resolveDefaultAgentId());
-            const answer = await agentPeer.chat(question, { target: state.ownerPeer! });
+            const humanPeer = await state.getHumanPeer(options.peer);
+            const answer = await agentPeer.chat(question, { target: humanPeer });
             console.log(answer ?? "No information available.");
           } catch (error) {
             console.error(`Failed to query: ${error}`);
@@ -385,10 +275,12 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
         .description("Semantic search over Honcho memory")
         .option("-k, --top-k <number>", "Number of results to return", "10")
         .option("-d, --max-distance <number>", "Maximum semantic distance (0-1)", "0.5")
-        .action(async (query: string, options: { topK: string; maxDistance: string }) => {
+        .option("-p, --peer <id>", "Channel peer ID or Honcho peer ID to target (default: owner)")
+        .action(async (query: string, options: { topK: string; maxDistance: string; peer?: string }) => {
           try {
             await state.ensureInitialized();
-            const representation = await state.ownerPeer!.representation({
+            const humanPeer = await state.getHumanPeer(options.peer);
+            const representation = await humanPeer.representation({
               searchQuery: query,
               searchTopK: parseInt(options.topK, 10),
               searchMaxDistance: parseFloat(options.maxDistance),

--- a/config.ts
+++ b/config.ts
@@ -16,6 +16,8 @@ export type HonchoConfig = {
   noisePatterns: string[];
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
+  peerMappings: Record<string, string>;
+  agentPeerMappings: Record<string, string>;
 };
 
 /**
@@ -30,6 +32,17 @@ function resolveEnvVars(value: string): string {
     }
     return envValue;
   });
+}
+
+function parseStringRecord(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof k === "string" && typeof v === "string" && k.length > 0 && v.length > 0) {
+      result[k] = v;
+    }
+  }
+  return result;
 }
 
 export const honchoConfigSchema = {
@@ -68,6 +81,8 @@ export const honchoConfigSchema = {
       noisePatterns,
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
+      peerMappings: parseStringRecord(cfg.peerMappings),
+      agentPeerMappings: parseStringRecord(cfg.agentPeerMappings),
     };
   },
 };

--- a/helpers.ts
+++ b/helpers.ts
@@ -142,6 +142,43 @@ export function cleanMessageContent(content: string): string {
   return cleaned.trim();
 }
 
+const CONVERSATION_INFO_SENTINEL = "Conversation info (untrusted metadata):";
+
+/**
+ * Extract the sender_id from a raw message's "Conversation info (untrusted metadata):"
+ * metadata block. Must be called BEFORE cleanMessageContent() which strips these blocks.
+ * Returns undefined for DMs (no metadata block) or on parse failure.
+ */
+export function extractSenderId(content: string): string | undefined {
+  if (!content || !content.includes(CONVERSATION_INFO_SENTINEL)) return undefined;
+
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== CONVERSATION_INFO_SENTINEL) continue;
+    if (lines[i + 1]?.trim() !== "```json") continue;
+
+    // Collect JSON lines between ```json and ```
+    const jsonLines: string[] = [];
+    for (let j = i + 2; j < lines.length; j++) {
+      if (lines[j].trim() === "```") break;
+      jsonLines.push(lines[j]);
+    }
+
+    try {
+      const parsed = JSON.parse(jsonLines.join("\n"));
+      // Try sender_id first, fall back to sender
+      const id = parsed.sender_id ?? parsed.sender;
+      if (typeof id === "string" && id.length > 0) {
+        return id;
+      }
+    } catch {
+      // Malformed JSON — return undefined
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
 /**
  * Returns true if the message should be dropped entirely.
  * Patterns starting with "/" are treated as anchored regexes (e.g. "/^HEARTBEAT/i").
@@ -167,9 +204,10 @@ export function shouldSkipMessage(content: string, noisePatterns: string[]): boo
 
 export function extractMessages(
   rawMessages: unknown[],
-  ownerPeer: Peer,
+  defaultHumanPeer: Peer,
   agentPeer: Peer,
-  noisePatterns: string[] = []
+  noisePatterns: string[] = [],
+  resolvePeer?: (senderId: string) => Peer | undefined,
 ): MessageInput[] {
   const result: MessageInput[] = [];
 
@@ -180,11 +218,12 @@ export function extractMessages(
 
     if (role !== "user" && role !== "assistant") continue;
 
-    let content = "";
+    // Extract raw content before cleaning
+    let rawContent = "";
     if (typeof m.content === "string") {
-      content = m.content;
+      rawContent = m.content;
     } else if (Array.isArray(m.content)) {
-      content = m.content
+      rawContent = m.content
         .filter(
           (block: unknown) =>
             typeof block === "object" &&
@@ -196,17 +235,23 @@ export function extractMessages(
         .join("\n");
     }
 
-    content = cleanMessageContent(content);
+    // For user messages, extract sender ID before cleaning strips metadata
+    let peer: Peer;
+    if (role === "user") {
+      const senderId = extractSenderId(rawContent);
+      peer = (senderId && resolvePeer?.(senderId)) || defaultHumanPeer;
+    } else {
+      peer = agentPeer;
+    }
+
+    let content = cleanMessageContent(rawContent);
     content = content.trim();
 
     if (!content) continue;
     if (shouldSkipMessage(content, noisePatterns)) continue;
 
-    if (content) {
-      const peer = role === "user" ? ownerPeer : agentPeer;
-      const ts = typeof m.timestamp === "number" ? new Date(m.timestamp) : undefined;
-      result.push(peer.message(content, ts ? { createdAt: ts } : undefined));
-    }
+    const ts = typeof m.timestamp === "number" ? new Date(m.timestamp) : undefined;
+    result.push(peer.message(content, ts ? { createdAt: ts } : undefined));
   }
 
   return result;

--- a/helpers.ts
+++ b/helpers.ts
@@ -148,13 +148,19 @@ const CONVERSATION_INFO_SENTINEL = "Conversation info (untrusted metadata):";
  * Extract the sender_id from a raw message's "Conversation info (untrusted metadata):"
  * metadata block. Must be called BEFORE cleanMessageContent() which strips these blocks.
  * Returns undefined for DMs (no metadata block) or on parse failure.
+ *
+ * Only considers the FIRST occurrence of the sentinel to prevent user-pasted or quoted
+ * metadata blocks from poisoning sender attribution.
  */
 export function extractSenderId(content: string): string | undefined {
   if (!content || !content.includes(CONVERSATION_INFO_SENTINEL)) return undefined;
 
   const lines = content.split("\n");
+  let found = false;
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].trim() !== CONVERSATION_INFO_SENTINEL) continue;
+    if (found) return undefined; // Ignore duplicate sentinels (likely user-pasted content)
+    found = true;
     if (lines[i + 1]?.trim() !== "```json") continue;
 
     // Collect JSON lines between ```json and ```

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -6,8 +6,31 @@ import {
   buildSessionKey,
   isSubagentSession,
   extractMessages,
+  extractSenderId,
 } from "../helpers.js";
 import { subagentParentMap } from "./subagent.js";
+
+/**
+ * Extract raw text content from a message object (before cleaning).
+ */
+function getRawContent(msg: unknown): string {
+  if (!msg || typeof msg !== "object") return "";
+  const m = msg as Record<string, unknown>;
+  if (typeof m.content === "string") return m.content;
+  if (Array.isArray(m.content)) {
+    return m.content
+      .filter(
+        (block: unknown) =>
+          typeof block === "object" &&
+          block !== null &&
+          (block as Record<string, unknown>).type === "text"
+      )
+      .map((block: unknown) => (block as Record<string, unknown>).text)
+      .filter((t): t is string => typeof t === "string")
+      .join("\n");
+  }
+  return "";
+}
 
 /**
  * Core message capture logic shared by agent_end, before_compaction, and before_reset.
@@ -55,30 +78,99 @@ async function flushMessages(
   const lastSavedIndex = Math.min(Math.max(rawLastSavedIndex, 0), messages.length);
   const startIndex = Math.max(turnStartIndex, lastSavedIndex);
 
-  const peerConfigs: Array<[string, { observeMe: boolean; observeOthers: boolean }]> = [
-    [OWNER_ID, { observeMe: true, observeOthers: state.cfg.ownerObserveOthers }],
-    [agentPeer.id, { observeMe: true, observeOthers: true }],
-  ];
-  if (parentPeer) {
-    peerConfigs.push([parentPeer.id, { observeMe: false, observeOthers: true }]);
-  }
-
-  await session.addPeers(peerConfigs);
-
   if (messages.length <= startIndex) {
     return 0;
   }
 
   const newRawMessages = messages.slice(startIndex);
-  const extracted = extractMessages(newRawMessages, state.ownerPeer!, agentPeer, state.cfg.noisePatterns);
+
+  // Pre-resolve human peers for all unique sender IDs in this batch
+  const senderIds = new Set<string>();
+  let lastSenderId: string | undefined;
+  let userMsgCount = 0;
+  for (const msg of newRawMessages) {
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg as Record<string, unknown>;
+    if (m.role !== "user") continue;
+    userMsgCount++;
+    const rawContent = getRawContent(msg);
+    const senderId = extractSenderId(rawContent);
+    if (senderId) {
+      senderIds.add(senderId);
+      lastSenderId = senderId;
+    } else {
+      const hasConvInfo = rawContent.includes("Conversation info (untrusted metadata):");
+      api.logger.debug?.(`[honcho] User message without sender_id (hasConvInfo=${hasConvInfo}, contentLen=${rawContent.length})`);
+    }
+  }
+  if (senderIds.size > 0) {
+    api.logger.debug?.(`[honcho] Resolved ${senderIds.size} unique sender(s) from ${userMsgCount} user message(s): ${[...senderIds].join(", ")}`);
+  }
+
+  // Parallel peer resolution — avoids sequential await bottleneck in group chats.
+  const resolvedPeers = new Map<string, Awaited<ReturnType<typeof state.getHumanPeer>>>();
+  const senderIdArray = [...senderIds];
+  const peers = await Promise.all(senderIdArray.map((id) => state.getHumanPeer(id)));
+  for (let i = 0; i < senderIdArray.length; i++) {
+    resolvedPeers.set(senderIdArray[i], peers[i]);
+  }
+
+  const defaultHumanPeer = await state.getHumanPeer();
+
+  // Build peer configs: default owner + all resolved human peers + agent + parent
+  const peerConfigMap = new Map<string, { observeMe: boolean; observeOthers: boolean }>();
+  peerConfigMap.set(OWNER_ID, { observeMe: true, observeOthers: state.cfg.ownerObserveOthers });
+  for (const [, peer] of resolvedPeers) {
+    if (peer.id !== OWNER_ID) {
+      peerConfigMap.set(peer.id, { observeMe: true, observeOthers: state.cfg.ownerObserveOthers });
+    }
+  }
+  peerConfigMap.set(agentPeer.id, { observeMe: true, observeOthers: true });
+  if (parentPeer) {
+    peerConfigMap.set(parentPeer.id, { observeMe: false, observeOthers: true });
+  }
+
+  const peerConfigs = Array.from(peerConfigMap.entries()) as Array<
+    [string, { observeMe: boolean; observeOthers: boolean }]
+  >;
+  await session.addPeers(peerConfigs);
+
+  const extracted = extractMessages(
+    newRawMessages,
+    defaultHumanPeer,
+    agentPeer,
+    state.cfg.noisePatterns,
+    (senderId) => resolvedPeers.get(senderId),
+  );
+
+  // Store sender IDs in session metadata for tool resolution.
+  // humanSenderId = last active sender (default for tools).
+  // humanSenderIds = all known senders in this session (for future multi-target tools).
+  // Named "sender" (not "peer") to distinguish raw channel IDs from resolved Honcho peer IDs.
+  const previousSenderIds: string[] = Array.isArray(existingMeta.humanSenderIds)
+    ? (existingMeta.humanSenderIds as string[])
+    : [];
+  const allSenderIds = [...new Set([...previousSenderIds, ...senderIds])];
+
+  const updatedMeta: Record<string, unknown> = {
+    ...existingMeta,
+    ...sessionMeta,
+    lastSavedIndex: messages.length,
+  };
+  if (lastSenderId) {
+    updatedMeta.humanSenderId = lastSenderId;
+  }
+  if (allSenderIds.length > 0) {
+    updatedMeta.humanSenderIds = allSenderIds;
+  }
 
   if (extracted.length === 0) {
-    await session.setMetadata({ ...existingMeta, ...sessionMeta, lastSavedIndex: messages.length });
+    await session.setMetadata(updatedMeta);
     return 0;
   }
 
   await session.addMessages(extracted);
-  await session.setMetadata({ ...existingMeta, ...sessionMeta, lastSavedIndex: messages.length });
+  await session.setMetadata(updatedMeta);
   return extracted.length;
 }
 

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -104,7 +104,7 @@ async function flushMessages(
     }
   }
   if (senderIds.size > 0) {
-    api.logger.debug?.(`[honcho] Resolved ${senderIds.size} unique sender(s) from ${userMsgCount} user message(s): ${[...senderIds].join(", ")}`);
+    api.logger.debug?.(`[honcho] Resolved ${senderIds.size} unique sender(s) from ${userMsgCount} user message(s)`);
   }
 
   // Parallel peer resolution — avoids sequential await bottleneck in group chats.

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -16,12 +16,13 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
     try {
       await state.ensureInitialized();
       const agentPeer = await state.getAgentPeer(agentId);
+      const humanPeer = await state.resolveSessionHumanPeer(sessionKey);
 
       const sections: string[] = [];
 
       if (isSubagent) {
         try {
-          const peerCtx = await agentPeer.context({ target: state.ownerPeer! });
+          const peerCtx = await agentPeer.context({ target: humanPeer });
           if (peerCtx.peerCard?.length) {
             sections.push(`Key facts:\n${peerCtx.peerCard.map((f: string) => `• ${f}`).join("\n")}`);
           }
@@ -43,7 +44,7 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
           context = await session.context({
             summary: true,
             tokens: 2000,
-            peerTarget: state.ownerPeer!,
+            peerTarget: humanPeer,
             peerPerspective: agentPeer,
           });
         } catch (e: unknown) {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -27,10 +27,17 @@
         "default": false,
         "description": "Whether the owner peer observes agent messages. When true, Honcho models the user's awareness of assistant responses."
       },
-      "disableDefaultNoisePatterns": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, built-in noise patterns are not applied — only noisePatterns entries are used."
+      "peerMappings": {
+        "type": "object",
+        "additionalProperties": { "type": "string" },
+        "default": {},
+        "description": "Maps channel peer IDs (e.g., Discord user IDs) to Honcho peer IDs. Unmapped senders are auto-created using their channel peer ID."
+      },
+      "agentPeerMappings": {
+        "type": "object",
+        "additionalProperties": { "type": "string" },
+        "default": {},
+        "description": "Maps OpenClaw agent IDs to Honcho peer IDs. By default, agent 'foo' gets peer ID 'agent-foo'."
       }
     }
   },
@@ -61,10 +68,15 @@
       "advanced": true,
       "help": "When enabled, Honcho models the user as aware of the agent's responses. Default: off."
     },
-    "disableDefaultNoisePatterns": {
-      "label": "Disable Default Noise Patterns",
+    "peerMappings": {
+      "label": "Peer Mappings",
       "advanced": true,
-      "help": "When enabled, only custom noisePatterns entries are used — built-in defaults are skipped."
+      "help": "Maps channel peer IDs (e.g., Discord user IDs) to Honcho peer IDs. Unmapped senders are auto-created."
+    },
+    "agentPeerMappings": {
+      "label": "Agent Peer Mappings",
+      "advanced": true,
+      "help": "Maps OpenClaw agent IDs to custom Honcho peer IDs. Default: agent 'foo' → peer 'agent-foo'."
     }
   }
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -27,6 +27,11 @@
         "default": false,
         "description": "Whether the owner peer observes agent messages. When true, Honcho models the user's awareness of assistant responses."
       },
+      "disableDefaultNoisePatterns": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, built-in noise patterns are not applied — only noisePatterns entries are used."
+      },
       "peerMappings": {
         "type": "object",
         "additionalProperties": { "type": "string" },
@@ -67,6 +72,11 @@
       "label": "Owner Observes Agent",
       "advanced": true,
       "help": "When enabled, Honcho models the user as aware of the agent's responses. Default: off."
+    },
+    "disableDefaultNoisePatterns": {
+      "label": "Disable Default Noise Patterns",
+      "advanced": true,
+      "help": "When enabled, only custom noisePatterns entries are used — built-in defaults are skipped."
     },
     "peerMappings": {
       "label": "Peer Mappings",

--- a/state.ts
+++ b/state.ts
@@ -59,6 +59,10 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
   // workspace metadata. Errors propagate to all waiters.
   let initPromise: Promise<void> | null = null;
 
+  // Serialize workspace metadata writes to prevent concurrent read-modify-write
+  // races between getHumanPeer() and getAgentPeer().
+  let metadataWriteLock: Promise<void> = Promise.resolve();
+
   const state: PluginState = {
     honcho,
     cfg,
@@ -146,10 +150,14 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     let honchoId = state.humanPeerMap[channelPeerId];
     if (!honchoId) {
       honchoId = channelPeerId;
-      // Persist auto-created mapping
+      // Persist auto-created mapping (serialized to prevent concurrent write races)
       state.humanPeerMap[channelPeerId] = honchoId;
-      const wsMeta = await honcho.getMetadata();
-      await honcho.setMetadata({ ...wsMeta, humanPeerMap: state.humanPeerMap });
+      const prev = metadataWriteLock;
+      metadataWriteLock = prev.then(async () => {
+        const wsMeta = await honcho.getMetadata();
+        await honcho.setMetadata({ ...wsMeta, humanPeerMap: state.humanPeerMap });
+      }).catch(() => { /* errors logged elsewhere */ });
+      await metadataWriteLock;
       api.logger.info(`[honcho] Auto-created human peer mapping: "${channelPeerId}" → "${honchoId}"`);
     }
 
@@ -213,8 +221,12 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
 
     if (state.agentPeerMap[id] !== peerId) {
       state.agentPeerMap[id] = peerId;
-      const wsMeta = await honcho.getMetadata();
-      await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap });
+      const prev = metadataWriteLock;
+      metadataWriteLock = prev.then(async () => {
+        const wsMeta = await honcho.getMetadata();
+        await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap });
+      }).catch(() => { /* errors logged elsewhere */ });
+      await metadataWriteLock;
     }
 
     peer = await honcho.peer(peerId);

--- a/state.ts
+++ b/state.ts
@@ -15,7 +15,10 @@ export const LEGACY_PEER_ID = "openclaw";
 export type PluginState = {
   honcho: Honcho;
   cfg: HonchoConfig;
-  ownerPeer: Peer | null;
+  /** Cache of resolved human peers, keyed by channel peer ID (or OWNER_ID for default). */
+  humanPeers: Map<string, Peer>;
+  /** Persistent mapping of channel peer ID → honcho peer ID, stored in workspace metadata. */
+  humanPeerMap: Record<string, string>;
   agentPeers: Map<string, Peer>;
   agentPeerMap: Record<string, string>;
   /** Message count recorded at before_prompt_build time, keyed by Honcho session key.
@@ -26,6 +29,13 @@ export type PluginState = {
   api: OpenClawPluginApi;
   ensureInitialized: () => Promise<void>;
   getAgentPeer: (agentId?: string) => Promise<Peer>;
+  /** Resolve a human peer by channel peer ID. Returns default "owner" peer if no ID given. */
+  getHumanPeer: (channelPeerId?: string) => Promise<Peer>;
+  /** Resolve the human peer for a session by reading humanSenderId from session metadata.
+   * Falls back to default "owner" peer if no metadata found. */
+  resolveSessionHumanPeer: (sessionKey: string) => Promise<Peer>;
+  /** Returns true if the given honcho peer ID belongs to a known human peer. */
+  isHumanPeerId: (peerId: string) => boolean;
   resolveDefaultAgentId: () => string;
 };
 
@@ -44,10 +54,16 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     workspaceId: cfg.workspaceId,
   });
 
+  // Promise-based init lock to prevent concurrent ensureInitialized() races.
+  // Without this, two concurrent hooks entering init simultaneously can corrupt
+  // workspace metadata. Errors propagate to all waiters.
+  let initPromise: Promise<void> | null = null;
+
   const state: PluginState = {
     honcho,
     cfg,
-    ownerPeer: null,
+    humanPeers: new Map<string, Peer>(),
+    humanPeerMap: {},
     agentPeers: new Map<string, Peer>(),
     agentPeerMap: {},
     turnStartIndex: new Map<string, number>(),
@@ -55,6 +71,9 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     api,
     ensureInitialized,
     getAgentPeer,
+    getHumanPeer,
+    resolveSessionHumanPeer,
+    isHumanPeerId,
     resolveDefaultAgentId,
   };
 
@@ -67,21 +86,104 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
 
   async function ensureInitialized(): Promise<void> {
     if (state.initialized) return;
+    if (initPromise) return initPromise;
+    initPromise = doInit();
+    try {
+      await initPromise;
+    } catch (err) {
+      // Reset so next caller retries instead of getting a stale rejection.
+      initPromise = null;
+      throw err;
+    }
+  }
+
+  async function doInit(): Promise<void> {
 
     const wsMeta = await honcho.getMetadata();
     state.agentPeerMap = (wsMeta.agentPeerMap as Record<string, string>) ?? {};
+    state.humanPeerMap = (wsMeta.humanPeerMap as Record<string, string>) ?? {};
+
+    // Config mappings take precedence over workspace metadata
+    for (const [channelId, honchoId] of Object.entries(cfg.peerMappings)) {
+      state.humanPeerMap[channelId] = honchoId;
+    }
+    for (const [agentId, honchoId] of Object.entries(cfg.agentPeerMappings)) {
+      state.agentPeerMap[agentId] = honchoId;
+    }
 
     const defaultId = resolveDefaultAgentId();
     if (Object.keys(state.agentPeerMap).length === 0) {
       state.agentPeerMap[defaultId] = `agent-${defaultId}`;
-      await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap });
+      await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap, humanPeerMap: state.humanPeerMap });
     } else if (Object.values(state.agentPeerMap).includes(LEGACY_PEER_ID) && !state.agentPeerMap[defaultId]) {
       state.agentPeerMap[defaultId] = LEGACY_PEER_ID;
-      await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap });
+      await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap, humanPeerMap: state.humanPeerMap });
     }
 
-    state.ownerPeer = await honcho.peer(OWNER_ID, { metadata: {} });
+    // Create default "owner" peer
+    const defaultPeer = await honcho.peer(OWNER_ID, { metadata: {} });
+    state.humanPeers.set(OWNER_ID, defaultPeer);
+
     state.initialized = true;
+  }
+
+  async function getHumanPeer(channelPeerId?: string): Promise<Peer> {
+    if (!channelPeerId) {
+      // Return default owner peer
+      let peer = state.humanPeers.get(OWNER_ID);
+      if (!peer) {
+        peer = await honcho.peer(OWNER_ID, { metadata: {} });
+        state.humanPeers.set(OWNER_ID, peer);
+      }
+      return peer;
+    }
+
+    // Check cache
+    let peer = state.humanPeers.get(channelPeerId);
+    if (peer) return peer;
+
+    // Resolve honcho peer ID from mapping or use channel peer ID directly
+    let honchoId = state.humanPeerMap[channelPeerId];
+    if (!honchoId) {
+      honchoId = channelPeerId;
+      // Persist auto-created mapping
+      state.humanPeerMap[channelPeerId] = honchoId;
+      const wsMeta = await honcho.getMetadata();
+      await honcho.setMetadata({ ...wsMeta, humanPeerMap: state.humanPeerMap });
+      api.logger.info(`[honcho] Auto-created human peer mapping: "${channelPeerId}" → "${honchoId}"`);
+    }
+
+    peer = await honcho.peer(honchoId, { metadata: { channelPeerId } });
+    state.humanPeers.set(channelPeerId, peer);
+    return peer;
+  }
+
+  async function resolveSessionHumanPeer(sessionKey: string): Promise<Peer> {
+    try {
+      const session = await honcho.session(sessionKey);
+      const meta = await session.getMetadata();
+      if (meta && typeof meta === "object") {
+        // Check humanSenderId (preferred) with fallback to legacy humanPeerId.
+        const senderId = (meta as Record<string, unknown>).humanSenderId
+          ?? (meta as Record<string, unknown>).humanPeerId;
+        if (typeof senderId === "string" && senderId.length > 0) {
+          return await getHumanPeer(senderId);
+        }
+      }
+    } catch {
+      // Fall through to default
+    }
+    return await getHumanPeer();
+  }
+
+  function isHumanPeerId(peerId: string): boolean {
+    if (peerId === OWNER_ID) return true;
+    // Check if this peer ID is a known human peer (either as a channel ID key or honcho ID value)
+    for (const [, peer] of state.humanPeers) {
+      if (peer.id === peerId) return true;
+    }
+    // Also check the mapping values
+    return Object.values(state.humanPeerMap).includes(peerId);
   }
 
   async function getAgentPeer(agentId?: string): Promise<Peer> {

--- a/tools/ask.ts
+++ b/tools/ask.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
+import { buildSessionKey } from "../helpers.js";
 
 export function registerAskTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
@@ -33,10 +34,11 @@ export function registerAskTool(api: OpenClawPluginApi, state: PluginState): voi
 
         await state.ensureInitialized();
         const agentPeer = await state.getAgentPeer(toolCtx.agentId);
+        const humanPeer = await state.resolveSessionHumanPeer(buildSessionKey(toolCtx));
 
         const reasoningLevel = depth === "thorough" ? "high" : "low";
         const answer = await agentPeer.chat(query, {
-          target: state.ownerPeer!,
+          target: humanPeer,
           reasoningLevel,
         });
 

--- a/tools/context.ts
+++ b/tools/context.ts
@@ -2,10 +2,11 @@ import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
+import { buildSessionKey } from "../helpers.js";
 
 export function registerContextTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
-    {
+    (toolCtx) => ({
       name: "honcho_context",
       label: "Get User Context",
       description:
@@ -26,9 +27,10 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
         const { detail = "card" } = params as { detail?: "card" | "full" };
 
         await state.ensureInitialized();
+        const humanPeer = await state.resolveSessionHumanPeer(buildSessionKey(toolCtx));
 
         if (detail === "card") {
-          const card = await state.ownerPeer!.card().catch((err) => {
+          const card = await humanPeer.card().catch((err) => {
             // Only treat NotFoundError as empty; re-throw others or log
             if (err?.name === "NotFoundError") return null;
             // Optionally log unexpected errors for debugging
@@ -60,7 +62,7 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
         }
 
         // detail === "full"
-        const representation = await state.ownerPeer!.representation({
+        const representation = await humanPeer.representation({
           includeMostFrequent: true,
         });
 
@@ -81,7 +83,7 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
           details: { detail, representationLength: representation.length },
         };
       },
-    },
+    }),
     { name: "honcho_context" }
   );
 }

--- a/tools/message-search.ts
+++ b/tools/message-search.ts
@@ -3,6 +3,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { Message } from "@honcho-ai/sdk";
 import type { PluginState } from "../state.js";
+import { buildSessionKey } from "../helpers.js";
 
 export function registerMessageSearchTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
@@ -90,7 +91,8 @@ export function registerMessageSearchTool(api: OpenClawPluginApi, state: PluginS
         // Route to the appropriate search method based on `from`
         let messages: Message[];
         if (from === "user") {
-          messages = await state.ownerPeer!.search(query, searchOpts);
+          const humanPeer = await state.resolveSessionHumanPeer(buildSessionKey(toolCtx));
+          messages = await humanPeer.search(query, searchOpts);
         } else if (from === "agent") {
           const agentPeer = await state.getAgentPeer(toolCtx.agentId);
           messages = await agentPeer.search(query, searchOpts);
@@ -111,7 +113,7 @@ export function registerMessageSearchTool(api: OpenClawPluginApi, state: PluginS
         }
 
         const results = messages.map((msg) => {
-          const speaker = msg.peerId === state.ownerPeer!.id ? "User" : "Agent";
+          const speaker = state.isHumanPeerId(msg.peerId) ? "User" : "Agent";
           return {
             id: msg.id,
             content: msg.content,

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -2,10 +2,11 @@ import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
+import { buildSessionKey } from "../helpers.js";
 
 export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
-    {
+    (toolCtx) => ({
       name: "honcho_search_conclusions",
       label: "Search Honcho conclusions",
       description:
@@ -40,8 +41,9 @@ export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): 
         };
 
         await state.ensureInitialized();
+        const humanPeer = await state.resolveSessionHumanPeer(buildSessionKey(toolCtx));
 
-        const representation = await state.ownerPeer!.representation({
+        const representation = await humanPeer.representation({
           searchQuery: query,
           searchTopK: topK ?? 10,
           searchMaxDistance: maxDistance ?? 0.5,
@@ -64,7 +66,7 @@ export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): 
           details: { query, resultCount: representation.split("\n").filter(Boolean).length },
         };
       },
-    },
+    }),
     { name: "honcho_search_conclusions" }
   );
 }

--- a/tools/session.ts
+++ b/tools/session.ts
@@ -54,6 +54,7 @@ export function registerSessionTool(api: OpenClawPluginApi, state: PluginState):
         await state.ensureInitialized();
         const agentPeer = await state.getAgentPeer(toolCtx.agentId);
         const sessionKey = buildSessionKey(toolCtx);
+        const humanPeer = await state.resolveSessionHumanPeer(sessionKey);
 
         try {
           const session = await state.honcho.session(sessionKey);
@@ -61,7 +62,7 @@ export function registerSessionTool(api: OpenClawPluginApi, state: PluginState):
           const context = await session.context({
             summary: includeSummary,
             tokens: messageLimit,
-            peerTarget: state.ownerPeer!,
+            peerTarget: humanPeer,
             peerPerspective: agentPeer,
             searchQuery: searchQuery,
           });
@@ -88,7 +89,7 @@ export function registerSessionTool(api: OpenClawPluginApi, state: PluginState):
 
           if (includeMessages && context.messages.length > 0) {
             const messageLines = context.messages.map((msg) => {
-              const speaker = msg.peerId === state.ownerPeer!.id ? "User" : "OpenClaw";
+              const speaker = state.isHumanPeerId(msg.peerId) ? "User" : "OpenClaw";
               const timestamp = msg.createdAt
                 ? new Date(msg.createdAt).toLocaleString()
                 : "";


### PR DESCRIPTION
## Summary

This PR incorporates the multi-peer mapping approach from #31 (@spooktheducks) with all three review fixes requested by @ajspig, plus our independent discovery of the same issue in #50.

## Background

We independently identified the group chat sender attribution problem (#50) — all `role: "user"` messages are attributed to the owner peer regardless of actual sender, contaminating the owner's user model. After filing #50, we discovered #31 and #32 already addressed this with a more comprehensive approach.

This PR takes #31's implementation (which @ajspig confirmed as architecturally correct) and applies the three requested fixes.

## Review fixes applied

### 1. 🔴 Concurrency protection for `ensureInitialized()` (blocking)

`state.ts` now uses a promise-based init lock. When two concurrent hooks enter `ensureInitialized()` simultaneously, the second waiter joins the first's promise instead of racing through init independently. Errors propagate to all waiters (the lock resets on failure so the next caller retries cleanly, rather than swallowing errors).

```ts
let initPromise: Promise<void> | null = null;

async function ensureInitialized(): Promise<void> {
  if (state.initialized) return;
  if (initPromise) return initPromise;
  initPromise = doInit();
  try { await initPromise; }
  catch (err) { initPromise = null; throw err; }
}
```

### 2. 🟡 Parallel peer resolution (should fix)

`hooks/capture.ts` now uses `Promise.all()` instead of sequential `for...of` + `await` for resolving human peers. This avoids a latency bottleneck in group chats with many unique senders.

```ts
const senderIdArray = [...senderIds];
const peers = await Promise.all(senderIdArray.map((id) => state.getHumanPeer(id)));
```

### 3. 🟡 Naming: sender IDs vs peer IDs (should fix)

Session metadata keys renamed from `humanPeerId`/`humanPeerIds` to `humanSenderId`/`humanSenderIds` to clearly distinguish raw channel sender IDs from resolved Honcho peer IDs. Includes backward-compatible fallback to legacy key names in `resolveSessionHumanPeer()`.

## What's included (from #31)

- `helpers.ts`: `extractSenderId()` + `getRawContent()` to parse sender identity from metadata before cleaning
- `state.ts`: `humanPeers` cache, `getHumanPeer()`, `resolveSessionHumanPeer()`, `isHumanPeerId()`
- `hooks/capture.ts`: batch sender extraction, parallel peer resolution, session metadata storage
- `hooks/context.ts`: session-resolved human peer for context injection
- `config.ts`: `peerMappings` and `agentPeerMappings` config fields
- All tools + CLI: migrated to session-specific human peer resolution
- `openclaw.plugin.json`: schema + UI hints for new config fields

## Relationship to other PRs

- **#50** (ours, closed): Independent minimal implementation of the same fix. Closed in favor of this more comprehensive approach.
- **#31** (@spooktheducks): Source of the multi-peer architecture. This PR applies the review fixes and rebases on current main. Co-authored-by credit included.
- **#32** (@bernesto): Per-agent workspace routing — separate feature with overlapping files. Not included here per @ajspig's suggestion to keep PRs focused.

Co-authored-by: spooktheducks <spooktheducks@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added peer mapping config keys (peerMappings, agentPeerMappings) and a multi-peer model with distinct peers per human sender and per agent; unmapped senders are auto-created and persisted.

* **Improvements**
  * CLI commands accept -p/--peer; CLI and tools now resolve and target session-scoped human peers.
  * Speaker labeling and message extraction now attribute by resolved human peers.

* **Docs**
  * README and plugin schema updated to document mapping options and multi-peer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->