### PR TITLE
feat: add configurable timeout for self-hosted Honcho

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,8 @@
+{
+  "strictness": 2,
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "updateExistingSummaryComment": true,
+  "fixWithAI": true,
+  "hideFooter": true
+}

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,8 +1,0 @@
-{
-  "strictness": 2,
-  "triggerOnUpdates": true,
-  "statusCheck": true,
-  "updateExistingSummaryComment": true,
-  "fixWithAI": true,
-  "hideFooter": true
-}

--- a/config.ts
+++ b/config.ts
@@ -66,12 +66,16 @@ export const honchoConfigSchema = {
         typeof cfg.baseUrl === "string" && cfg.baseUrl.length > 0
           ? cfg.baseUrl
           : process.env.HONCHO_BASE_URL ?? "https://api.honcho.dev",
-      timeoutMs:
-        typeof cfg.timeoutMs === "number" && Number.isFinite(cfg.timeoutMs) && cfg.timeoutMs > 0
-          ? cfg.timeoutMs
-          : process.env.HONCHO_TIMEOUT_MS
-            ? Number(process.env.HONCHO_TIMEOUT_MS)
-            : undefined,
+      timeoutMs: (() => {
+        if (typeof cfg.timeoutMs === "number" && Number.isFinite(cfg.timeoutMs) && cfg.timeoutMs > 0) {
+          return cfg.timeoutMs;
+        }
+        if (process.env.HONCHO_TIMEOUT_MS !== undefined) {
+          const parsed = Number(process.env.HONCHO_TIMEOUT_MS);
+          if (Number.isFinite(parsed) && parsed > 0) return parsed;
+        }
+        return undefined;
+      })(),
       noisePatterns,
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,

--- a/config.ts
+++ b/config.ts
@@ -13,6 +13,7 @@ export type HonchoConfig = {
   apiKey?: string;
   workspaceId: string;
   baseUrl: string;
+  timeoutMs?: number;
   noisePatterns: string[];
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
@@ -65,6 +66,12 @@ export const honchoConfigSchema = {
         typeof cfg.baseUrl === "string" && cfg.baseUrl.length > 0
           ? cfg.baseUrl
           : process.env.HONCHO_BASE_URL ?? "https://api.honcho.dev",
+      timeoutMs:
+        typeof cfg.timeoutMs === "number" && Number.isFinite(cfg.timeoutMs) && cfg.timeoutMs > 0
+          ? cfg.timeoutMs
+          : process.env.HONCHO_TIMEOUT_MS
+            ? Number(process.env.HONCHO_TIMEOUT_MS)
+            : undefined,
       noisePatterns,
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -17,6 +17,11 @@
         "type": "string",
         "default": "https://api.honcho.dev"
       },
+      "timeoutMs": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "HTTP timeout in milliseconds for Honcho SDK requests. Useful for slower self-hosted local models."
+      },
       "noisePatterns": {
         "type": "array",
         "items": { "type": "string" },
@@ -50,6 +55,12 @@
       "label": "API Base URL",
       "advanced": true,
       "placeholder": "https://api.honcho.dev"
+    },
+    "timeoutMs": {
+      "label": "HTTP Timeout (ms)",
+      "advanced": true,
+      "placeholder": "60000",
+      "help": "Increase this for self-hosted Honcho deployments backed by slower local models."
     },
     "noisePatterns": {
       "label": "Noise Patterns",

--- a/state.ts
+++ b/state.ts
@@ -42,6 +42,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     apiKey: cfg.apiKey,
     baseURL: cfg.baseUrl,
     workspaceId: cfg.workspaceId,
+    timeout: cfg.timeoutMs,
   });
 
   const state: PluginState = {


### PR DESCRIPTION
## Summary
- add an optional `timeoutMs` plugin setting and surface it in the plugin schema/UI
- allow `HONCHO_TIMEOUT_MS` as an environment fallback
- pass the configured timeout through to the Honcho SDK client

## Why
The plugin currently assumes hosted-Honcho latencies and uses the SDK default timeout. That works for the public service, but self-hosted Honcho deployments backed by slower local models can exceed that window and fail even when the underlying request eventually succeeds. This change gives operators a supported way to raise the timeout without patching the plugin locally.

## Validation
- built the plugin with `pnpm build`
- verified the plugin accepts a larger timeout and uses it in the Honcho client configuration for a working self-hosted deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP timeout for Honcho SDK requests. Users can set the timeout value (in milliseconds) via configuration settings or environment variable, with a minimum value of 1ms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->