### PR TITLE
fix: honour crossSessionSearch flag in memory_search

### DIFF
--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -184,6 +184,52 @@ describe("Honcho memory runtime", () => {
     expect(file.text).toContain("Other summary");
   });
 
+  it("spans every session via the owner peer when crossSessionSearch is true", async () => {
+    const state = createState();
+
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+
+    // Even though activeSessionKey points at session-1, cross-session search
+    // should surface hits from sessions the active key doesn't cover.
+    const results = await manager.search("anything", {
+      maxResults: 10,
+    });
+
+    const paths = results.map((entry) => entry.path);
+    expect(paths).toContain("sessions/session-1.txt");
+    expect(paths).toContain("sessions/session-1-child.txt");
+    expect(paths).toContain("sessions/other-session.txt");
+
+    // Owner peer must drive the search directly — the session-scoped branch
+    // would never surface `other-session` when activeSessionKey is session-1.
+    expect(state.ownerPeer.search).toHaveBeenCalledTimes(1);
+  });
+
+  it("restricts search to the active session when crossSessionSearch is false", async () => {
+    const state = createState("https://api.honcho.dev", { crossSessionSearch: false });
+
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+
+    const results = await manager.search("anything", {
+      maxResults: 10,
+    });
+
+    // Only session-1 and its prefixed children should come back.
+    const paths = results.map((entry) => entry.path);
+    expect(paths).toContain("sessions/session-1.txt");
+    expect(paths).toContain("sessions/session-1-child.txt");
+    expect(paths).not.toContain("sessions/other-session.txt");
+
+    // Owner-peer search must NOT be used in scoped mode.
+    expect(state.ownerPeer.search).not.toHaveBeenCalled();
+  });
+
   it("reads scoped transcript slices and resolves backend metadata", async () => {
     const state = createState("http://localhost:8000", { crossSessionSearch: false });
 
@@ -217,10 +263,28 @@ describe("Honcho memory runtime", () => {
       qmd: {},
       sessionKey: "agent-main-dashboard-test-telegram",
     });
+
+    // When the caller has no real session key, the descriptor must omit
+    // sessionKey rather than synthesize a "default-<provider>" placeholder
+    // that would scope searches to a session that doesn't exist.
+    expect(resolveHonchoMemoryBackendConfig({})).toEqual({
+      backend: "qmd",
+      qmd: {},
+    });
+    expect(resolveHonchoMemoryBackendConfig({ sessionKey: "   " })).toEqual({
+      backend: "qmd",
+      qmd: {},
+    });
+    expect(resolveHonchoMemoryBackendConfig({ messageProvider: "slack" })).toEqual({
+      backend: "qmd",
+      qmd: {},
+    });
   });
 
   it("clamps fallback snippet ranges to the transcript length", async () => {
-    const state = createState();
+    // Use scoped mode so the session-scoped search path is exercised and
+    // the fallback line-range heuristic runs against a deterministic session.
+    const state = createState("https://api.honcho.dev", { crossSessionSearch: false });
     const { manager } = await getHonchoMemorySearchManager(state, {
       agentId: "main",
       sessionKey: "session-2",

--- a/runtime.ts
+++ b/runtime.ts
@@ -138,6 +138,11 @@ export async function getHonchoMemorySearchManager(
           typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
             ? opts.sessionKey
             : activeSessionKey ?? null;
+        // When crossSessionSearch is true (the default), session scoping is a
+        // soft hint for activeSessionKey membership only: the search itself
+        // spans every session the owner peer can see. When false, we enforce
+        // strict scoping — calls that reach outside the active session throw,
+        // and results from foreign sessions are filtered out.
         const scopeEnabled = !state.cfg.crossSessionSearch;
         if (
           scopeEnabled &&
@@ -168,7 +173,7 @@ export async function getHonchoMemorySearchManager(
           }
         };
 
-        if (requestedSessionKey) {
+        if (scopeEnabled && requestedSessionKey) {
           const exactSession = await state.honcho.session(requestedSessionKey, {
             metadata: { agentId },
           });
@@ -189,6 +194,9 @@ export async function getHonchoMemorySearchManager(
             }
           }
         } else {
+          // Cross-session search: ask the owner peer directly so results
+          // span every session in the workspace. This is also the fallback
+          // when no session key was supplied at all.
           collect(await ownerPeer.search(query, { limit }));
         }
 
@@ -258,13 +266,21 @@ export async function getHonchoMemorySearchManager(
 /** Resolve the memory backend descriptor expected by the OpenClaw memory slot. */
 export function resolveHonchoMemoryBackendConfig(
   params: { sessionKey?: string; messageProvider?: string } = {}
-) {
-  const sessionKey = buildSessionKey(params);
-  return {
+): { backend: "qmd"; qmd: Record<string, unknown>; sessionKey?: string } {
+  // Only publish a sessionKey when the caller actually provided one. Otherwise
+  // buildSessionKey() would synthesize a "default-<provider>" key that has no
+  // corresponding Honcho session, and every scoped search against it returns
+  // zero rows. Leaving sessionKey unset lets the memory slot resolve it later
+  // from the live request context, or fall through to cross-session search.
+  const raw = typeof params.sessionKey === "string" ? params.sessionKey.trim() : "";
+  const descriptor: { backend: "qmd"; qmd: Record<string, unknown>; sessionKey?: string } = {
     backend: "qmd",
     qmd: {},
-    sessionKey,
   };
+  if (raw) {
+    descriptor.sessionKey = buildSessionKey({ sessionKey: raw, messageProvider: params.messageProvider });
+  }
+  return descriptor;
 }
 
 /** Register the Honcho runtime adapter when the host exposes memory runtime registration. */

--- a/tools/memory-passthrough.test.ts
+++ b/tools/memory-passthrough.test.ts
@@ -94,6 +94,45 @@ describe("memory passthrough tools", () => {
     });
   });
 
+  it("omits sessionKey from manager calls when ctx has no session key", async () => {
+    const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown> }> = [];
+    const api = {
+      registerTool: (factory: (ctx: Record<string, unknown>) => Record<string, unknown>) => {
+        registrations.push({ factory });
+      },
+    };
+
+    registerMemoryPassthrough(api as never, {} as never);
+
+    // CLI / cron / skill-driven callers have no ctx.sessionKey. The old
+    // behavior synthesized "default-unknown", which Honcho then scoped every
+    // search to, yielding zero results. The tool must omit sessionKey so the
+    // runtime falls through to peer-wide cross-session search.
+    const ctx = { agentId: "main", config: {} };
+    const searchTool = registrations[0]!.factory(ctx) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    };
+
+    const managerSearchMock = vi.fn(async () => []);
+    getHonchoMemorySearchManagerMock.mockResolvedValueOnce({
+      manager: {
+        search: managerSearchMock,
+        status: vi.fn(() => ({ backend: "qmd", provider: "honcho", model: "n/a", custom: {} })),
+      },
+    });
+
+    await searchTool.execute("call-search", { query: "anything" });
+
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, {
+      agentId: "main",
+      sessionKey: undefined,
+    });
+    expect(managerSearchMock).toHaveBeenCalledWith("anything", {
+      maxResults: undefined,
+    });
+    expect(managerSearchMock.mock.calls[0]?.[1]).not.toHaveProperty("sessionKey");
+  });
+
   it("returns structured unavailable payloads when manager acquisition fails", async () => {
     const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown> }> = [];
     const api = {

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -5,6 +5,18 @@ import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 import { getHonchoMemorySearchManager } from "../runtime.js";
 
+/**
+ * Build a Honcho session key from tool context, or return undefined when the
+ * caller has no real session. Skipping the synthesized "default-<provider>"
+ * fallback here lets the runtime fall through to a peer-wide search instead
+ * of scoping to a session that doesn't exist in Honcho.
+ */
+function resolveHonchoSessionScope(ctx: { sessionKey?: string }): string | undefined {
+  const raw = typeof ctx.sessionKey === "string" ? ctx.sessionKey.trim() : "";
+  if (!raw) return undefined;
+  return buildSessionKey({ sessionKey: raw });
+}
+
 const MemorySearchSchema = Type.Object({
   query: Type.String(),
   maxResults: Type.Optional(Type.Number()),
@@ -98,9 +110,7 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const maxResults = readNumberParam(params, "maxResults");
         // Keep parity with the generic schema even though Honcho does not use minScore.
         readNumberParam(params, "minScore");
-        const honchoSessionKey = buildSessionKey({
-          sessionKey: ctx.sessionKey,
-        });
+        const honchoSessionKey = resolveHonchoSessionScope(ctx);
 
         try {
           const { manager } = await getHonchoMemorySearchManager(state, {
@@ -109,7 +119,7 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
           });
           const results = await manager.search(query, {
             maxResults: maxResults ?? undefined,
-            sessionKey: honchoSessionKey,
+            ...(honchoSessionKey ? { sessionKey: honchoSessionKey } : {}),
           });
           const status = manager.status();
           return jsonResult({
@@ -138,9 +148,7 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const relPath = readStringParam(params, "path", { required: true });
         const from = readNumberParam(params, "from", { integer: true });
         const lines = readNumberParam(params, "lines", { integer: true });
-        const honchoSessionKey = buildSessionKey({
-          sessionKey: ctx.sessionKey,
-        });
+        const honchoSessionKey = resolveHonchoSessionScope(ctx);
 
         try {
           const { manager } = await getHonchoMemorySearchManager(state, {


### PR DESCRIPTION
## Problem

`memory_search` returns zero results across the board whenever
`crossSessionSearch` is true (the default) and the caller has no real
session key (CLI invocations, cron heartbeat, most skill-driven tool
calls).

## Root cause

Two layers combine to hide every hit:

1. `buildSessionKey()` in `helpers.ts` falls back to
   `"default-<provider>"` whenever `ctx.sessionKey` is empty. No such
   session exists in Honcho.
2. `getHonchoMemorySearchManager()` in `runtime.ts` routes **every**
   truthy `requestedSessionKey` into a session-scoped branch that only
   walks that session id + strict `${key}-` prefix children, regardless
   of the `crossSessionSearch` flag. The flag only guards an
   out-of-scope validation throw and a filter predicate — it never
   actually switches the search strategy.

Result: every search gets force-scoped to `default-<provider>`, which
returns `[]`. The owner-peer / cross-session path at the bottom of the
manager's `search()` is only reachable when `requestedSessionKey` is
nullish, which never happens in practice.

## Fix

Three minimal changes:

1. **`runtime.ts` — honour the flag.** When
   `cfg.crossSessionSearch === true`, skip the scoped branch entirely
   and call `ownerPeer.search(query)` directly so results span every
   session in the workspace. The scoped branch is reserved for
   `crossSessionSearch: false`, which continues to enforce strict active-
   session boundaries (and still throws on out-of-scope requests).
2. **`runtime.ts::resolveHonchoMemoryBackendConfig`** — omit
   `sessionKey` from the backend descriptor when the caller has no real
   session key, instead of synthesizing `default-<provider>`. The memory
   slot can resolve the key later from live context, or fall through to
   cross-session search.
3. **`tools/memory-passthrough.ts`** — `memory_search` / `memory_get`
   skip the synthesized fallback when `ctx.sessionKey` is empty, passing
   `sessionKey: undefined` through to the manager so the runtime reaches
   the peer-wide path.

## Testing

- New test: `spans every session via the owner peer when crossSessionSearch is true`
  asserts results from `session-1`, `session-1-child`, and
  `other-session` all surface via a single `ownerPeer.search` call.
- New test: `restricts search to the active session when crossSessionSearch is false`
  asserts `other-session` is excluded and `ownerPeer.search` is not
  used in scoped mode.
- New test in `memory-passthrough.test.ts`: confirms `sessionKey` is
  omitted from the manager options when `ctx.sessionKey` is absent.
- New assertions in `resolveHonchoMemoryBackendConfig` coverage: empty /
  whitespace / provider-only inputs produce a descriptor without
  `sessionKey`.
- Existing `clamps fallback snippet ranges` test now pins
  `crossSessionSearch: false` so it continues to exercise the scoped
  branch it was written for.

All 10 tests pass. `pnpm build` compiles clean.

## Context

Discovered while operating a multi-gateway Honcho deployment. The
downstream fleet has been running a runtime-patch workaround that
rewrites `dist/*.js` at install time; upstreaming the fix is preferable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cross-session search—when enabled, searches now span across all sessions instead of being limited to the active session
  * Session-optional search—search queries can now execute without requiring a session key

* **Bug Fixes**
  * Session key handling improved—no longer synthesized when absent, providing more accurate backend configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->