### PR TITLE
fix: restore generic memory tool compatibility after runtime.tools removal

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,7 @@ import { registerAskTool } from "./tools/ask.js";
 import { registerMemoryPassthrough } from "./tools/memory-passthrough.js";
 import { registerMessageSearchTool } from "./tools/message-search.js";
 import { registerCli } from "./commands/cli.js";
+import { registerHonchoMemoryRuntime } from "./runtime.js";
 
 /**
  * Memory prompt section builder for Honcho tools.
@@ -94,6 +95,9 @@ export default definePluginEntry({
     // Register memory prompt section — tool selection guidance lives here,
     // not in individual tool descriptions.
     api.registerMemoryPromptSection(buildPromptSection);
+
+    // Memory runtime adapter — wires Honcho into OpenClaw's memory-core slot.
+    registerHonchoMemoryRuntime(api, state);
 
     // Hooks
     registerGatewayHook(api, state);

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -49,6 +49,24 @@ function createState(baseUrl = "https://api.honcho.dev"): PluginState {
       },
     ],
   ]);
+  const searchResults = new Map<string, Array<Record<string, unknown>>>([
+    [
+      "session-1",
+      [{ id: "msg-1", sessionId: "session-1", content: "Need to remember this" }],
+    ],
+    [
+      "session-1-child",
+      [{ id: "msg-2", sessionId: "session-1-child", content: "Child transcript hit" }],
+    ],
+  ]);
+
+  const createSession = (sessionId: string) => ({
+    id: sessionId,
+    context: vi.fn(async () => contexts.get(sessionId)),
+    search: vi.fn(async () => searchResults.get(sessionId) ?? []),
+  });
+
+  const childSession = createSession("session-1-child");
 
   return {
     cfg: {
@@ -59,9 +77,7 @@ function createState(baseUrl = "https://api.honcho.dev"): PluginState {
       ownerObserveOthers: false,
     },
     honcho: {
-      session: vi.fn(async (sessionId: string) => ({
-        context: vi.fn(async () => contexts.get(sessionId)),
-      })),
+      session: vi.fn(async (sessionId: string) => createSession(sessionId)),
     } as never,
     ownerPeer: {
       id: "owner",
@@ -70,6 +86,11 @@ function createState(baseUrl = "https://api.honcho.dev"): PluginState {
         { sessionId: "session-1-child", content: "Child transcript hit" },
         { sessionId: "other-session", content: "Other result" },
       ]),
+      sessions: vi.fn(async () => ({
+        async *[Symbol.asyncIterator]() {
+          yield childSession;
+        },
+      })),
     } as never,
     agentPeers: new Map(),
     agentPeerMap: {},
@@ -86,7 +107,10 @@ describe("Honcho memory runtime", () => {
   it("filters search results by session key and returns session transcript paths", async () => {
     const state = createState();
 
-    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
     const results = await manager.search("remember", {
       sessionKey: "session-1",
       maxResults: 10,
@@ -100,12 +124,16 @@ describe("Honcho memory runtime", () => {
     expect(results[0]?.snippet).toBe("Need to remember this");
     expect(results[0]?.startLine).toBeGreaterThan(0);
     expect(results[0]?.endLine).toBeGreaterThanOrEqual(results[0]?.startLine ?? 0);
+    expect((state.ownerPeer.search as unknown as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
   });
 
-  it("reads transcript slices and resolves backend metadata", async () => {
+  it("reads scoped transcript slices and resolves backend metadata", async () => {
     const state = createState("http://localhost:8000");
 
-    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
     const file = await manager.readFile({
       relPath: "sessions/session-1.txt",
       from: 1,
@@ -116,6 +144,11 @@ describe("Honcho memory runtime", () => {
     expect(file.text).toContain("# Summary");
     expect(file.text).toContain("Summary for session one");
     expect(manager.status().provider).toBe("honcho-selfhosted");
+    await expect(
+      manager.readFile({
+        relPath: "sessions/other-session.txt",
+      }),
+    ).rejects.toThrow(/outside the active session/);
 
     expect(
       resolveHonchoMemoryBackendConfig({

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -171,4 +171,25 @@ describe("Honcho memory runtime", () => {
       sessionKey: "agent-main-dashboard-test-telegram",
     });
   });
+
+  it("fails cleanly when ownerPeer is unavailable after initialization", async () => {
+    const state = createState();
+    state.ownerPeer = null;
+
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+
+    await expect(
+      manager.search("remember", {
+        sessionKey: "session-1",
+      }),
+    ).rejects.toThrow(/owner peer not initialized/);
+    await expect(
+      manager.readFile({
+        relPath: "sessions/session-1.txt",
+      }),
+    ).rejects.toThrow(/owner peer not initialized/);
+  });
 });

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -125,6 +125,16 @@ describe("Honcho memory runtime", () => {
     expect(results[0]?.startLine).toBeGreaterThan(0);
     expect(results[0]?.endLine).toBeGreaterThanOrEqual(results[0]?.startLine ?? 0);
     expect((state.ownerPeer.search as unknown as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+
+    const implicitScopeResults = await manager.search("remember", {
+      maxResults: 10,
+    });
+    expect(implicitScopeResults).toHaveLength(2);
+    await expect(
+      manager.search("remember", {
+        sessionKey: "other-session",
+      }),
+    ).rejects.toThrow(/outside the active session/);
   });
 
   it("reads scoped transcript slices and resolves backend metadata", async () => {

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -48,6 +48,24 @@ function createState(baseUrl = "https://api.honcho.dev"): PluginState {
         ],
       },
     ],
+    [
+      "session-2",
+      {
+        summary: { content: "Summary for session two" },
+        messages: [
+          {
+            peerId: "owner",
+            createdAt: "2026-04-06T00:00:04Z",
+            content: "Alpha",
+          },
+          {
+            peerId: "agent-main",
+            createdAt: "2026-04-06T00:00:05Z",
+            content: "Beta",
+          },
+        ],
+      },
+    ],
   ]);
   const searchResults = new Map<string, Array<Record<string, unknown>>>([
     [
@@ -57,6 +75,10 @@ function createState(baseUrl = "https://api.honcho.dev"): PluginState {
     [
       "session-1-child",
       [{ id: "msg-2", sessionId: "session-1-child", content: "Child transcript hit" }],
+    ],
+    [
+      "session-2",
+      [{ id: "msg-3", sessionId: "session-2", content: "Beta\nextra" }],
     ],
   ]);
 
@@ -170,6 +192,23 @@ describe("Honcho memory runtime", () => {
       qmd: {},
       sessionKey: "agent-main-dashboard-test-telegram",
     });
+  });
+
+  it("clamps fallback snippet ranges to the transcript length", async () => {
+    const state = createState();
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-2",
+    });
+
+    const [result] = await manager.search("beta", {
+      sessionKey: "session-2",
+      maxResults: 5,
+    });
+
+    expect(result?.path).toBe("sessions/session-2.txt");
+    expect(result?.startLine).toBe(8);
+    expect(result?.endLine).toBe(9);
   });
 
   it("fails cleanly when ownerPeer is unavailable after initialization", async () => {

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { getHonchoMemorySearchManager, resolveHonchoMemoryBackendConfig } from "./runtime.js";
+import type { PluginState } from "./state.js";
+
+function createState(baseUrl = "https://api.honcho.dev"): PluginState {
+  const contexts = new Map<string, { summary: { content: string }; messages: Array<Record<string, unknown>> }>([
+    [
+      "session-1",
+      {
+        summary: { content: "Summary for session one" },
+        messages: [
+          {
+            peerId: "owner",
+            createdAt: "2026-04-06T00:00:00Z",
+            content: "Need to remember this",
+          },
+          {
+            peerId: "agent-main",
+            createdAt: "2026-04-06T00:00:01Z",
+            content: "Agent reply",
+          },
+        ],
+      },
+    ],
+    [
+      "session-1-child",
+      {
+        summary: { content: "Child summary" },
+        messages: [
+          {
+            peerId: "owner",
+            createdAt: "2026-04-06T00:00:02Z",
+            content: "Child transcript hit",
+          },
+        ],
+      },
+    ],
+    [
+      "other-session",
+      {
+        summary: { content: "Other summary" },
+        messages: [
+          {
+            peerId: "owner",
+            createdAt: "2026-04-06T00:00:03Z",
+            content: "Other result",
+          },
+        ],
+      },
+    ],
+  ]);
+
+  return {
+    cfg: {
+      workspaceId: "openclaw",
+      baseUrl,
+      noisePatterns: [],
+      disableDefaultNoisePatterns: false,
+      ownerObserveOthers: false,
+    },
+    honcho: {
+      session: vi.fn(async (sessionId: string) => ({
+        context: vi.fn(async () => contexts.get(sessionId)),
+      })),
+    } as never,
+    ownerPeer: {
+      id: "owner",
+      search: vi.fn(async () => [
+        { sessionId: "session-1", content: "Need to remember this" },
+        { sessionId: "session-1-child", content: "Child transcript hit" },
+        { sessionId: "other-session", content: "Other result" },
+      ]),
+    } as never,
+    agentPeers: new Map(),
+    agentPeerMap: {},
+    turnStartIndex: new Map(),
+    initialized: true,
+    api: {} as never,
+    ensureInitialized: vi.fn(async () => {}),
+    getAgentPeer: vi.fn(async (agentId = "main") => ({ id: `agent-${agentId}` })),
+    resolveDefaultAgentId: vi.fn(() => "main"),
+  } as unknown as PluginState;
+}
+
+describe("Honcho memory runtime", () => {
+  it("filters search results by session key and returns session transcript paths", async () => {
+    const state = createState();
+
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+    const results = await manager.search("remember", {
+      sessionKey: "session-1",
+      maxResults: 10,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results.map((entry) => entry.path)).toEqual([
+      "sessions/session-1.txt",
+      "sessions/session-1-child.txt",
+    ]);
+    expect(results[0]?.snippet).toBe("Need to remember this");
+    expect(results[0]?.startLine).toBeGreaterThan(0);
+    expect(results[0]?.endLine).toBeGreaterThanOrEqual(results[0]?.startLine ?? 0);
+  });
+
+  it("reads transcript slices and resolves backend metadata", async () => {
+    const state = createState("http://localhost:8000");
+
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+    const file = await manager.readFile({
+      relPath: "sessions/session-1.txt",
+      from: 1,
+      lines: 4,
+    });
+
+    expect(file.path).toBe("sessions/session-1.txt");
+    expect(file.text).toContain("# Summary");
+    expect(file.text).toContain("Summary for session one");
+    expect(manager.status().provider).toBe("honcho-selfhosted");
+
+    expect(
+      resolveHonchoMemoryBackendConfig({
+        sessionKey: "agent:main:dashboard:test",
+        messageProvider: "telegram",
+      }),
+    ).toEqual({
+      backend: "qmd",
+      qmd: {},
+      sessionKey: "agent-main-dashboard-test-telegram",
+    });
+  });
+});

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,6 +1,18 @@
 import { buildSessionKey } from "./helpers.js";
 import type { PluginState } from "./state.js";
 
+const DEFAULT_SEARCH_RESULTS = 10;
+const MAX_SEARCH_RESULTS = 50;
+
+function isLocalBaseUrl(baseUrl?: string): boolean {
+  try {
+    const host = new URL(baseUrl ?? "").hostname;
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
 function normalizeSessionPath(sessionId: string): string {
   return `sessions/${sessionId}.txt`;
 }
@@ -68,9 +80,13 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
         manager: {
           async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
             await state.ensureInitialized();
+            const requested = Number.isFinite(opts.maxResults)
+              ? Number(opts.maxResults)
+              : DEFAULT_SEARCH_RESULTS;
+            const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
 
             const raw = await state.ownerPeer.search(query, {
-              limit: opts.maxResults ?? 10,
+              limit,
             });
 
             const requestedSessionKey =
@@ -110,10 +126,7 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
           status() {
             return {
               backend: "qmd",
-              provider:
-                state.cfg.baseUrl?.includes("localhost") || state.cfg.baseUrl?.includes("127.0.0.1")
-                  ? "honcho-selfhosted"
-                  : "honcho",
+              provider: isLocalBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
               model: "n/a",
               sources: ["sessions"],
               custom: {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,17 +1,8 @@
 import { buildSessionKey } from "./helpers.js";
-import type { PluginState } from "./state.js";
+import { isLocalHonchoBaseUrl, type PluginState } from "./state.js";
 
 const DEFAULT_SEARCH_RESULTS = 10;
 const MAX_SEARCH_RESULTS = 50;
-
-function isLocalBaseUrl(baseUrl?: string): boolean {
-  try {
-    const host = new URL(baseUrl ?? "").hostname;
-    return host === "localhost" || host === "127.0.0.1" || host === "::1";
-  } catch {
-    return false;
-  }
-}
 
 function normalizeSessionPath(sessionId: string): string {
   return `sessions/${sessionId}.txt`;
@@ -69,6 +60,38 @@ async function buildSessionTranscript(
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
+function findSnippetLineRange(transcript: string, snippet: string): { startLine: number; endLine: number } {
+  const transcriptLines = transcript.split(/\r?\n/);
+  const snippetLines = snippet.split(/\r?\n/);
+
+  if (!snippet.trim()) {
+    return { startLine: 1, endLine: 1 };
+  }
+
+  for (let i = 0; i <= transcriptLines.length - snippetLines.length; i += 1) {
+    let matches = true;
+    for (let j = 0; j < snippetLines.length; j += 1) {
+      if (transcriptLines[i + j] !== snippetLines[j]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return { startLine: i + 1, endLine: i + snippetLines.length };
+    }
+  }
+
+  const firstNeedle = snippetLines.find((line) => line.trim().length > 0);
+  if (firstNeedle) {
+    const idx = transcriptLines.findIndex((line) => line.includes(firstNeedle));
+    if (idx >= 0) {
+      return { startLine: idx + 1, endLine: idx + snippetLines.length };
+    }
+  }
+
+  return { startLine: 1, endLine: Math.max(1, snippetLines.length) };
+}
+
 export function registerHonchoMemoryRuntime(api: any, state: PluginState): void {
   api.registerMemoryRuntime({
     async getMemorySearchManager(params: { agentId?: string }) {
@@ -84,30 +107,42 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
               ? Number(opts.maxResults)
               : DEFAULT_SEARCH_RESULTS;
             const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
-
-            const raw = await state.ownerPeer.search(query, {
-              limit,
-            });
-
             const requestedSessionKey =
               typeof opts.sessionKey === "string" && opts.sessionKey.length > 0 ? opts.sessionKey : null;
 
-            return raw
+            const raw = await state.ownerPeer.search(query, {
+              limit: requestedSessionKey ? MAX_SEARCH_RESULTS : limit,
+            });
+
+            const filtered = raw
               .filter((msg: any) => {
                 if (!requestedSessionKey) return true;
                 return msg.sessionId === requestedSessionKey || msg.sessionId.startsWith(`${requestedSessionKey}-`);
               })
-              .map((msg: any) => {
+              .slice(0, limit);
+
+            const transcriptCache = new Map<string, Promise<string>>();
+
+            return Promise.all(
+              filtered.map(async (msg: any) => {
                 const snippet = typeof msg.content === "string" ? msg.content : "";
+                let transcriptPromise = transcriptCache.get(msg.sessionId);
+                if (!transcriptPromise) {
+                  transcriptPromise = buildSessionTranscript(state, agentId, msg.sessionId);
+                  transcriptCache.set(msg.sessionId, transcriptPromise);
+                }
+                const transcript = await transcriptPromise;
+                const { startLine, endLine } = findSnippetLineRange(transcript, snippet);
                 return {
                   path: normalizeSessionPath(msg.sessionId),
-                  startLine: 1,
-                  endLine: countLines(snippet),
+                  startLine,
+                  endLine,
                   score: 1,
                   snippet,
                   source: "sessions",
                 };
-              });
+              })
+            );
           },
 
           async readFile(params: { relPath: string; from?: number; lines?: number }) {
@@ -126,7 +161,7 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
           status() {
             return {
               backend: "qmd",
-              provider: isLocalBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
+              provider: isLocalHonchoBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
               model: "n/a",
               sources: ["sessions"],
               custom: {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,0 +1,147 @@
+import { buildSessionKey } from "./helpers.js";
+import type { PluginState } from "./state.js";
+
+function normalizeSessionPath(sessionId: string): string {
+  return `sessions/${sessionId}.txt`;
+}
+
+function parseSessionPath(relPath: string): string | null {
+  const m = /^sessions\/(.+)\.txt$/.exec(relPath);
+  return m ? m[1] : null;
+}
+
+function countLines(text: string): number {
+  return text.length === 0 ? 1 : text.split(/\r?\n/).length;
+}
+
+function sliceLines(text: string, from = 1, lines?: number): string {
+  const all = text.split(/\r?\n/);
+  const start = Math.max(1, from) - 1;
+  const end = lines == null ? all.length : Math.max(start, start + Math.max(0, lines));
+  return all.slice(start, end).join("\n");
+}
+
+async function buildSessionTranscript(
+  state: PluginState,
+  agentId: string,
+  sessionId: string
+): Promise<string> {
+  await state.ensureInitialized();
+
+  const agentPeer = await state.getAgentPeer(agentId);
+  const session = await state.honcho.session(sessionId, { metadata: { agentId } });
+  const context = await session.context({
+    summary: true,
+    tokens: 20000,
+    peerTarget: state.ownerPeer,
+    peerPerspective: agentPeer,
+  });
+
+  const lines: string[] = [];
+
+  if (context.summary?.content) {
+    lines.push("# Summary", context.summary.content, "");
+  }
+
+  for (const msg of context.messages ?? []) {
+    const speaker =
+      msg.peerId === state.ownerPeer.id
+        ? "User"
+        : msg.peerId === agentPeer.id
+          ? `Agent(${agentId})`
+          : `Peer(${msg.peerId})`;
+    const ts = msg.createdAt ? ` ${msg.createdAt}` : "";
+    lines.push(`## ${speaker}${ts}`, msg.content ?? "", "");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function registerHonchoMemoryRuntime(api: any, state: PluginState): void {
+  api.registerMemoryRuntime({
+    async getMemorySearchManager(params: { agentId?: string }) {
+      const { agentId = state.resolveDefaultAgentId() } = params ?? {};
+
+      await state.ensureInitialized();
+
+      return {
+        manager: {
+          async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
+            await state.ensureInitialized();
+
+            const raw = await state.ownerPeer.search(query, {
+              limit: opts.maxResults ?? 10,
+            });
+
+            const requestedSessionKey =
+              typeof opts.sessionKey === "string" && opts.sessionKey.length > 0 ? opts.sessionKey : null;
+
+            return raw
+              .filter((msg: any) => {
+                if (!requestedSessionKey) return true;
+                return msg.sessionId === requestedSessionKey || msg.sessionId.startsWith(`${requestedSessionKey}-`);
+              })
+              .map((msg: any) => {
+                const snippet = typeof msg.content === "string" ? msg.content : "";
+                return {
+                  path: normalizeSessionPath(msg.sessionId),
+                  startLine: 1,
+                  endLine: countLines(snippet),
+                  score: 1,
+                  snippet,
+                  source: "sessions",
+                };
+              });
+          },
+
+          async readFile(params: { relPath: string; from?: number; lines?: number }) {
+            const sessionId = parseSessionPath(params.relPath);
+            if (!sessionId) {
+              throw new Error(`Unsupported Honcho memory path: ${params.relPath}`);
+            }
+
+            const transcript = await buildSessionTranscript(state, agentId, sessionId);
+            return {
+              path: params.relPath,
+              text: sliceLines(transcript, params.from, params.lines),
+            };
+          },
+
+          status() {
+            return {
+              backend: "qmd",
+              provider:
+                state.cfg.baseUrl?.includes("localhost") || state.cfg.baseUrl?.includes("127.0.0.1")
+                  ? "honcho-selfhosted"
+                  : "honcho",
+              model: "n/a",
+              sources: ["sessions"],
+              custom: {
+                searchMode: "semantic",
+                workspaceId: state.cfg.workspaceId,
+                baseUrl: state.cfg.baseUrl,
+              },
+            };
+          },
+
+          async probeEmbeddingAvailability() {
+            return { ok: true };
+          },
+
+          async probeVectorAvailability() {
+            return true;
+          },
+        },
+      };
+    },
+
+    resolveMemoryBackendConfig(params: { sessionKey?: string; messageProvider?: string } = {}) {
+      const sessionKey = buildSessionKey(params);
+      return {
+        backend: "qmd",
+        qmd: {},
+        sessionKey,
+      };
+    },
+  });
+}

--- a/runtime.ts
+++ b/runtime.ts
@@ -13,10 +13,6 @@ function parseSessionPath(relPath: string): string | null {
   return m ? m[1] : null;
 }
 
-function countLines(text: string): number {
-  return text.length === 0 ? 1 : text.split(/\r?\n/).length;
-}
-
 function sliceLines(text: string, from = 1, lines?: number): string {
   const all = text.split(/\r?\n/);
   const start = Math.max(1, from) - 1;

--- a/runtime.ts
+++ b/runtime.ts
@@ -24,7 +24,7 @@ function matchesSessionScope(sessionId: string, activeSessionKey: string): boole
 function sliceLines(text: string, from = 1, lines?: number): string {
   const all = text.split(/\r?\n/);
   const start = Math.max(1, from) - 1;
-  const end = lines == null ? all.length : Math.max(start, start + Math.max(0, lines));
+  const end = lines == null ? all.length : Math.min(all.length, start + Math.max(0, lines));
   return all.slice(start, end).join("\n");
 }
 
@@ -173,7 +173,7 @@ export async function getHonchoMemorySearchManager(
           collect(await exactSession.search(query, { limit }));
 
           if (filtered.length < limit) {
-            const sessions = await state.ownerPeer.sessions();
+            const sessions = await ownerPeer.sessions();
             for await (const session of sessions) {
               if (filtered.length >= limit) break;
               if (

--- a/runtime.ts
+++ b/runtime.ts
@@ -92,104 +92,117 @@ function findSnippetLineRange(transcript: string, snippet: string): { startLine:
   return { startLine: 1, endLine: Math.max(1, snippetLines.length) };
 }
 
+export async function getHonchoMemorySearchManager(
+  state: PluginState,
+  params: { agentId?: string } = {}
+) {
+  const { agentId = state.resolveDefaultAgentId() } = params;
+
+  await state.ensureInitialized();
+
+  return {
+    manager: {
+      async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
+        await state.ensureInitialized();
+        const requested = Number.isFinite(opts.maxResults)
+          ? Number(opts.maxResults)
+          : DEFAULT_SEARCH_RESULTS;
+        const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
+        const requestedSessionKey =
+          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0 ? opts.sessionKey : null;
+
+        const raw = await state.ownerPeer.search(query, {
+          limit: requestedSessionKey ? MAX_SEARCH_RESULTS : limit,
+        });
+
+        const filtered = raw
+          .filter((msg: any) => {
+            if (!requestedSessionKey) return true;
+            return msg.sessionId === requestedSessionKey || msg.sessionId.startsWith(`${requestedSessionKey}-`);
+          })
+          .slice(0, limit);
+
+        const transcriptCache = new Map<string, Promise<string>>();
+
+        return Promise.all(
+          filtered.map(async (msg: any) => {
+            const snippet = typeof msg.content === "string" ? msg.content : "";
+            let transcriptPromise = transcriptCache.get(msg.sessionId);
+            if (!transcriptPromise) {
+              transcriptPromise = buildSessionTranscript(state, agentId, msg.sessionId);
+              transcriptCache.set(msg.sessionId, transcriptPromise);
+            }
+            const transcript = await transcriptPromise;
+            const { startLine, endLine } = findSnippetLineRange(transcript, snippet);
+            return {
+              path: normalizeSessionPath(msg.sessionId),
+              startLine,
+              endLine,
+              score: 1,
+              snippet,
+              source: "sessions",
+            };
+          })
+        );
+      },
+
+      async readFile(params: { relPath: string; from?: number; lines?: number }) {
+        const sessionId = parseSessionPath(params.relPath);
+        if (!sessionId) {
+          throw new Error(`Unsupported Honcho memory path: ${params.relPath}`);
+        }
+
+        const transcript = await buildSessionTranscript(state, agentId, sessionId);
+        return {
+          path: params.relPath,
+          text: sliceLines(transcript, params.from, params.lines),
+        };
+      },
+
+      status() {
+        return {
+          backend: "qmd",
+          provider: isLocalHonchoBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
+          model: "n/a",
+          sources: ["sessions"],
+          custom: {
+            searchMode: "semantic",
+            workspaceId: state.cfg.workspaceId,
+            baseUrl: state.cfg.baseUrl,
+          },
+        };
+      },
+
+      async probeEmbeddingAvailability() {
+        return { ok: true };
+      },
+
+      async probeVectorAvailability() {
+        return true;
+      },
+    },
+  };
+}
+
+export function resolveHonchoMemoryBackendConfig(
+  params: { sessionKey?: string; messageProvider?: string } = {}
+) {
+  const sessionKey = buildSessionKey(params);
+  return {
+    backend: "qmd",
+    qmd: {},
+    sessionKey,
+  };
+}
+
 export function registerHonchoMemoryRuntime(api: any, state: PluginState): void {
   api.registerMemoryRuntime({
-    async getMemorySearchManager(params: { agentId?: string }) {
-      const { agentId = state.resolveDefaultAgentId() } = params ?? {};
-
-      await state.ensureInitialized();
-
-      return {
-        manager: {
-          async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
-            await state.ensureInitialized();
-            const requested = Number.isFinite(opts.maxResults)
-              ? Number(opts.maxResults)
-              : DEFAULT_SEARCH_RESULTS;
-            const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
-            const requestedSessionKey =
-              typeof opts.sessionKey === "string" && opts.sessionKey.length > 0 ? opts.sessionKey : null;
-
-            const raw = await state.ownerPeer.search(query, {
-              limit: requestedSessionKey ? MAX_SEARCH_RESULTS : limit,
-            });
-
-            const filtered = raw
-              .filter((msg: any) => {
-                if (!requestedSessionKey) return true;
-                return msg.sessionId === requestedSessionKey || msg.sessionId.startsWith(`${requestedSessionKey}-`);
-              })
-              .slice(0, limit);
-
-            const transcriptCache = new Map<string, Promise<string>>();
-
-            return Promise.all(
-              filtered.map(async (msg: any) => {
-                const snippet = typeof msg.content === "string" ? msg.content : "";
-                let transcriptPromise = transcriptCache.get(msg.sessionId);
-                if (!transcriptPromise) {
-                  transcriptPromise = buildSessionTranscript(state, agentId, msg.sessionId);
-                  transcriptCache.set(msg.sessionId, transcriptPromise);
-                }
-                const transcript = await transcriptPromise;
-                const { startLine, endLine } = findSnippetLineRange(transcript, snippet);
-                return {
-                  path: normalizeSessionPath(msg.sessionId),
-                  startLine,
-                  endLine,
-                  score: 1,
-                  snippet,
-                  source: "sessions",
-                };
-              })
-            );
-          },
-
-          async readFile(params: { relPath: string; from?: number; lines?: number }) {
-            const sessionId = parseSessionPath(params.relPath);
-            if (!sessionId) {
-              throw new Error(`Unsupported Honcho memory path: ${params.relPath}`);
-            }
-
-            const transcript = await buildSessionTranscript(state, agentId, sessionId);
-            return {
-              path: params.relPath,
-              text: sliceLines(transcript, params.from, params.lines),
-            };
-          },
-
-          status() {
-            return {
-              backend: "qmd",
-              provider: isLocalHonchoBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
-              model: "n/a",
-              sources: ["sessions"],
-              custom: {
-                searchMode: "semantic",
-                workspaceId: state.cfg.workspaceId,
-                baseUrl: state.cfg.baseUrl,
-              },
-            };
-          },
-
-          async probeEmbeddingAvailability() {
-            return { ok: true };
-          },
-
-          async probeVectorAvailability() {
-            return true;
-          },
-        },
-      };
+    getMemorySearchManager(params: { agentId?: string }) {
+      return getHonchoMemorySearchManager(state, params);
     },
 
     resolveMemoryBackendConfig(params: { sessionKey?: string; messageProvider?: string } = {}) {
-      const sessionKey = buildSessionKey(params);
-      return {
-        backend: "qmd",
-        qmd: {},
-        sessionKey,
-      };
+      return resolveHonchoMemoryBackendConfig(params);
     },
   });
 }

--- a/runtime.ts
+++ b/runtime.ts
@@ -13,6 +13,10 @@ function parseSessionPath(relPath: string): string | null {
   return m ? m[1] : null;
 }
 
+function matchesSessionScope(sessionId: string, activeSessionKey: string): boolean {
+  return sessionId === activeSessionKey || sessionId.startsWith(`${activeSessionKey}-`);
+}
+
 function sliceLines(text: string, from = 1, lines?: number): string {
   const all = text.split(/\r?\n/);
   const start = Math.max(1, from) - 1;
@@ -90,9 +94,9 @@ function findSnippetLineRange(transcript: string, snippet: string): { startLine:
 
 export async function getHonchoMemorySearchManager(
   state: PluginState,
-  params: { agentId?: string } = {}
+  params: { agentId?: string; sessionKey?: string } = {}
 ) {
-  const { agentId = state.resolveDefaultAgentId() } = params;
+  const { agentId = state.resolveDefaultAgentId(), sessionKey: activeSessionKey } = params;
 
   await state.ensureInitialized();
 
@@ -106,19 +110,48 @@ export async function getHonchoMemorySearchManager(
         const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
         const requestedSessionKey =
           typeof opts.sessionKey === "string" && opts.sessionKey.length > 0 ? opts.sessionKey : null;
-
-        const raw = await state.ownerPeer.search(query, {
-          limit: requestedSessionKey ? MAX_SEARCH_RESULTS : limit,
-        });
-
-        const filtered = raw
-          .filter((msg: any) => {
-            if (!requestedSessionKey) return true;
-            return msg.sessionId === requestedSessionKey || msg.sessionId.startsWith(`${requestedSessionKey}-`);
-          })
-          .slice(0, limit);
-
         const transcriptCache = new Map<string, Promise<string>>();
+        const seenSessionIds = new Set<string>();
+        const filtered: Array<any> = [];
+
+        const collect = (messages: Array<any>) => {
+          for (const msg of messages) {
+            if (filtered.length >= limit) break;
+            const sessionId = typeof msg?.sessionId === "string" ? msg.sessionId : "";
+            if (!sessionId || seenSessionIds.has(`${sessionId}:${String(msg?.id ?? msg?.createdAt ?? msg?.content ?? "")}`)) {
+              continue;
+            }
+            if (requestedSessionKey && !matchesSessionScope(sessionId, requestedSessionKey)) {
+              continue;
+            }
+            seenSessionIds.add(`${sessionId}:${String(msg?.id ?? msg?.createdAt ?? msg?.content ?? "")}`);
+            filtered.push(msg);
+          }
+        };
+
+        if (requestedSessionKey) {
+          const exactSession = await state.honcho.session(requestedSessionKey, {
+            metadata: { agentId },
+          });
+          collect(await exactSession.search(query, { limit }));
+
+          if (filtered.length < limit) {
+            const sessions = await state.ownerPeer.sessions();
+            for await (const session of sessions) {
+              if (filtered.length >= limit) break;
+              if (
+                typeof session?.id !== "string" ||
+                session.id === requestedSessionKey ||
+                !session.id.startsWith(`${requestedSessionKey}-`)
+              ) {
+                continue;
+              }
+              collect(await session.search(query, { limit: limit - filtered.length }));
+            }
+          }
+        } else {
+          collect(await state.ownerPeer.search(query, { limit }));
+        }
 
         return Promise.all(
           filtered.map(async (msg: any) => {
@@ -146,6 +179,9 @@ export async function getHonchoMemorySearchManager(
         const sessionId = parseSessionPath(params.relPath);
         if (!sessionId) {
           throw new Error(`Unsupported Honcho memory path: ${params.relPath}`);
+        }
+        if (activeSessionKey && !matchesSessionScope(sessionId, activeSessionKey)) {
+          throw new Error(`Requested Honcho memory path is outside the active session: ${params.relPath}`);
         }
 
         const transcript = await buildSessionTranscript(state, agentId, sessionId);
@@ -192,8 +228,12 @@ export function resolveHonchoMemoryBackendConfig(
 }
 
 export function registerHonchoMemoryRuntime(api: any, state: PluginState): void {
+  if (typeof api?.registerMemoryRuntime !== "function") {
+    return;
+  }
+
   api.registerMemoryRuntime({
-    getMemorySearchManager(params: { agentId?: string }) {
+    getMemorySearchManager(params: { agentId?: string; sessionKey?: string }) {
       return getHonchoMemorySearchManager(state, params);
     },
 

--- a/runtime.ts
+++ b/runtime.ts
@@ -121,7 +121,18 @@ export async function getHonchoMemorySearchManager(
           : DEFAULT_SEARCH_RESULTS;
         const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
         const requestedSessionKey =
-          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0 ? opts.sessionKey : null;
+          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
+            ? opts.sessionKey
+            : activeSessionKey ?? null;
+        if (
+          activeSessionKey &&
+          requestedSessionKey &&
+          !matchesSessionScope(requestedSessionKey, activeSessionKey)
+        ) {
+          throw new Error(
+            `Requested Honcho session is outside the active session: ${requestedSessionKey}`
+          );
+        }
         const transcriptCache = new Map<string, Promise<string>>();
         const seenSessionIds = new Set<string>();
         const filtered: Array<any> = [];

--- a/runtime.ts
+++ b/runtime.ts
@@ -4,19 +4,23 @@ import { isLocalHonchoBaseUrl, type PluginState } from "./state.js";
 const DEFAULT_SEARCH_RESULTS = 10;
 const MAX_SEARCH_RESULTS = 50;
 
+/** Convert a Honcho session id into the generic memory tool path shape. */
 function normalizeSessionPath(sessionId: string): string {
   return `sessions/${sessionId}.txt`;
 }
 
+/** Parse the synthetic transcript path used by memory_get back into a session id. */
 function parseSessionPath(relPath: string): string | null {
   const m = /^sessions\/(.+)\.txt$/.exec(relPath);
   return m ? m[1] : null;
 }
 
+/** Allow the active session and Honcho child-session variants for scoped reads/searches. */
 function matchesSessionScope(sessionId: string, activeSessionKey: string): boolean {
   return sessionId === activeSessionKey || sessionId.startsWith(`${activeSessionKey}-`);
 }
 
+/** Return only the requested line window from a synthesized Honcho transcript. */
 function sliceLines(text: string, from = 1, lines?: number): string {
   const all = text.split(/\r?\n/);
   const start = Math.max(1, from) - 1;
@@ -24,6 +28,7 @@ function sliceLines(text: string, from = 1, lines?: number): string {
   return all.slice(start, end).join("\n");
 }
 
+/** Reconstruct a readable session transcript from Honcho session context data. */
 async function buildSessionTranscript(
   state: PluginState,
   agentId: string,
@@ -60,6 +65,7 @@ async function buildSessionTranscript(
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
+/** Best-effort map a matched snippet back to transcript line numbers for memory_search. */
 function findSnippetLineRange(transcript: string, snippet: string): { startLine: number; endLine: number } {
   const transcriptLines = transcript.split(/\r?\n/);
   const snippetLines = snippet.split(/\r?\n/);
@@ -92,6 +98,12 @@ function findSnippetLineRange(transcript: string, snippet: string): { startLine:
   return { startLine: 1, endLine: Math.max(1, snippetLines.length) };
 }
 
+/**
+ * Build a Honcho-backed memory manager that satisfies OpenClaw's active-memory contract.
+ *
+ * The returned manager powers both the registered memory runtime and the direct
+ * memory_search / memory_get compatibility tools.
+ */
 export async function getHonchoMemorySearchManager(
   state: PluginState,
   params: { agentId?: string; sessionKey?: string } = {}
@@ -216,6 +228,7 @@ export async function getHonchoMemorySearchManager(
   };
 }
 
+/** Resolve the memory backend descriptor expected by the OpenClaw memory slot. */
 export function resolveHonchoMemoryBackendConfig(
   params: { sessionKey?: string; messageProvider?: string } = {}
 ) {
@@ -227,6 +240,7 @@ export function resolveHonchoMemoryBackendConfig(
   };
 }
 
+/** Register the Honcho runtime adapter when the host exposes memory runtime registration. */
 export function registerHonchoMemoryRuntime(api: any, state: PluginState): void {
   if (typeof api?.registerMemoryRuntime !== "function") {
     return;

--- a/runtime.ts
+++ b/runtime.ts
@@ -35,13 +35,17 @@ async function buildSessionTranscript(
   sessionId: string
 ): Promise<string> {
   await state.ensureInitialized();
+  const ownerPeer = state.ownerPeer;
+  if (!ownerPeer) {
+    throw new Error("Honcho owner peer not initialized");
+  }
 
   const agentPeer = await state.getAgentPeer(agentId);
   const session = await state.honcho.session(sessionId, { metadata: { agentId } });
   const context = await session.context({
     summary: true,
     tokens: 20000,
-    peerTarget: state.ownerPeer,
+    peerTarget: ownerPeer,
     peerPerspective: agentPeer,
   });
 
@@ -53,7 +57,7 @@ async function buildSessionTranscript(
 
   for (const msg of context.messages ?? []) {
     const speaker =
-      msg.peerId === state.ownerPeer.id
+      msg.peerId === ownerPeer.id
         ? "User"
         : msg.peerId === agentPeer.id
           ? `Agent(${agentId})`
@@ -116,6 +120,10 @@ export async function getHonchoMemorySearchManager(
     manager: {
       async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
         await state.ensureInitialized();
+        const ownerPeer = state.ownerPeer;
+        if (!ownerPeer) {
+          throw new Error("Honcho owner peer not initialized");
+        }
         const requested = Number.isFinite(opts.maxResults)
           ? Number(opts.maxResults)
           : DEFAULT_SEARCH_RESULTS;
@@ -173,7 +181,7 @@ export async function getHonchoMemorySearchManager(
             }
           }
         } else {
-          collect(await state.ownerPeer.search(query, { limit }));
+          collect(await ownerPeer.search(query, { limit }));
         }
 
         return Promise.all(

--- a/runtime.ts
+++ b/runtime.ts
@@ -95,11 +95,17 @@ function findSnippetLineRange(transcript: string, snippet: string): { startLine:
   if (firstNeedle) {
     const idx = transcriptLines.findIndex((line) => line.includes(firstNeedle));
     if (idx >= 0) {
-      return { startLine: idx + 1, endLine: idx + snippetLines.length };
+      return {
+        startLine: idx + 1,
+        endLine: Math.min(transcriptLines.length, idx + snippetLines.length),
+      };
     }
   }
 
-  return { startLine: 1, endLine: Math.max(1, snippetLines.length) };
+  return {
+    startLine: 1,
+    endLine: Math.min(Math.max(1, transcriptLines.length), Math.max(1, snippetLines.length)),
+  };
 }
 
 /**

--- a/state.ts
+++ b/state.ts
@@ -32,7 +32,15 @@ export type PluginState = {
 export function createPluginState(api: OpenClawPluginApi): PluginState {
   const cfg = honchoConfigSchema.parse(api.pluginConfig);
 
-  if (!cfg.apiKey) {
+  const base = String(cfg.baseUrl ?? "").toLowerCase();
+  const selfHosted =
+    base.startsWith("http://localhost") ||
+    base.startsWith("http://127.0.0.1") ||
+    base.startsWith("http://") ||
+    base.startsWith("https://localhost") ||
+    base.startsWith("https://127.0.0.1");
+
+  if (!cfg.apiKey && !selfHosted) {
     api.logger.warn(
       "openclaw-honcho: No API key configured. Set HONCHO_API_KEY or configure apiKey in plugin config."
     );

--- a/state.ts
+++ b/state.ts
@@ -12,6 +12,20 @@ import { honchoConfigSchema, type HonchoConfig } from "./config.js";
 export const OWNER_ID = "owner";
 export const LEGACY_PEER_ID = "openclaw";
 
+export function isLocalHonchoBaseUrl(baseUrl?: string): boolean {
+  const base = String(baseUrl ?? "").trim();
+  if (!base) return false;
+
+  try {
+    const { hostname, protocol } = new URL(base);
+    if (protocol !== "http:" && protocol !== "https:") return false;
+    const normalizedHost = hostname.replace(/^\[(.*)\]$/, "$1");
+    return normalizedHost === "localhost" || normalizedHost === "127.0.0.1" || normalizedHost === "::1";
+  } catch {
+    return false;
+  }
+}
+
 export type PluginState = {
   honcho: Honcho;
   cfg: HonchoConfig;
@@ -32,18 +46,7 @@ export type PluginState = {
 export function createPluginState(api: OpenClawPluginApi): PluginState {
   const cfg = honchoConfigSchema.parse(api.pluginConfig);
 
-  const base = String(cfg.baseUrl ?? "").trim();
-  let selfHosted = false;
-  if (base) {
-    try {
-      const { hostname, protocol } = new URL(base);
-      selfHosted =
-        (protocol === "http:" || protocol === "https:") &&
-        (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1");
-    } catch {
-      selfHosted = false;
-    }
-  }
+  const selfHosted = isLocalHonchoBaseUrl(cfg.baseUrl);
 
   if (!cfg.apiKey && !selfHosted) {
     api.logger.warn(

--- a/state.ts
+++ b/state.ts
@@ -32,13 +32,18 @@ export type PluginState = {
 export function createPluginState(api: OpenClawPluginApi): PluginState {
   const cfg = honchoConfigSchema.parse(api.pluginConfig);
 
-  const base = String(cfg.baseUrl ?? "").toLowerCase();
-  const selfHosted =
-    base.startsWith("http://localhost") ||
-    base.startsWith("http://127.0.0.1") ||
-    base.startsWith("http://") ||
-    base.startsWith("https://localhost") ||
-    base.startsWith("https://127.0.0.1");
+  const base = String(cfg.baseUrl ?? "").trim();
+  let selfHosted = false;
+  if (base) {
+    try {
+      const { hostname, protocol } = new URL(base);
+      selfHosted =
+        (protocol === "http:" || protocol === "https:") &&
+        (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1");
+    } catch {
+      selfHosted = false;
+    }
+  }
 
   if (!cfg.apiKey && !selfHosted) {
     api.logger.warn(

--- a/tools/memory-passthrough.test.ts
+++ b/tools/memory-passthrough.test.ts
@@ -86,11 +86,11 @@ describe("memory passthrough tools", () => {
     expect(getResult.content[0]?.text).toContain("\"text\": \"remembered fact\"");
     expect(getHonchoMemorySearchManagerMock).toHaveBeenNthCalledWith(1, {}, {
       agentId: "main",
-      sessionKey: "agent:main:dashboard:test",
+      sessionKey: "agent-main-dashboard-test-unknown",
     });
     expect(getHonchoMemorySearchManagerMock).toHaveBeenNthCalledWith(2, {}, {
       agentId: "main",
-      sessionKey: "agent:main:dashboard:test",
+      sessionKey: "agent-main-dashboard-test-unknown",
     });
   });
 
@@ -117,5 +117,9 @@ describe("memory passthrough tools", () => {
 
     expect(result.content[0]?.text).toContain("\"disabled\": true");
     expect(result.content[0]?.text).toContain("\"error\": \"auth failed\"");
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, {
+      agentId: "main",
+      sessionKey: "agent-main-dashboard-test-unknown",
+    });
   });
 });

--- a/tools/memory-passthrough.test.ts
+++ b/tools/memory-passthrough.test.ts
@@ -84,6 +84,38 @@ describe("memory passthrough tools", () => {
     expect(searchResult.content[0]?.text).toContain("\"provider\": \"honcho\"");
     expect(searchResult.content[0]?.text).toContain("\"path\": \"sessions/test-session.txt\"");
     expect(getResult.content[0]?.text).toContain("\"text\": \"remembered fact\"");
-    expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, { agentId: "main" });
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenNthCalledWith(1, {}, {
+      agentId: "main",
+      sessionKey: "agent:main:dashboard:test",
+    });
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenNthCalledWith(2, {}, {
+      agentId: "main",
+      sessionKey: "agent:main:dashboard:test",
+    });
+  });
+
+  it("returns structured unavailable payloads when manager acquisition fails", async () => {
+    const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown> }> = [];
+    const api = {
+      registerTool: (factory: (ctx: Record<string, unknown>) => Record<string, unknown>) => {
+        registrations.push({ factory });
+      },
+    };
+    getHonchoMemorySearchManagerMock.mockRejectedValueOnce(new Error("auth failed"));
+
+    registerMemoryPassthrough(api as never, {} as never);
+
+    const ctx = {
+      agentId: "main",
+      config: {},
+      sessionKey: "agent:main:dashboard:test",
+    };
+    const searchTool = registrations[0]!.factory(ctx) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    };
+    const result = await searchTool.execute("call-search", { query: "Chief" });
+
+    expect(result.content[0]?.text).toContain("\"disabled\": true");
+    expect(result.content[0]?.text).toContain("\"error\": \"auth failed\"");
   });
 });

--- a/tools/memory-passthrough.test.ts
+++ b/tools/memory-passthrough.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { getHonchoMemorySearchManagerMock } = vi.hoisted(() => ({
+  getHonchoMemorySearchManagerMock: vi.fn(),
+}));
+
+vi.mock("../runtime.js", () => ({
+  getHonchoMemorySearchManager: getHonchoMemorySearchManagerMock,
+}));
+
+import { registerMemoryPassthrough } from "./memory-passthrough.js";
+
+describe("memory passthrough tools", () => {
+  beforeEach(() => {
+    getHonchoMemorySearchManagerMock.mockReset();
+    getHonchoMemorySearchManagerMock.mockResolvedValue({
+      manager: {
+        search: vi.fn(async () => [
+          {
+            path: "sessions/test-session.txt",
+            startLine: 3,
+            endLine: 3,
+            score: 1,
+            snippet: "remembered fact",
+            source: "sessions",
+          },
+        ]),
+        readFile: vi.fn(async () => ({
+          path: "sessions/test-session.txt",
+          text: "remembered fact",
+        })),
+        status: vi.fn(() => ({
+          backend: "qmd",
+          provider: "honcho",
+          model: "n/a",
+          custom: { searchMode: "semantic" },
+        })),
+      },
+    });
+  });
+
+  it("registers direct memory_search and memory_get tools", async () => {
+    const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown>; opts?: Record<string, unknown> }> = [];
+    const api = {
+      registerTool: (factory: (ctx: Record<string, unknown>) => Record<string, unknown>, opts?: Record<string, unknown>) => {
+        registrations.push({ factory, opts });
+      },
+    };
+
+    registerMemoryPassthrough(api as never, {} as never);
+
+    expect(registrations).toHaveLength(2);
+    expect(registrations[0]?.opts).toEqual({ name: "memory_search" });
+    expect(registrations[1]?.opts).toEqual({ name: "memory_get" });
+
+    const ctx = {
+      agentId: "main",
+      config: {},
+      sessionKey: "agent:main:dashboard:test",
+    };
+
+    const searchTool = registrations[0]!.factory(ctx) as {
+      name: string;
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    };
+    const getTool = registrations[1]!.factory(ctx) as {
+      name: string;
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    };
+
+    expect(searchTool.name).toBe("memory_search");
+    expect(getTool.name).toBe("memory_get");
+
+    const searchResult = await searchTool.execute("call-search", {
+      query: "Chief",
+      maxResults: 3,
+    });
+    const getResult = await getTool.execute("call-get", {
+      path: "sessions/test-session.txt",
+      from: 1,
+      lines: 2,
+    });
+
+    expect(searchResult.content[0]?.text).toContain("\"provider\": \"honcho\"");
+    expect(searchResult.content[0]?.text).toContain("\"path\": \"sessions/test-session.txt\"");
+    expect(getResult.content[0]?.text).toContain("\"text\": \"remembered fact\"");
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, { agentId: "main" });
+  });
+});

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -93,11 +93,11 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         // Keep parity with the generic schema even though Honcho does not use minScore.
         readNumberParam(params, "minScore");
 
-        const { manager } = await getHonchoMemorySearchManager(state, {
-          agentId: ctx.agentId,
-        });
-
         try {
+          const { manager } = await getHonchoMemorySearchManager(state, {
+            agentId: ctx.agentId,
+            sessionKey: ctx.sessionKey,
+          });
           const results = await manager.search(query, {
             maxResults: maxResults ?? undefined,
             sessionKey: ctx.sessionKey,
@@ -130,11 +130,11 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const from = readNumberParam(params, "from", { integer: true });
         const lines = readNumberParam(params, "lines", { integer: true });
 
-        const { manager } = await getHonchoMemorySearchManager(state, {
-          agentId: ctx.agentId,
-        });
-
         try {
+          const { manager } = await getHonchoMemorySearchManager(state, {
+            agentId: ctx.agentId,
+            sessionKey: ctx.sessionKey,
+          });
           const result = await manager.readFile({
             relPath,
             from: from ?? undefined,

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -1,8 +1,6 @@
 import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-// @ts-ignore - resolved by openclaw runtime
-import { jsonResult, readNumberParam, readStringParam } from "openclaw/plugin-sdk/memory-core";
 import type { PluginState } from "../state.js";
 import { getHonchoMemorySearchManager } from "../runtime.js";
 
@@ -28,6 +26,57 @@ function buildMemorySearchUnavailableResult(error: string | undefined) {
     warning: "Memory search is unavailable due to a memory provider error.",
     action: "Check memory provider configuration and retry memory_search.",
   };
+}
+
+function jsonResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+    details: payload,
+  };
+}
+
+function readStringParam(
+  params: Record<string, unknown>,
+  key: string,
+  options: { required?: boolean } = {}
+) {
+  const raw = params[key];
+  if (typeof raw === "string") {
+    const value = raw.trim();
+    if (value) return value;
+  }
+  if (options.required) {
+    throw new Error(`${key} required`);
+  }
+  return undefined;
+}
+
+function readNumberParam(
+  params: Record<string, unknown>,
+  key: string,
+  options: { integer?: boolean } = {}
+) {
+  const raw = params[key];
+  let value: number | undefined;
+
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    value = raw;
+  } else if (typeof raw === "string") {
+    const parsed = Number.parseFloat(raw.trim());
+    if (Number.isFinite(parsed)) {
+      value = parsed;
+    }
+  }
+
+  if (value === undefined) {
+    return undefined;
+  }
+  return options.integer ? Math.trunc(value) : value;
 }
 
 export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginState): void {
@@ -70,7 +119,7 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
   );
 
   api.registerTool(
-    (_ctx) => ({
+    (ctx) => ({
       name: "memory_get",
       label: "Memory Get",
       description:
@@ -81,7 +130,9 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const from = readNumberParam(params, "from", { integer: true });
         const lines = readNumberParam(params, "lines", { integer: true });
 
-        const { manager } = await getHonchoMemorySearchManager(state);
+        const { manager } = await getHonchoMemorySearchManager(state, {
+          agentId: ctx.agentId,
+        });
 
         try {
           const result = await manager.readFile({

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -16,6 +16,7 @@ const MemoryGetSchema = Type.Object({
   lines: Type.Optional(Type.Number()),
 }, { additionalProperties: false });
 
+/** Build the generic unavailable payload shape expected by memory_search callers. */
 function buildMemorySearchUnavailableResult(error: string | undefined) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
   return {
@@ -28,6 +29,7 @@ function buildMemorySearchUnavailableResult(error: string | undefined) {
   };
 }
 
+/** Mirror OpenClaw's plain-text JSON tool result shape without depending on runtime helpers. */
 function jsonResult(payload: unknown) {
   return {
     content: [
@@ -40,6 +42,7 @@ function jsonResult(payload: unknown) {
   };
 }
 
+/** Read a required or optional string parameter from a plain tool input object. */
 function readStringParam(
   params: Record<string, unknown>,
   key: string,
@@ -56,6 +59,7 @@ function readStringParam(
   return undefined;
 }
 
+/** Read a numeric tool parameter while tolerating either number or string input. */
 function readNumberParam(
   params: Record<string, unknown>,
   key: string,
@@ -79,6 +83,7 @@ function readNumberParam(
   return options.integer ? Math.trunc(value) : value;
 }
 
+/** Register host-compatible memory_search and memory_get tools for Honcho-backed memory. */
 export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
     (ctx) => ({

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -1,26 +1,101 @@
+import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+// @ts-ignore - resolved by openclaw runtime
+import { jsonResult, readNumberParam, readStringParam } from "openclaw/plugin-sdk/memory-core";
 import type { PluginState } from "../state.js";
+import { getHonchoMemorySearchManager } from "../runtime.js";
 
-export function registerMemoryPassthrough(api: OpenClawPluginApi, _state: PluginState): void {
+const MemorySearchSchema = Type.Object({
+  query: Type.String(),
+  maxResults: Type.Optional(Type.Number()),
+  minScore: Type.Optional(Type.Number()),
+}, { additionalProperties: false });
+
+const MemoryGetSchema = Type.Object({
+  path: Type.String(),
+  from: Type.Optional(Type.Number()),
+  lines: Type.Optional(Type.Number()),
+}, { additionalProperties: false });
+
+function buildMemorySearchUnavailableResult(error: string | undefined) {
+  const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
+  return {
+    results: [],
+    disabled: true,
+    unavailable: true,
+    error: reason,
+    warning: "Memory search is unavailable due to a memory provider error.",
+    action: "Check memory provider configuration and retry memory_search.",
+  };
+}
+
+export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
-    (ctx) => {
-      if (!api.runtime?.tools) {
-        return null;
-      }
-      const memorySearchTool = api.runtime.tools.createMemorySearchTool({
-        config: ctx.config,
-        agentSessionKey: ctx.sessionKey,
-      });
-      const memoryGetTool = api.runtime.tools.createMemoryGetTool({
-        config: ctx.config,
-        agentSessionKey: ctx.sessionKey,
-      });
-      if (!memorySearchTool || !memoryGetTool) {
-        return null;
-      }
-      return [memorySearchTool, memoryGetTool];
-    },
-    { names: ["memory_search", "memory_get"] }
+    (ctx) => ({
+      name: "memory_search",
+      label: "Memory Search",
+      description:
+        "Search the active memory plugin for relevant prior context and return snippets with path and line numbers.",
+      parameters: MemorySearchSchema,
+      async execute(_toolCallId, params) {
+        const query = readStringParam(params, "query", { required: true });
+        const maxResults = readNumberParam(params, "maxResults");
+        // Keep parity with the generic schema even though Honcho does not use minScore.
+        readNumberParam(params, "minScore");
+
+        const { manager } = await getHonchoMemorySearchManager(state, {
+          agentId: ctx.agentId,
+        });
+
+        try {
+          const results = await manager.search(query, {
+            maxResults: maxResults ?? undefined,
+            sessionKey: ctx.sessionKey,
+          });
+          const status = manager.status();
+          return jsonResult({
+            results,
+            provider: status.provider,
+            model: status.model,
+            mode: (status.custom as { searchMode?: string } | undefined)?.searchMode,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResult(buildMemorySearchUnavailableResult(message));
+        }
+      },
+    }),
+    { name: "memory_search" }
+  );
+
+  api.registerTool(
+    (_ctx) => ({
+      name: "memory_get",
+      label: "Memory Get",
+      description:
+        "Read a specific snippet from the active memory plugin using a path returned by memory_search.",
+      parameters: MemoryGetSchema,
+      async execute(_toolCallId, params) {
+        const relPath = readStringParam(params, "path", { required: true });
+        const from = readNumberParam(params, "from", { integer: true });
+        const lines = readNumberParam(params, "lines", { integer: true });
+
+        const { manager } = await getHonchoMemorySearchManager(state);
+
+        try {
+          const result = await manager.readFile({
+            relPath,
+            from: from ?? undefined,
+            lines: lines ?? undefined,
+          });
+          return jsonResult(result);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResult({ path: relPath, text: "", disabled: true, error: message });
+        }
+      },
+    }),
+    { name: "memory_get" }
   );
 }

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
+import { buildSessionKey } from "../helpers.js";
 import { getHonchoMemorySearchManager } from "../runtime.js";
 
 const MemorySearchSchema = Type.Object({
@@ -97,15 +98,18 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const maxResults = readNumberParam(params, "maxResults");
         // Keep parity with the generic schema even though Honcho does not use minScore.
         readNumberParam(params, "minScore");
+        const honchoSessionKey = buildSessionKey({
+          sessionKey: ctx.sessionKey,
+        });
 
         try {
           const { manager } = await getHonchoMemorySearchManager(state, {
             agentId: ctx.agentId,
-            sessionKey: ctx.sessionKey,
+            sessionKey: honchoSessionKey,
           });
           const results = await manager.search(query, {
             maxResults: maxResults ?? undefined,
-            sessionKey: ctx.sessionKey,
+            sessionKey: honchoSessionKey,
           });
           const status = manager.status();
           return jsonResult({
@@ -134,11 +138,14 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const relPath = readStringParam(params, "path", { required: true });
         const from = readNumberParam(params, "from", { integer: true });
         const lines = readNumberParam(params, "lines", { integer: true });
+        const honchoSessionKey = buildSessionKey({
+          sessionKey: ctx.sessionKey,
+        });
 
         try {
           const { manager } = await getHonchoMemorySearchManager(state, {
             agentId: ctx.agentId,
-            sessionKey: ctx.sessionKey,
+            sessionKey: honchoSessionKey,
           });
           const result = await manager.readFile({
             relPath,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "types": ["node"]
   },
   "include": ["*.ts", "hooks/**/*.ts", "tools/**/*.ts", "commands/**/*.ts"],
-  "exclude": ["node_modules", "dist", "test"]
+  "exclude": ["node_modules", "dist", "test", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Thanks to @karabayogo for the original PR #45 work. This PR incorporates those
changes and adds a host-compat follow-up so the plugin works again on newer
OpenClaw builds that no longer expose `api.runtime.tools`.

## What this does

### 1. Incorporates PR #45
- registers Honcho as the active memory runtime via `api.registerMemoryRuntime(...)`
- scopes the API-key warning so it does not fire for self-hosted localhost usage
- keeps the Honcho memory-runtime status path aligned with current OpenClaw

### 2. Restores generic `memory_search` / `memory_get` without `api.runtime.tools`
- extracts a reusable Honcho-backed memory manager from `runtime.ts`
- registers `memory_search` and `memory_get` directly inside Honcho
- removes the dependency on the deleted `api.runtime.tools` host surface

### 3. Tightens session scoping and failure handling
- scopes `memory_get` to the active session key so transcript reads cannot cross session boundaries
- makes manager-scoped `search()` default to the active session and reject cross-session overrides
- normalizes direct-tool session keys through the same `buildSessionKey(...)` path used by Honcho capture/context hooks, so dashboard and chat sessions resolve to valid Honcho session ids
- avoids pre-filter truncation for session-scoped searches by searching the exact Honcho session first and then matching prefixed child sessions
- clamps fallback snippet line ranges so `memory_search` never emits `endLine` values past EOF
- wraps manager acquisition inside the tool error fallback path so initialization/auth failures return structured JSON errors
- guards `registerMemoryRuntime` for hosts that do not expose that method
- defensively checks that `ownerPeer` is initialized before transcript/search operations dereference it

### 4. Adds regression coverage and packaging cleanup
- tests for the extracted Honcho memory manager
- tests for direct `memory_search` / `memory_get` passthrough registration
- test coverage for manager-acquisition failure fallback, session-scoped search behavior, missing-owner-peer guards, and fallback line-range clamping
- excludes `*.test.ts` from published `dist`

## Validation

### Repo validation
- `pnpm exec vitest run`
- `pnpm build`

### Live host validation
- gateway healthy after restart
- Honcho initializes successfully
- `doctor.memory.status` resolves to `provider: "honcho"`
- fresh session tool inventory includes `memory_search`, `memory_get`, and the expected `honcho_*` tools
- live agent turns successfully called both `memory_search` and `memory_get` on the latest locally installed candidate

### Maintainer note
`/tools/invoke` is not the authoritative validation surface for plugin-provided
`memory_search` / `memory_get` because the HTTP handler intentionally suppresses
plugin tools whose names collide with known core tool ids. The meaningful checks
for this PR are fresh-session `tools.effective`, `doctor.memory.status`, and a
real agent turn that actually calls the tools.

## Context

This is intended as the smallest plausible upstream-compatible adaptation after
OpenClaw moved memory tooling into `memory-core` and removed `api.runtime.tools`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Honcho-backed memory runtime: session-scoped search, transcript reconstruction, and transcript slicing.
  * Memory tools now always register and return structured results with provider/status metadata; improved parameter parsing.

* **Bug Fixes**
  * Memory operations return consistent structured error/unavailable responses instead of failing silently.

* **Tests**
  * Added end-to-end tests for the memory runtime and passthrough tools.

* **Chores**
  * Exclude test files from TypeScript build; suppress API-key warning for local/self-hosted base URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->