### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 All notable changes to `@honcho-ai/openclaw-honcho` will be documented in this file.
 
-## Unreleased
+## [1.3.0] - 2026-04-09
+
+Minor version bump: this release replaces the memory tool implementation (not just
+a bug fix) and makes cross-session memory access configurable — both are behavioral
+changes that affect how agents interact with the memory subsystem.
+
+### Added
+- **Honcho-native `memory_search` and `memory_get` tools (#52, #45)**: Self-contained implementations that replace the deleted `api.runtime.tools` passthrough. Tools use TypeBox schemas, return structured JSON with provider/status metadata, and degrade gracefully with structured error payloads when the backend is unavailable. Contributed by @bcdonadio; foundational runtime adapter by @slideshow-dingo.
+- **Configurable `crossSessionSearch` option**: `memory_search` and `memory_get` now default to cross-session access (`crossSessionSearch: true`), matching Honcho's design for cross-session exploration and user representation. Set `crossSessionSearch: false` in plugin config to restrict tools to the active session and its children only. This replaces the previous hardcoded session scoping from #52.
+- **Backward-compatible runtime registration guard (#52)**: `registerHonchoMemoryRuntime()` now checks for `api.registerMemoryRuntime` before calling it, so the plugin loads cleanly on older OpenClaw hosts that don't expose the memory runtime API.
+- **Memory runtime + passthrough test suites (#52)**: 6 tests covering session-scoped search, cross-session rejection, transcript slicing, snippet range clamping, null ownerPeer handling, and tool registration.
 
 ### Fixed
-- **Stale tool names in `workspace_md/AGENTS.md` (#49)**: Default agent template referenced deprecated tool names (`honcho_profile`, `honcho_search`, `honcho_recall`, `honcho_analyze`) that no longer exist since v1.2.0. Agents bootstrapped with the template would fail when calling memory tools. Updated all references to match registered tools and added parameter hints.
+- **Stale tool names in `workspace_md/AGENTS.md` (#49)**: Default agent template referenced deprecated tool names (`honcho_profile`, `honcho_search`, `honcho_recall`, `honcho_analyze`) that no longer exist since v1.2.0. Updated all references to match registered tools and added parameter hints.
+- **Snippet line range could exceed transcript length (#52)**: `sliceLines` and `findSnippetLineRange` now clamp `endLine` to the actual transcript length, preventing out-of-bounds ranges in `memory_search` results.
+- **ownerPeer null access in runtime (#52)**: `buildSessionTranscript` and `search` now guard against uninitialized `ownerPeer`, throwing a descriptive error instead of a `TypeError`.
 
 ## [1.2.2] - 2026-03-31
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `baseUrl`              | `string`   | `"https://api.honcho.dev"` | API endpoint (for self-hosted instances). |
 | `noisePatterns`        | `string[]` | built-in defaults          | Patterns to skip messages. User-provided patterns are merged with built-in defaults (unless `disableDefaultNoisePatterns` is set). |
 | `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
+| `crossSessionSearch`   | `boolean`  | `true`                     | Allow `memory_search` and `memory_get` to access any session. Set to `false` to restrict to the active session and its children. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
 
 ### Self-Hosted / Local Honcho

--- a/config.ts
+++ b/config.ts
@@ -16,6 +16,7 @@ export type HonchoConfig = {
   noisePatterns: string[];
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
+  crossSessionSearch: boolean;
 };
 
 /**
@@ -68,6 +69,7 @@ export const honchoConfigSchema = {
       noisePatterns,
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
+      crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,
     };
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/openclaw-honcho",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "type": "module",
   "description": "Honcho AI-native memory integration for OpenClaw",
   "main": "dist/index.js",

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { getHonchoMemorySearchManager, resolveHonchoMemoryBackendConfig } from "./runtime.js";
 import type { PluginState } from "./state.js";
 
-function createState(baseUrl = "https://api.honcho.dev"): PluginState {
+function createState(baseUrl = "https://api.honcho.dev", { crossSessionSearch = true }: { crossSessionSearch?: boolean } = {}): PluginState {
   const contexts = new Map<string, { summary: { content: string }; messages: Array<Record<string, unknown>> }>([
     [
       "session-1",
@@ -80,6 +80,10 @@ function createState(baseUrl = "https://api.honcho.dev"): PluginState {
       "session-2",
       [{ id: "msg-3", sessionId: "session-2", content: "Beta\nextra" }],
     ],
+    [
+      "other-session",
+      [{ id: "msg-4", sessionId: "other-session", content: "Other result" }],
+    ],
   ]);
 
   const createSession = (sessionId: string) => ({
@@ -97,6 +101,7 @@ function createState(baseUrl = "https://api.honcho.dev"): PluginState {
       noisePatterns: [],
       disableDefaultNoisePatterns: false,
       ownerObserveOthers: false,
+      crossSessionSearch,
     },
     honcho: {
       session: vi.fn(async (sessionId: string) => createSession(sessionId)),
@@ -127,7 +132,7 @@ function createState(baseUrl = "https://api.honcho.dev"): PluginState {
 
 describe("Honcho memory runtime", () => {
   it("filters search results by session key and returns session transcript paths", async () => {
-    const state = createState();
+    const state = createState("https://api.honcho.dev", { crossSessionSearch: false });
 
     const { manager } = await getHonchoMemorySearchManager(state, {
       agentId: "main",
@@ -159,8 +164,28 @@ describe("Honcho memory runtime", () => {
     ).rejects.toThrow(/outside the active session/);
   });
 
+  it("allows cross-session search when crossSessionSearch is true", async () => {
+    const state = createState();
+
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+
+    const results = await manager.search("remember", {
+      sessionKey: "other-session",
+    });
+    expect(results.length).toBeGreaterThan(0);
+
+    const file = await manager.readFile({
+      relPath: "sessions/other-session.txt",
+    });
+    expect(file.path).toBe("sessions/other-session.txt");
+    expect(file.text).toContain("Other summary");
+  });
+
   it("reads scoped transcript slices and resolves backend metadata", async () => {
-    const state = createState("http://localhost:8000");
+    const state = createState("http://localhost:8000", { crossSessionSearch: false });
 
     const { manager } = await getHonchoMemorySearchManager(state, {
       agentId: "main",

--- a/runtime.ts
+++ b/runtime.ts
@@ -138,7 +138,9 @@ export async function getHonchoMemorySearchManager(
           typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
             ? opts.sessionKey
             : activeSessionKey ?? null;
+        const scopeEnabled = !state.cfg.crossSessionSearch;
         if (
+          scopeEnabled &&
           activeSessionKey &&
           requestedSessionKey &&
           !matchesSessionScope(requestedSessionKey, activeSessionKey)
@@ -158,7 +160,7 @@ export async function getHonchoMemorySearchManager(
             if (!sessionId || seenSessionIds.has(`${sessionId}:${String(msg?.id ?? msg?.createdAt ?? msg?.content ?? "")}`)) {
               continue;
             }
-            if (requestedSessionKey && !matchesSessionScope(sessionId, requestedSessionKey)) {
+            if (scopeEnabled && requestedSessionKey && !matchesSessionScope(sessionId, requestedSessionKey)) {
               continue;
             }
             seenSessionIds.add(`${sessionId}:${String(msg?.id ?? msg?.createdAt ?? msg?.content ?? "")}`);
@@ -217,7 +219,7 @@ export async function getHonchoMemorySearchManager(
         if (!sessionId) {
           throw new Error(`Unsupported Honcho memory path: ${params.relPath}`);
         }
-        if (activeSessionKey && !matchesSessionScope(sessionId, activeSessionKey)) {
+        if (!state.cfg.crossSessionSearch && activeSessionKey && !matchesSessionScope(sessionId, activeSessionKey)) {
           throw new Error(`Requested Honcho memory path is outside the active session: ${params.relPath}`);
         }
 


### PR DESCRIPTION
Version bump and changelog for #52 (memory tool rewrite) and #45 (runtime adapter foundation).

### Changes
- **package.json**: 1.2.2 → 1.3.0
- **CHANGELOG.md**: New 1.3.0 entry with contributor attribution (@bcdonadio, @slideshow-dingo)
- **crossSessionSearch config**: New boolean option (default: `true`) that makes #52's session scoping opt-in. When `false`, memory tools are restricted to the active session and its children.
- **Tests**: Updated runtime tests to cover both crossSessionSearch modes.

Minor version bump rationale: replaces the memory tool implementation (not a patch-level fix) and introduces configurable session security boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `crossSessionSearch` option (defaults to enabled) for expanded session access in memory search operations.
  * Introduced native memory search and retrieval tools.
  * Added runtime registration guard for memory functionality.

* **Bug Fixes**
  * Fixed transcript line range boundary handling.
  * Improved error handling for uninitialized session contexts.

* **Tests**
  * Extended test suite for memory runtime and cross-session search scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->