### PR TITLE
chore: release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@honcho-ai/openclaw-honcho` will be documented in this file.
 
+## [1.3.1] - 2026-04-09
+
+### Fixed
+- **`honcho setup` now migrates memory files for all configured agents (#53, #46)**: Previously, setup only scanned and uploaded files for the default agent. Now performs two-phase scanning — owner files from shared workspace roots, then agent-specific files (SOUL.md, AGENTS.md, etc.) from each agent's workspace path. Files are routed to the correct `agent-{id}` peer. Deduplicates by (filePath, peerId) to prevent double-uploads. Normalizes agent IDs with duplicate detection and user-facing warnings. Contributed by @jodok.
+
 ## [1.3.0] - 2026-04-09
 
 Minor version bump: this release replaces the memory tool implementation (not just

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/openclaw-honcho",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "description": "Honcho AI-native memory integration for OpenClaw",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release for #53 (multi-agent setup migration by @jodok).

- **package.json**: 1.3.0 → 1.3.1
- **CHANGELOG.md**: New 1.3.1 entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed `honcho setup` to migrate memory files for all configured agents instead of only the default agent
* Improved upload routing and deduplication to prevent duplicate file uploads across agents  
* Added agent ID normalization with user-facing warnings for potential duplicates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->