### PR TITLE
chore: release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@honcho-ai/openclaw-honcho` will be documented in this file.
 
+## [1.3.2] - 2026-04-09
+
+### Added
+- **Configurable HTTP timeout for self-hosted Honcho (#54)**: New `timeoutMs` config option (or `HONCHO_TIMEOUT_MS` env var) sets the HTTP timeout in milliseconds for Honcho SDK requests. Useful for self-hosted deployments backed by slower local models that exceed the SDK's default timeout. Both config and env paths validate for positive finite numbers. Contributed by @ksullivan27.
+
 ## [1.3.1] - 2026-04-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/openclaw-honcho",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "description": "Honcho AI-native memory integration for OpenClaw",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release for #54 (configurable HTTP timeout by @ksullivan27).

- **package.json**: 1.3.1 → 1.3.2
- **CHANGELOG.md**: New 1.3.2 entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP timeout support for self-hosted Honcho deployments. Users can now customize request timeout values through the `timeoutMs` configuration option or `HONCHO_TIMEOUT_MS` environment variable, with built-in validation ensuring all timeout values are positive and finite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->