### PR TITLE
docs: add known issue for OpenClaw 2026.4.5 hook regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,37 @@ You can also pre-warm QMD to avoid first-run delays:
 qmd query "test"
 ```
 
+## Known Issues
+
+### OpenClaw 2026.4.5: Hooks silently stop firing
+
+OpenClaw 2026.4.5 has a plugin loader bug where reentrant provider snapshot loads during initialization can cause hooks to register into a registry that is later discarded. The result is that `agent_end` (and potentially other hooks) never fire — the plugin appears loaded and no errors are logged, but no sessions are written to Honcho.
+
+**Affected versions:** OpenClaw 2026.4.5 only.
+
+**Symptoms:**
+- Plugin logs `Honcho memory plugin loaded` at startup
+- No errors in gateway logs
+- `honcho_search_messages` returns nothing after the upgrade date
+- Honcho queue shows 0 pending (deriver has nothing to process)
+- Manual Honcho API calls still work
+
+**Fix:** Update OpenClaw to **2026.4.6 or later**. The upstream fixes landed in the 4.6 changelog:
+
+> Plugins/provider hooks: stop recursive provider snapshot loads from overflowing the stack during plugin initialization. (#61922, #61938, #61946, #61951)
+
+```bash
+# Update OpenClaw
+npm install -g openclaw@latest
+# or
+brew upgrade openclaw
+
+# Restart the gateway
+openclaw gateway restart
+```
+
+**Verified working:** OpenClaw 2026.3.22 through 2026.4.4, and 2026.4.6+.
+
 ## Development
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, building from source, and contribution guidelines.


### PR DESCRIPTION
## Summary

Adds a Known Issues section to the README documenting the OpenClaw 2026.4.5 plugin loader regression that silently breaks hook dispatch for community memory plugins.

## Root cause

OpenClaw 2026.4.5 introduced a reentrant plugin loading bug: during initialization, provider hook resolution could trigger nested plugin loads that race with the primary load. Hooks registered by our plugin end up in a registry that is later discarded when the nested load overwrites it. The global hook runner is initialized with the final registry (which lacks our hooks), so `agent_end` never fires.

The bug was fixed upstream in OpenClaw 2026.4.6 by Peter Steinberger across four commits:
- `725cbcc` — narrow provider hook reentry guard
- `7d9a6b5` — detect reentrant plugin loads
- `510fca6` — avoid helper reentry loads
- `c78defd` / `fa67ab2` — cache key and gateway-bindable loader fixes

Upstream refs: openclaw/openclaw#61922, #61938, #61946, #61951

## What this PR does

Adds a `Known Issues` section to the README with:
- Affected version (4.5 only)
- Symptom checklist matching the user report
- Root cause explanation
- Fix: upgrade to 4.6+
- Verified working version range

## Context

Reported via Discord by a user who upgraded OpenClaw 2026.4.2 → 2026.4.5 on April 6 and saw zero sessions written from that day forward. Traced through the full OpenClaw source (plugin loader, registry, hook runner, facade runtime, activation state) across versions to confirm the root cause. Verified on OpenClaw 2026.4.8 that the bug is fixed — all hooks fire correctly.

No code changes to the plugin. This is documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Known Issues" section documenting a specific OpenClaw 2026.4.5 plugin loader failure. Includes observed symptoms (search returning no results after upgrade, no gateway errors) and remediation steps (upgrade OpenClaw to 2026.4.6+).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->