### PR TITLE
feat: per-agent workspace routing via agentWorkspaces config

### DIFF
--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -435,13 +435,27 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
         .description("Show Honcho connection status")
         .action(async () => {
           try {
-            await state.ensureInitialized();
-            const defaultPeer = await state.getAgentPeer(state.resolveDefaultAgentId());
+            const defaultAgentId = state.resolveDefaultAgentId();
+            const defaultWs = await state.ensureInitializedFor(defaultAgentId);
+            const defaultPeer = await state.getAgentPeerFor(defaultAgentId);
 
             console.log("Connected to Honcho");
-            console.log(`  Workspace: ${state.cfg.workspaceId}`);
-            console.log(`  Default agent: ${state.resolveDefaultAgentId()} → peer "${defaultPeer.id}"`);
-            console.log(`  Agent peers mapped: ${Object.keys(state.agentPeerMap).join(", ") || "(none)"}`);
+            console.log(`  Default workspace: ${state.cfg.workspaceId}`);
+            console.log(`  Default agent: ${defaultAgentId} → workspace "${defaultWs.workspaceId}", peer "${defaultPeer.id}"`);
+            console.log(`  Default workspace agent peers mapped: ${Object.keys(defaultWs.agentPeerMap).join(", ") || "(none)"}`);
+
+            const agentWorkspaces = state.cfg.agentWorkspaces;
+            if (agentWorkspaces && Object.keys(agentWorkspaces).length > 0) {
+              console.log(`\n  Per-agent workspace routing:`);
+              const entries = Object.entries(agentWorkspaces).sort(([a], [b]) => a.localeCompare(b));
+              for (const [agentId, workspaceId] of entries) {
+                console.log(`    ${agentId} → ${workspaceId}`);
+              }
+              const activeWorkspaces = Array.from(state.workspaces.values())
+                .filter((ws) => ws.initialized)
+                .map((ws) => ws.workspaceId);
+              console.log(`  Active (initialized) workspaces: ${activeWorkspaces.join(", ") || "(none)"}`);
+            }
           } catch (error) {
             console.error(`Failed to connect: ${error}`);
           }
@@ -453,9 +467,10 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
         .option("-a, --agent <id>", "Agent ID to query as (default: primary agent)")
         .action(async (question: string, options: { agent?: string }) => {
           try {
-            await state.ensureInitialized();
-            const agentPeer = await state.getAgentPeer(options.agent ?? state.resolveDefaultAgentId());
-            const answer = await agentPeer.chat(question, { target: state.ownerPeer! });
+            const agentId = options.agent ?? state.resolveDefaultAgentId();
+            const ws = await state.ensureInitializedFor(agentId);
+            const agentPeer = await state.getAgentPeerFor(agentId);
+            const answer = await agentPeer.chat(question, { target: ws.ownerPeer! });
             console.log(answer ?? "No information available.");
           } catch (error) {
             console.error(`Failed to query: ${error}`);
@@ -467,10 +482,12 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
         .description("Semantic search over Honcho memory")
         .option("-k, --top-k <number>", "Number of results to return", "10")
         .option("-d, --max-distance <number>", "Maximum semantic distance (0-1)", "0.5")
-        .action(async (query: string, options: { topK: string; maxDistance: string }) => {
+        .option("-a, --agent <id>", "Agent ID whose workspace to search (default: primary agent)")
+        .action(async (query: string, options: { topK: string; maxDistance: string; agent?: string }) => {
           try {
-            await state.ensureInitialized();
-            const representation = await state.ownerPeer!.representation({
+            const agentId = options.agent ?? state.resolveDefaultAgentId();
+            const ws = await state.ensureInitializedFor(agentId);
+            const representation = await ws.ownerPeer!.representation({
               searchQuery: query,
               searchTopK: parseInt(options.topK, 10),
               searchMaxDistance: parseFloat(options.maxDistance),

--- a/config.test.ts
+++ b/config.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { honchoConfigSchema } from "./config.js";
+
+describe("honchoConfigSchema.parse", () => {
+  it("accepts an agentWorkspaces mapping and normalizes agent IDs to lowercase", () => {
+    const cfg = honchoConfigSchema.parse({
+      workspaceId: "openclaw",
+      agentWorkspaces: {
+        Personal: "personal_workspace",
+        developer: "personal_workspace",
+        MANAGER: "ops_workspace",
+      },
+    });
+
+    expect(cfg.workspaceId).toBe("openclaw");
+    expect(cfg.agentWorkspaces).toEqual({
+      personal: "personal_workspace",
+      developer: "personal_workspace",
+      manager: "ops_workspace",
+    });
+  });
+
+  it("leaves agentWorkspaces undefined when missing", () => {
+    const cfg = honchoConfigSchema.parse({ workspaceId: "openclaw" });
+    expect(cfg.agentWorkspaces).toBeUndefined();
+  });
+
+  it("leaves agentWorkspaces undefined when given an empty object", () => {
+    const cfg = honchoConfigSchema.parse({ workspaceId: "openclaw", agentWorkspaces: {} });
+    expect(cfg.agentWorkspaces).toBeUndefined();
+  });
+
+  it("rejects non-string workspace mappings", () => {
+    expect(() =>
+      honchoConfigSchema.parse({
+        workspaceId: "openclaw",
+        agentWorkspaces: { personal: 42 },
+      }),
+    ).toThrow(/non-empty string/);
+  });
+
+  it("rejects an array-shaped agentWorkspaces value", () => {
+    expect(() =>
+      honchoConfigSchema.parse({
+        workspaceId: "openclaw",
+        agentWorkspaces: ["personal_workspace"] as unknown as Record<string, string>,
+      }),
+    ).toThrow(/must be an object/);
+  });
+
+  it("rejects empty-string workspace IDs in the mapping", () => {
+    expect(() =>
+      honchoConfigSchema.parse({
+        workspaceId: "openclaw",
+        agentWorkspaces: { personal: "" },
+      }),
+    ).toThrow(/non-empty string/);
+  });
+});

--- a/config.ts
+++ b/config.ts
@@ -12,6 +12,7 @@ export const DEFAULT_NOISE_PATTERNS: string[] = [
 export type HonchoConfig = {
   apiKey?: string;
   workspaceId: string;
+  agentWorkspaces?: Record<string, string>;
   baseUrl: string;
   timeoutMs?: number;
   noisePatterns: string[];
@@ -57,12 +58,32 @@ export const honchoConfigSchema = {
       ...new Set([...(disableDefaultNoisePatterns ? [] : DEFAULT_NOISE_PATTERNS), ...userPatterns]),
     ];
 
+    let agentWorkspaces: Record<string, string> | undefined;
+    if (cfg.agentWorkspaces !== undefined && cfg.agentWorkspaces !== null) {
+      if (typeof cfg.agentWorkspaces !== "object" || Array.isArray(cfg.agentWorkspaces)) {
+        throw new Error("openclaw-honcho: agentWorkspaces must be an object mapping agentId → workspaceId string");
+      }
+      const entries: Array<[string, string]> = [];
+      for (const [key, value] of Object.entries(cfg.agentWorkspaces as Record<string, unknown>)) {
+        if (typeof value !== "string" || value.length === 0) {
+          throw new Error(`openclaw-honcho: agentWorkspaces["${key}"] must be a non-empty string workspaceId`);
+        }
+        const normalizedKey = key.toLowerCase().trim();
+        if (!normalizedKey) continue;
+        entries.push([normalizedKey, value]);
+      }
+      if (entries.length > 0) {
+        agentWorkspaces = Object.fromEntries(entries);
+      }
+    }
+
     return {
       apiKey,
       workspaceId:
         typeof cfg.workspaceId === "string" && cfg.workspaceId.length > 0
           ? cfg.workspaceId
           : process.env.HONCHO_WORKSPACE_ID ?? "openclaw",
+      agentWorkspaces,
       baseUrl:
         typeof cfg.baseUrl === "string" && cfg.baseUrl.length > 0
           ? cfg.baseUrl

--- a/docs/agent-workspaces.md
+++ b/docs/agent-workspaces.md
@@ -1,0 +1,65 @@
+# Per-agent workspaces
+
+`openclaw-honcho` supports routing each OpenClaw agent to its own Honcho
+workspace via an optional `agentWorkspaces` config field. This is useful
+for multi-agent setups where you want memory isolation between clusters
+of agents (for example, a personal-assistant cluster and an
+operations-assistant cluster) while still sharing the same plugin
+installation.
+
+## Configuration
+
+Add `agentWorkspaces` to the plugin config as an `agentId → workspaceId`
+map. Agents listed there read/write memory in the named workspace;
+agents not listed fall back to the top-level `workspaceId`.
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw-honcho": {
+        "config": {
+          "workspaceId": "openclaw",
+          "agentWorkspaces": {
+            "personal": "personal_workspace",
+            "manager": "ops_workspace",
+            "developer": "personal_workspace"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Agent IDs are normalized to lowercase, so `Personal` and `personal`
+resolve to the same entry. Workspace IDs are passed through to the
+Honcho SDK unchanged.
+
+## How routing works
+
+- The plugin maintains one `Honcho` client, one owner peer, and one
+  agent-peer cache **per resolved workspace**. Clients are created on
+  first use and reused thereafter.
+- Every hook, tool, and CLI call resolves the workspace via the caller's
+  `agentId`, so two agents pointed at different workspaces never share
+  state.
+- Two agents pointed at the same workspace (for example `personal` and
+  `developer` both mapped to `personal_workspace` above) share the same
+  Honcho client, owner peer, and session space — so cross-agent memory
+  in a single workspace keeps working the way it does today.
+
+## Session-key resolution
+
+The plugin builds Honcho session keys from both `ctx.messageProvider`
+(hook context) and `ctx.messageChannel` (tool context). This means that
+`honcho_session`, `memory_search`, and `memory_get` read the same
+session slot the capture hook writes to, regardless of which context
+shape the host runtime exposes.
+
+## Backward compatibility
+
+When `agentWorkspaces` is absent (or an empty object), every agent
+resolves to the top-level `workspaceId` — exactly the same behaviour as
+earlier releases. No migration is required to adopt this feature, and
+existing single-workspace deployments are unaffected.

--- a/helpers.test.ts
+++ b/helpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSessionKey } from "./helpers.js";
+
+describe("buildSessionKey", () => {
+  it("prefers messageProvider over messageChannel when both are present", () => {
+    const key = buildSessionKey({
+      sessionKey: "agent:developer:discord:channel:1234567890123456789",
+      messageProvider: "discord",
+      messageChannel: "other",
+    });
+    expect(key).toBe("agent-developer-discord-channel-1234567890123456789-discord");
+  });
+
+  it("falls back to messageChannel when messageProvider is missing (tool ctx shape)", () => {
+    const key = buildSessionKey({
+      sessionKey: "agent:developer:discord:channel:1234567890123456789",
+      messageChannel: "discord",
+    });
+    expect(key).toBe("agent-developer-discord-channel-1234567890123456789-discord");
+    expect(key).not.toContain("-unknown");
+  });
+
+  it("uses messageProvider when messageChannel is missing (hook ctx shape)", () => {
+    const key = buildSessionKey({
+      sessionKey: "agent:developer:discord:channel:1234567890123456789",
+      messageProvider: "discord",
+    });
+    expect(key).toBe("agent-developer-discord-channel-1234567890123456789-discord");
+  });
+
+  it("falls back to 'unknown' when neither field is present", () => {
+    const key = buildSessionKey({ sessionKey: "agent:developer:cli:session" });
+    expect(key).toBe("agent-developer-cli-session-unknown");
+  });
+
+  it("defaults baseKey to 'default' when sessionKey is missing", () => {
+    expect(buildSessionKey({})).toBe("default-unknown");
+    expect(buildSessionKey()).toBe("default-unknown");
+  });
+
+  it("collapses non-alphanumerics to '-'", () => {
+    const key = buildSessionKey({
+      sessionKey: "agent:main:slack:team_abc/channel@xyz",
+      messageProvider: "slack",
+    });
+    expect(key).toMatch(/^[a-zA-Z0-9-]+$/);
+    expect(key).toContain("-slack");
+  });
+});

--- a/helpers.ts
+++ b/helpers.ts
@@ -6,12 +6,20 @@ import type { Peer, MessageInput } from "@honcho-ai/sdk";
 
 /**
  * Build a Honcho session key from OpenClaw context.
- * Combines sessionKey + messageProvider to create unique sessions per platform.
+ * Combines sessionKey + provider to create unique sessions per platform.
  * Uses hyphens as separators (Honcho requires hyphens, not underscores).
+ *
+ * OpenClaw exposes two different ctx shapes: hook ctx carries `messageProvider`,
+ * tool ctx carries `messageChannel`. Accept either so every call site resolves
+ * to the same session id regardless of which surface invoked it.
  */
-export function buildSessionKey(ctx?: { sessionKey?: string; messageProvider?: string }): string {
+export function buildSessionKey(ctx?: {
+  sessionKey?: string;
+  messageProvider?: string;
+  messageChannel?: string;
+}): string {
   const baseKey = ctx?.sessionKey ?? "default";
-  const provider = ctx?.messageProvider ?? "unknown";
+  const provider = ctx?.messageProvider ?? ctx?.messageChannel ?? "unknown";
   const combined = `${baseKey}-${provider}`;
   return combined.replace(/[^a-zA-Z0-9-]/g, "-");
 }

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -17,7 +17,12 @@ async function flushMessages(
   api: OpenClawPluginApi,
   state: PluginState,
   messages: unknown[],
-  ctx: { sessionKey?: string; agentId?: string; messageProvider?: string },
+  ctx: {
+    sessionKey?: string;
+    agentId?: string;
+    messageProvider?: string;
+    messageChannel?: string;
+  },
 ): Promise<number> {
   if (!messages?.length) return 0;
 
@@ -26,11 +31,17 @@ async function flushMessages(
   const isSubagent = isSubagentSession(ctx);
   const parentAgentId = isSubagent ? subagentParentMap.get(ctx.sessionKey ?? "") : undefined;
 
-  await state.ensureInitialized();
-  const agentPeer = await state.getAgentPeer(agentId);
+  const ws = await state.ensureInitializedFor(agentId);
+  const agentPeer = await state.getAgentPeerFor(agentId);
+  // Parent peer observation only works when parent and child agents share a workspace.
+  // For cross-workspace subagents, we skip adding the parent peer rather than cross
+  // session/peer boundaries between Honcho workspaces.
   const parentPeer =
-    isSubagent && parentAgentId && parentAgentId !== agentId
-      ? await state.getAgentPeer(parentAgentId)
+    isSubagent &&
+    parentAgentId &&
+    parentAgentId !== agentId &&
+    state.resolveWorkspaceIdForAgent(parentAgentId) === ws.workspaceId
+      ? await state.getAgentPeerFor(parentAgentId)
       : null;
 
   const sessionMeta: Record<string, unknown> = {
@@ -41,7 +52,7 @@ async function flushMessages(
     } : {}),
   };
 
-  const session = await state.honcho.session(sessionKey, { metadata: sessionMeta });
+  const session = await ws.honcho.session(sessionKey, { metadata: sessionMeta });
   const meta = await session.getMetadata();
   const existingMeta: Record<string, unknown> =
     meta && typeof meta === "object" ? (meta as Record<string, unknown>) : {};
@@ -70,7 +81,7 @@ async function flushMessages(
   }
 
   const newRawMessages = messages.slice(startIndex);
-  const extracted = extractMessages(newRawMessages, state.ownerPeer!, agentPeer, state.cfg.noisePatterns);
+  const extracted = extractMessages(newRawMessages, ws.ownerPeer!, agentPeer, state.cfg.noisePatterns);
 
   if (extracted.length === 0) {
     await session.setMetadata({ ...existingMeta, ...sessionMeta, lastSavedIndex: messages.length });

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -14,14 +14,14 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
     state.turnStartIndex.set(sessionKey, event.messages.length);
 
     try {
-      await state.ensureInitialized();
-      const agentPeer = await state.getAgentPeer(agentId);
+      const ws = await state.ensureInitializedFor(agentId);
+      const agentPeer = await state.getAgentPeerFor(agentId);
 
       const sections: string[] = [];
 
       if (isSubagent) {
         try {
-          const peerCtx = await agentPeer.context({ target: state.ownerPeer! });
+          const peerCtx = await agentPeer.context({ target: ws.ownerPeer! });
           if (peerCtx.peerCard?.length) {
             sections.push(`Key facts:\n${peerCtx.peerCard.map((f: string) => `• ${f}`).join("\n")}`);
           }
@@ -36,14 +36,14 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
           throw e;
         }
       } else {
-        const session = await state.honcho.session(sessionKey, { metadata: { agentId } });
+        const session = await ws.honcho.session(sessionKey, { metadata: { agentId } });
 
         let context;
         try {
           context = await session.context({
             summary: true,
             tokens: 2000,
-            peerTarget: state.ownerPeer!,
+            peerTarget: ws.ownerPeer!,
             peerPerspective: agentPeer,
           });
         } catch (e: unknown) {

--- a/hooks/gateway.ts
+++ b/hooks/gateway.ts
@@ -6,8 +6,22 @@ export function registerGatewayHook(api: OpenClawPluginApi, state: PluginState):
   api.on("gateway_start", async (_event, _ctx) => {
     api.logger.info("Initializing Honcho memory...");
     try {
-      await state.ensureInitialized();
-      api.logger.info("Honcho memory ready");
+      // Initialize the default workspace eagerly; per-agent workspaces are
+      // lazily initialized on first use via ensureInitializedFor(agentId).
+      await state.ensureInitializedFor(state.resolveDefaultAgentId());
+      const configuredWorkspaces = new Set<string>([state.cfg.workspaceId]);
+      if (state.cfg.agentWorkspaces) {
+        for (const ws of Object.values(state.cfg.agentWorkspaces)) {
+          configuredWorkspaces.add(ws);
+        }
+      }
+      if (configuredWorkspaces.size > 1) {
+        api.logger.info(
+          `Honcho memory ready (default workspace: ${state.cfg.workspaceId}; ${configuredWorkspaces.size - 1} additional workspace(s) will init on first agent use)`
+        );
+      } else {
+        api.logger.info("Honcho memory ready");
+      }
     } catch (error) {
       api.logger.error(`Failed to initialize Honcho: ${error}`);
     }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -11,7 +11,12 @@
       },
       "workspaceId": {
         "type": "string",
-        "description": "Honcho workspace ID (defaults to 'openclaw')"
+        "description": "Honcho workspace ID (defaults to 'openclaw'). Used as the fallback workspace for agents not listed in agentWorkspaces."
+      },
+      "agentWorkspaces": {
+        "type": "object",
+        "description": "Optional mapping of agentId → Honcho workspaceId. Agents listed here route their memory reads/writes to the named workspace. Unmapped agents fall back to workspaceId.",
+        "additionalProperties": { "type": "string" }
       },
       "baseUrl": {
         "type": "string",
@@ -49,7 +54,12 @@
     "workspaceId": {
       "label": "Workspace ID",
       "placeholder": "openclaw",
-      "help": "Honcho workspace ID"
+      "help": "Honcho workspace ID — used as the default and as a fallback for agents not listed in Agent Workspaces."
+    },
+    "agentWorkspaces": {
+      "label": "Agent Workspaces",
+      "advanced": true,
+      "help": "Per-agent workspace routing. Map agentId → Honcho workspaceId so each OpenClaw agent reads/writes memory in its own Honcho workspace. Unlisted agents use Workspace ID."
     },
     "baseUrl": {
       "label": "API Base URL",

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { getHonchoMemorySearchManager, resolveHonchoMemoryBackendConfig } from "./runtime.js";
-import type { PluginState } from "./state.js";
+import type { PerWorkspaceState, PluginState } from "./state.js";
 
-function createState(baseUrl = "https://api.honcho.dev", { crossSessionSearch = true }: { crossSessionSearch?: boolean } = {}): PluginState {
+function createState(
+  baseUrl = "https://api.honcho.dev",
+  { crossSessionSearch = true, workspaceId = "openclaw" }: { crossSessionSearch?: boolean; workspaceId?: string } = {}
+): PluginState {
   const contexts = new Map<string, { summary: { content: string }; messages: Array<Record<string, unknown>> }>([
     [
       "session-1",
@@ -94,45 +97,63 @@ function createState(baseUrl = "https://api.honcho.dev", { crossSessionSearch = 
 
   const childSession = createSession("session-1-child");
 
+  const ownerPeer = {
+    id: "owner",
+    search: vi.fn(async () => [
+      { sessionId: "session-1", content: "Need to remember this" },
+      { sessionId: "session-1-child", content: "Child transcript hit" },
+      { sessionId: "other-session", content: "Other result" },
+    ]),
+    sessions: vi.fn(async () => ({
+      async *[Symbol.asyncIterator]() {
+        yield childSession;
+      },
+    })),
+  };
+
+  const honcho = {
+    session: vi.fn(async (sessionId: string) => createSession(sessionId)),
+  } as never;
+
+  const workspace: PerWorkspaceState = {
+    workspaceId,
+    honcho,
+    ownerPeer: ownerPeer as never,
+    agentPeers: new Map(),
+    agentPeerMap: {},
+    initialized: true,
+    initPromise: null,
+  };
+
+  const workspaces = new Map<string, PerWorkspaceState>();
+  workspaces.set(workspaceId, workspace);
+
   return {
     cfg: {
-      workspaceId: "openclaw",
+      workspaceId,
       baseUrl,
       noisePatterns: [],
       disableDefaultNoisePatterns: false,
       ownerObserveOthers: false,
       crossSessionSearch,
     },
-    honcho: {
-      session: vi.fn(async (sessionId: string) => createSession(sessionId)),
-    } as never,
-    ownerPeer: {
-      id: "owner",
-      search: vi.fn(async () => [
-        { sessionId: "session-1", content: "Need to remember this" },
-        { sessionId: "session-1-child", content: "Child transcript hit" },
-        { sessionId: "other-session", content: "Other result" },
-      ]),
-      sessions: vi.fn(async () => ({
-        async *[Symbol.asyncIterator]() {
-          yield childSession;
-        },
-      })),
-    } as never,
-    agentPeers: new Map(),
-    agentPeerMap: {},
+    workspaces,
     turnStartIndex: new Map(),
-    initialized: true,
     api: {} as never,
-    ensureInitialized: vi.fn(async () => {}),
-    getAgentPeer: vi.fn(async (agentId = "main") => ({ id: `agent-${agentId}` })),
+    resolveWorkspaceIdForAgent: vi.fn(() => workspaceId),
+    getWorkspaceFor: vi.fn(() => workspace),
+    getHonchoFor: vi.fn(() => honcho),
+    ensureInitializedFor: vi.fn(async () => workspace),
+    getOwnerPeerFor: vi.fn(async () => workspace.ownerPeer!),
+    getAgentPeerFor: vi.fn(async (agentId = "main") => ({ id: `agent-${agentId}` } as never)),
     resolveDefaultAgentId: vi.fn(() => "main"),
-  } as unknown as PluginState;
+  };
 }
 
 describe("Honcho memory runtime", () => {
   it("filters search results by session key and returns session transcript paths", async () => {
     const state = createState("https://api.honcho.dev", { crossSessionSearch: false });
+    const defaultWs = state.workspaces.get(state.cfg.workspaceId)!;
 
     const { manager } = await getHonchoMemorySearchManager(state, {
       agentId: "main",
@@ -151,7 +172,7 @@ describe("Honcho memory runtime", () => {
     expect(results[0]?.snippet).toBe("Need to remember this");
     expect(results[0]?.startLine).toBeGreaterThan(0);
     expect(results[0]?.endLine).toBeGreaterThanOrEqual(results[0]?.startLine ?? 0);
-    expect((state.ownerPeer.search as unknown as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect(defaultWs.ownerPeer!.search as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
 
     const implicitScopeResults = await manager.search("remember", {
       maxResults: 10,
@@ -238,7 +259,8 @@ describe("Honcho memory runtime", () => {
 
   it("fails cleanly when ownerPeer is unavailable after initialization", async () => {
     const state = createState();
-    state.ownerPeer = null;
+    const ws = state.workspaces.get(state.cfg.workspaceId)!;
+    ws.ownerPeer = null;
 
     const { manager } = await getHonchoMemorySearchManager(state, {
       agentId: "main",
@@ -255,5 +277,15 @@ describe("Honcho memory runtime", () => {
         relPath: "sessions/session-1.txt",
       }),
     ).rejects.toThrow(/owner peer not initialized/);
+  });
+
+  it("exposes the routed workspaceId through manager.status()", async () => {
+    const state = createState("https://api.honcho.dev", { workspaceId: "personal_workspace" });
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "personal",
+      sessionKey: "session-1",
+    });
+    const status = manager.status();
+    expect((status.custom as { workspaceId?: string }).workspaceId).toBe("personal_workspace");
   });
 });

--- a/runtime.ts
+++ b/runtime.ts
@@ -34,14 +34,14 @@ async function buildSessionTranscript(
   agentId: string,
   sessionId: string
 ): Promise<string> {
-  await state.ensureInitialized();
-  const ownerPeer = state.ownerPeer;
+  const ws = await state.ensureInitializedFor(agentId);
+  const ownerPeer = ws.ownerPeer;
   if (!ownerPeer) {
     throw new Error("Honcho owner peer not initialized");
   }
 
-  const agentPeer = await state.getAgentPeer(agentId);
-  const session = await state.honcho.session(sessionId, { metadata: { agentId } });
+  const agentPeer = await state.getAgentPeerFor(agentId);
+  const session = await ws.honcho.session(sessionId, { metadata: { agentId } });
   const context = await session.context({
     summary: true,
     tokens: 20000,
@@ -120,13 +120,13 @@ export async function getHonchoMemorySearchManager(
 ) {
   const { agentId = state.resolveDefaultAgentId(), sessionKey: activeSessionKey } = params;
 
-  await state.ensureInitialized();
+  const ws = await state.ensureInitializedFor(agentId);
 
   return {
     manager: {
       async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
-        await state.ensureInitialized();
-        const ownerPeer = state.ownerPeer;
+        const wsLocal = await state.ensureInitializedFor(agentId);
+        const ownerPeer = wsLocal.ownerPeer;
         if (!ownerPeer) {
           throw new Error("Honcho owner peer not initialized");
         }
@@ -169,7 +169,7 @@ export async function getHonchoMemorySearchManager(
         };
 
         if (requestedSessionKey) {
-          const exactSession = await state.honcho.session(requestedSessionKey, {
+          const exactSession = await wsLocal.honcho.session(requestedSessionKey, {
             metadata: { agentId },
           });
           collect(await exactSession.search(query, { limit }));
@@ -238,7 +238,7 @@ export async function getHonchoMemorySearchManager(
           sources: ["sessions"],
           custom: {
             searchMode: "semantic",
-            workspaceId: state.cfg.workspaceId,
+            workspaceId: ws.workspaceId,
             baseUrl: state.cfg.baseUrl,
           },
         };
@@ -257,7 +257,7 @@ export async function getHonchoMemorySearchManager(
 
 /** Resolve the memory backend descriptor expected by the OpenClaw memory slot. */
 export function resolveHonchoMemoryBackendConfig(
-  params: { sessionKey?: string; messageProvider?: string } = {}
+  params: { sessionKey?: string; messageProvider?: string; messageChannel?: string } = {}
 ) {
   const sessionKey = buildSessionKey(params);
   return {
@@ -278,7 +278,9 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
       return getHonchoMemorySearchManager(state, params);
     },
 
-    resolveMemoryBackendConfig(params: { sessionKey?: string; messageProvider?: string } = {}) {
+    resolveMemoryBackendConfig(
+      params: { sessionKey?: string; messageProvider?: string; messageChannel?: string } = {}
+    ) {
       return resolveHonchoMemoryBackendConfig(params);
     },
   });

--- a/state.test.ts
+++ b/state.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@honcho-ai/sdk", () => {
+  class Honcho {
+    workspaceId: string;
+    apiKey?: string;
+    baseURL?: string;
+    timeout?: number;
+    constructor(opts: { workspaceId: string; apiKey?: string; baseURL?: string; timeout?: number }) {
+      this.workspaceId = opts.workspaceId;
+      this.apiKey = opts.apiKey;
+      this.baseURL = opts.baseURL;
+      this.timeout = opts.timeout;
+    }
+    getMetadata = vi.fn(async () => ({}));
+    setMetadata = vi.fn(async () => undefined);
+    peer = vi.fn(async (peerId: string) => ({
+      id: peerId,
+      getMetadata: vi.fn(async () => ({})),
+      setMetadata: vi.fn(async () => undefined),
+    }));
+    peers = vi.fn(async () => ({
+      async *[Symbol.asyncIterator]() {
+        // no pre-existing peers
+      },
+    }));
+    session = vi.fn();
+    search = vi.fn();
+  }
+  return { Honcho };
+});
+
+import { createPluginState } from "./state.js";
+
+function createFakeApi(pluginConfig: Record<string, unknown>, agentsList?: Array<Record<string, unknown>>) {
+  return {
+    pluginConfig,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    config: agentsList ? { agents: { list: agentsList } } : { agents: { list: [] } },
+  } as never;
+}
+
+describe("per-agent workspace routing", () => {
+  it("resolveWorkspaceIdForAgent returns the mapped workspace or falls back to workspaceId", () => {
+    const state = createPluginState(
+      createFakeApi({
+        apiKey: "test",
+        workspaceId: "openclaw",
+        agentWorkspaces: {
+          personal: "personal_workspace",
+          manager: "ops_workspace",
+        },
+      }),
+    );
+
+    expect(state.resolveWorkspaceIdForAgent("personal")).toBe("personal_workspace");
+    expect(state.resolveWorkspaceIdForAgent("Personal")).toBe("personal_workspace");
+    expect(state.resolveWorkspaceIdForAgent("manager")).toBe("ops_workspace");
+    expect(state.resolveWorkspaceIdForAgent("unmapped-agent")).toBe("openclaw");
+    expect(state.resolveWorkspaceIdForAgent(undefined)).toBe("openclaw");
+  });
+
+  it("getHonchoFor memoizes per-workspace Honcho client instances", () => {
+    const state = createPluginState(
+      createFakeApi({
+        apiKey: "test",
+        workspaceId: "openclaw",
+        agentWorkspaces: {
+          personal: "personal_workspace",
+          developer: "personal_workspace",
+        },
+      }),
+    );
+
+    const personal1 = state.getHonchoFor("personal");
+    const personal2 = state.getHonchoFor("personal");
+    const developer = state.getHonchoFor("developer");
+    const unmapped = state.getHonchoFor("phone");
+
+    expect(personal1).toBe(personal2); // same workspace, cached
+    expect(personal1).toBe(developer); // two agents share a workspace → share a client
+    expect(personal1).not.toBe(unmapped); // unmapped fallback has its own client
+    expect((unmapped as unknown as { workspaceId: string }).workspaceId).toBe("openclaw");
+    expect((personal1 as unknown as { workspaceId: string }).workspaceId).toBe("personal_workspace");
+  });
+
+  it("two agents routed to different workspaces do not share state", async () => {
+    const state = createPluginState(
+      createFakeApi({
+        apiKey: "test",
+        workspaceId: "openclaw",
+        agentWorkspaces: {
+          personal: "personal_workspace",
+          manager: "ops_workspace",
+        },
+      }),
+    );
+
+    const personalWs = await state.ensureInitializedFor("personal");
+    const managerWs = await state.ensureInitializedFor("manager");
+
+    expect(personalWs.workspaceId).toBe("personal_workspace");
+    expect(managerWs.workspaceId).toBe("ops_workspace");
+    expect(personalWs.honcho).not.toBe(managerWs.honcho);
+    expect(personalWs.ownerPeer).not.toBe(managerWs.ownerPeer);
+    expect(personalWs.agentPeers).not.toBe(managerWs.agentPeers);
+  });
+
+  it("unmapped agents still initialize against the default workspace end-to-end", async () => {
+    const state = createPluginState(
+      createFakeApi({
+        apiKey: "test",
+        workspaceId: "openclaw",
+        agentWorkspaces: { personal: "personal_workspace" },
+      }),
+    );
+
+    const fallbackWs = await state.ensureInitializedFor("someRandomAgent");
+    expect(fallbackWs.workspaceId).toBe("openclaw");
+    expect(fallbackWs.initialized).toBe(true);
+    expect(fallbackWs.ownerPeer).not.toBeNull();
+  });
+
+  it("backward compatibility: config without agentWorkspaces routes every agent to workspaceId", async () => {
+    const state = createPluginState(
+      createFakeApi({ apiKey: "test", workspaceId: "OnlyWorkspace" }),
+    );
+
+    expect(state.resolveWorkspaceIdForAgent("personal")).toBe("OnlyWorkspace");
+    expect(state.resolveWorkspaceIdForAgent("developer")).toBe("OnlyWorkspace");
+    const ws1 = await state.ensureInitializedFor("personal");
+    const ws2 = await state.ensureInitializedFor("developer");
+    expect(ws1).toBe(ws2); // single workspace shared by all agents
+    expect(state.workspaces.size).toBe(1);
+  });
+});

--- a/state.ts
+++ b/state.ts
@@ -2,6 +2,10 @@
  * Shared mutable state for the Honcho memory plugin.
  * Follows the dependency-injection pattern: createPluginState() returns a
  * PluginState object that gets passed to every module.
+ *
+ * Per-agent workspace routing: each configured workspace (via `agentWorkspaces`)
+ * gets its own `PerWorkspaceState` — dedicated Honcho client, owner peer, and
+ * agent peer cache — so memory reads/writes stay isolated per workspace.
  */
 
 import { Honcho, type Peer } from "@honcho-ai/sdk";
@@ -26,20 +30,38 @@ export function isLocalHonchoBaseUrl(baseUrl?: string): boolean {
   }
 }
 
-export type PluginState = {
+export type PerWorkspaceState = {
+  workspaceId: string;
   honcho: Honcho;
-  cfg: HonchoConfig;
   ownerPeer: Peer | null;
   agentPeers: Map<string, Peer>;
   agentPeerMap: Record<string, string>;
+  initialized: boolean;
+  initPromise: Promise<void> | null;
+};
+
+export type PluginState = {
+  cfg: HonchoConfig;
+  /** Per-workspace state, keyed by resolved Honcho workspaceId. */
+  workspaces: Map<string, PerWorkspaceState>;
   /** Message count recorded at before_prompt_build time, keyed by Honcho session key.
    * Used by the capture hook to determine where the current turn starts in the
-   * accumulated message array, so first-init skips pre-installation history. */
+   * accumulated message array, so first-init skips pre-installation history.
+   * Session keys are globally unique across workspaces. */
   turnStartIndex: Map<string, number>;
-  initialized: boolean;
   api: OpenClawPluginApi;
-  ensureInitialized: () => Promise<void>;
-  getAgentPeer: (agentId?: string) => Promise<Peer>;
+  /** Resolve the workspaceId a given agent should route to (falls back to cfg.workspaceId). */
+  resolveWorkspaceIdForAgent: (agentId?: string) => string;
+  /** Lazy-initialized PerWorkspaceState for the given agent. */
+  getWorkspaceFor: (agentId?: string) => PerWorkspaceState;
+  /** Return the Honcho client for the given agent's workspace. */
+  getHonchoFor: (agentId?: string) => Honcho;
+  /** Ensure the per-workspace client is initialized (owner peer created, metadata read). */
+  ensureInitializedFor: (agentId?: string) => Promise<PerWorkspaceState>;
+  /** Resolve the owner peer for the given agent's workspace (after init). */
+  getOwnerPeerFor: (agentId?: string) => Promise<Peer>;
+  /** Resolve the agent peer for the given agent in its routed workspace. */
+  getAgentPeerFor: (agentId?: string) => Promise<Peer>;
   resolveDefaultAgentId: () => string;
 };
 
@@ -54,26 +76,43 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     );
   }
 
-  const honcho = new Honcho({
-    apiKey: cfg.apiKey,
-    baseURL: cfg.baseUrl,
-    workspaceId: cfg.workspaceId,
-    timeout: cfg.timeoutMs,
-  });
+  const workspaces = new Map<string, PerWorkspaceState>();
+
+  function createWorkspaceState(workspaceId: string): PerWorkspaceState {
+    const honcho = new Honcho({
+      apiKey: cfg.apiKey,
+      baseURL: cfg.baseUrl,
+      workspaceId,
+      timeout: cfg.timeoutMs,
+    });
+    return {
+      workspaceId,
+      honcho,
+      ownerPeer: null,
+      agentPeers: new Map<string, Peer>(),
+      agentPeerMap: {},
+      initialized: false,
+      initPromise: null,
+    };
+  }
 
   const state: PluginState = {
-    honcho,
     cfg,
-    ownerPeer: null,
-    agentPeers: new Map<string, Peer>(),
-    agentPeerMap: {},
+    workspaces,
     turnStartIndex: new Map<string, number>(),
-    initialized: false,
     api,
-    ensureInitialized,
-    getAgentPeer,
+    resolveWorkspaceIdForAgent,
+    getWorkspaceFor,
+    getHonchoFor,
+    ensureInitializedFor,
+    getOwnerPeerFor,
+    getAgentPeerFor,
     resolveDefaultAgentId,
   };
+
+  function normalizeAgentId(agentId?: string): string {
+    return (agentId ?? resolveDefaultAgentId()).toLowerCase().trim() || "main";
+  }
 
   function resolveDefaultAgentId(): string {
     const agents = api.config?.agents?.list;
@@ -82,41 +121,82 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     return (defaultAgent?.id ?? "main").toLowerCase().trim() || "main";
   }
 
-  async function ensureInitialized(): Promise<void> {
-    if (state.initialized) return;
-
-    const wsMeta = await honcho.getMetadata();
-    state.agentPeerMap = (wsMeta.agentPeerMap as Record<string, string>) ?? {};
-
-    const defaultId = resolveDefaultAgentId();
-    if (Object.keys(state.agentPeerMap).length === 0) {
-      state.agentPeerMap[defaultId] = `agent-${defaultId}`;
-      await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap });
-    } else if (Object.values(state.agentPeerMap).includes(LEGACY_PEER_ID) && !state.agentPeerMap[defaultId]) {
-      state.agentPeerMap[defaultId] = LEGACY_PEER_ID;
-      await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap });
-    }
-
-    state.ownerPeer = await honcho.peer(OWNER_ID, { metadata: {} });
-    state.initialized = true;
+  function resolveWorkspaceIdForAgent(agentId?: string): string {
+    const id = normalizeAgentId(agentId);
+    const mapped = cfg.agentWorkspaces?.[id];
+    if (typeof mapped === "string" && mapped.length > 0) return mapped;
+    return cfg.workspaceId;
   }
 
-  async function getAgentPeer(agentId?: string): Promise<Peer> {
-    const id = (agentId || resolveDefaultAgentId()).toLowerCase().trim() || "main";
+  function getWorkspaceFor(agentId?: string): PerWorkspaceState {
+    const workspaceId = resolveWorkspaceIdForAgent(agentId);
+    let ws = workspaces.get(workspaceId);
+    if (!ws) {
+      ws = createWorkspaceState(workspaceId);
+      workspaces.set(workspaceId, ws);
+    }
+    return ws;
+  }
 
-    let peer = state.agentPeers.get(id);
+  function getHonchoFor(agentId?: string): Honcho {
+    return getWorkspaceFor(agentId).honcho;
+  }
+
+  async function initializeWorkspace(ws: PerWorkspaceState): Promise<void> {
+    const wsMeta = await ws.honcho.getMetadata();
+    ws.agentPeerMap = (wsMeta.agentPeerMap as Record<string, string>) ?? {};
+
+    const defaultId = resolveDefaultAgentId();
+    if (Object.keys(ws.agentPeerMap).length === 0) {
+      ws.agentPeerMap[defaultId] = `agent-${defaultId}`;
+      await ws.honcho.setMetadata({ ...wsMeta, agentPeerMap: ws.agentPeerMap });
+    } else if (Object.values(ws.agentPeerMap).includes(LEGACY_PEER_ID) && !ws.agentPeerMap[defaultId]) {
+      ws.agentPeerMap[defaultId] = LEGACY_PEER_ID;
+      await ws.honcho.setMetadata({ ...wsMeta, agentPeerMap: ws.agentPeerMap });
+    }
+
+    ws.ownerPeer = await ws.honcho.peer(OWNER_ID, { metadata: {} });
+    ws.initialized = true;
+  }
+
+  async function ensureInitializedFor(agentId?: string): Promise<PerWorkspaceState> {
+    const ws = getWorkspaceFor(agentId);
+    if (ws.initialized) return ws;
+    if (!ws.initPromise) {
+      ws.initPromise = initializeWorkspace(ws).catch((err) => {
+        ws.initPromise = null;
+        throw err;
+      });
+    }
+    await ws.initPromise;
+    return ws;
+  }
+
+  async function getOwnerPeerFor(agentId?: string): Promise<Peer> {
+    const ws = await ensureInitializedFor(agentId);
+    if (!ws.ownerPeer) {
+      throw new Error(`Honcho owner peer not initialized for workspace "${ws.workspaceId}"`);
+    }
+    return ws.ownerPeer;
+  }
+
+  async function getAgentPeerFor(agentId?: string): Promise<Peer> {
+    const id = normalizeAgentId(agentId);
+    const ws = await ensureInitializedFor(id);
+
+    let peer = ws.agentPeers.get(id);
     if (peer) return peer;
 
-    let peerId = state.agentPeerMap[id];
+    let peerId = ws.agentPeerMap[id];
 
     if (!peerId) {
-      const allPeers = await honcho.peers();
+      const allPeers = await ws.honcho.peers();
       for await (const p of allPeers) {
         if (p.id === OWNER_ID) continue;
         const meta = await p.getMetadata();
         if (meta?.agentId === id) {
           peerId = p.id;
-          api.logger.info(`[honcho] Recovered peer "${peerId}" for renamed agent "${id}"`);
+          api.logger.info(`[honcho] Recovered peer "${peerId}" for renamed agent "${id}" in workspace "${ws.workspaceId}"`);
           break;
         }
       }
@@ -126,14 +206,14 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
       peerId = `agent-${id}`;
     }
 
-    if (state.agentPeerMap[id] !== peerId) {
-      state.agentPeerMap[id] = peerId;
-      const wsMeta = await honcho.getMetadata();
-      await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap });
+    if (ws.agentPeerMap[id] !== peerId) {
+      ws.agentPeerMap[id] = peerId;
+      const wsMeta = await ws.honcho.getMetadata();
+      await ws.honcho.setMetadata({ ...wsMeta, agentPeerMap: ws.agentPeerMap });
     }
 
-    peer = await honcho.peer(peerId);
-    state.agentPeers.set(id, peer);
+    peer = await ws.honcho.peer(peerId);
+    ws.agentPeers.set(id, peer);
 
     const existingMeta = await peer.getMetadata();
     if (existingMeta.agentId !== id) {

--- a/tools/ask.ts
+++ b/tools/ask.ts
@@ -31,12 +31,12 @@ export function registerAskTool(api: OpenClawPluginApi, state: PluginState): voi
           depth?: "quick" | "thorough";
         };
 
-        await state.ensureInitialized();
-        const agentPeer = await state.getAgentPeer(toolCtx.agentId);
+        const ws = await state.ensureInitializedFor(toolCtx.agentId);
+        const agentPeer = await state.getAgentPeerFor(toolCtx.agentId);
 
         const reasoningLevel = depth === "thorough" ? "high" : "low";
         const answer = await agentPeer.chat(query, {
-          target: state.ownerPeer!,
+          target: ws.ownerPeer!,
           reasoningLevel,
         });
 

--- a/tools/context.ts
+++ b/tools/context.ts
@@ -5,7 +5,7 @@ import type { PluginState } from "../state.js";
 
 export function registerContextTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
-    {
+    (toolCtx) => ({
       name: "honcho_context",
       label: "Get User Context",
       description:
@@ -25,10 +25,10 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
       async execute(_toolCallId, params) {
         const { detail = "card" } = params as { detail?: "card" | "full" };
 
-        await state.ensureInitialized();
+        const ws = await state.ensureInitializedFor(toolCtx.agentId);
 
         if (detail === "card") {
-          const card = await state.ownerPeer!.card().catch((err) => {
+          const card = await ws.ownerPeer!.card().catch((err) => {
             // Only treat NotFoundError as empty; re-throw others or log
             if (err?.name === "NotFoundError") return null;
             // Optionally log unexpected errors for debugging
@@ -60,7 +60,7 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
         }
 
         // detail === "full"
-        const representation = await state.ownerPeer!.representation({
+        const representation = await ws.ownerPeer!.representation({
           includeMostFrequent: true,
         });
 
@@ -81,7 +81,7 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
           details: { detail, representationLength: representation.length },
         };
       },
-    },
+    }),
     { name: "honcho_context" }
   );
 }

--- a/tools/memory-passthrough.test.ts
+++ b/tools/memory-passthrough.test.ts
@@ -57,6 +57,7 @@ describe("memory passthrough tools", () => {
       agentId: "main",
       config: {},
       sessionKey: "agent:main:dashboard:test",
+      messageProvider: "discord",
     };
 
     const searchTool = registrations[0]!.factory(ctx) as {
@@ -86,12 +87,142 @@ describe("memory passthrough tools", () => {
     expect(getResult.content[0]?.text).toContain("\"text\": \"remembered fact\"");
     expect(getHonchoMemorySearchManagerMock).toHaveBeenNthCalledWith(1, {}, {
       agentId: "main",
-      sessionKey: "agent-main-dashboard-test-unknown",
+      sessionKey: "agent-main-dashboard-test-discord",
     });
     expect(getHonchoMemorySearchManagerMock).toHaveBeenNthCalledWith(2, {}, {
       agentId: "main",
-      sessionKey: "agent-main-dashboard-test-unknown",
+      sessionKey: "agent-main-dashboard-test-discord",
     });
+  });
+
+  it("forwards messageProvider into the built Honcho session key for memory_search", async () => {
+    const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown> }> = [];
+    const api = {
+      registerTool: (factory: (ctx: Record<string, unknown>) => Record<string, unknown>) => {
+        registrations.push({ factory });
+      },
+    };
+
+    registerMemoryPassthrough(api as never, {} as never);
+
+    const ctx = {
+      agentId: "developer",
+      config: {},
+      sessionKey: "agent-developer-discord-channel-1234567890123456789",
+      messageProvider: "discord",
+    };
+    const searchTool = registrations[0]!.factory(ctx) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    };
+
+    await searchTool.execute("call-search", { query: "Chief" });
+
+    const expectedSessionKey = "agent-developer-discord-channel-1234567890123456789-discord";
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, {
+      agentId: "developer",
+      sessionKey: expectedSessionKey,
+    });
+    expect(expectedSessionKey).not.toContain("-unknown");
+
+    const managerResult = await getHonchoMemorySearchManagerMock.mock.results[0]!.value;
+    const searchCalls = (managerResult.manager.search as ReturnType<typeof vi.fn>).mock.calls;
+    const lastSearchArgs = searchCalls[searchCalls.length - 1];
+    expect(lastSearchArgs?.[1]).toMatchObject({ sessionKey: expectedSessionKey });
+  });
+
+  it("forwards messageProvider into the built Honcho session key for memory_get", async () => {
+    const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown> }> = [];
+    const api = {
+      registerTool: (factory: (ctx: Record<string, unknown>) => Record<string, unknown>) => {
+        registrations.push({ factory });
+      },
+    };
+
+    registerMemoryPassthrough(api as never, {} as never);
+
+    const ctx = {
+      agentId: "developer",
+      config: {},
+      sessionKey: "agent-developer-discord-channel-1234567890123456789",
+      messageProvider: "discord",
+    };
+    const getTool = registrations[1]!.factory(ctx) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    };
+
+    await getTool.execute("call-get", { path: "sessions/x.txt" });
+
+    const expectedSessionKey = "agent-developer-discord-channel-1234567890123456789-discord";
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, {
+      agentId: "developer",
+      sessionKey: expectedSessionKey,
+    });
+    expect(expectedSessionKey).not.toContain("-unknown");
+  });
+
+  it("resolves session key from messageChannel for memory_search when tool ctx omits messageProvider", async () => {
+    const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown> }> = [];
+    const api = {
+      registerTool: (factory: (ctx: Record<string, unknown>) => Record<string, unknown>) => {
+        registrations.push({ factory });
+      },
+    };
+
+    registerMemoryPassthrough(api as never, {} as never);
+
+    const ctx = {
+      agentId: "developer",
+      config: {},
+      sessionKey: "agent:developer:discord:channel:1234567890123456789",
+      messageChannel: "discord",
+    };
+    const searchTool = registrations[0]!.factory(ctx) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    };
+
+    await searchTool.execute("call-search", { query: "Chief" });
+
+    const expectedSessionKey = "agent-developer-discord-channel-1234567890123456789-discord";
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, {
+      agentId: "developer",
+      sessionKey: expectedSessionKey,
+    });
+    expect(expectedSessionKey).not.toContain("-unknown");
+
+    const managerResult = await getHonchoMemorySearchManagerMock.mock.results[0]!.value;
+    const searchCalls = (managerResult.manager.search as ReturnType<typeof vi.fn>).mock.calls;
+    const lastSearchArgs = searchCalls[searchCalls.length - 1];
+    expect(lastSearchArgs?.[1]).toMatchObject({ sessionKey: expectedSessionKey });
+  });
+
+  it("resolves session key from messageChannel for memory_get when tool ctx omits messageProvider", async () => {
+    const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown> }> = [];
+    const api = {
+      registerTool: (factory: (ctx: Record<string, unknown>) => Record<string, unknown>) => {
+        registrations.push({ factory });
+      },
+    };
+
+    registerMemoryPassthrough(api as never, {} as never);
+
+    const ctx = {
+      agentId: "developer",
+      config: {},
+      sessionKey: "agent:developer:discord:channel:1234567890123456789",
+      messageChannel: "discord",
+    };
+    const getTool = registrations[1]!.factory(ctx) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    };
+
+    await getTool.execute("call-get", { path: "sessions/x.txt" });
+
+    const expectedSessionKey = "agent-developer-discord-channel-1234567890123456789-discord";
+    expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, {
+      agentId: "developer",
+      sessionKey: expectedSessionKey,
+    });
+    expect(expectedSessionKey).not.toContain("-unknown");
   });
 
   it("returns structured unavailable payloads when manager acquisition fails", async () => {
@@ -109,6 +240,7 @@ describe("memory passthrough tools", () => {
       agentId: "main",
       config: {},
       sessionKey: "agent:main:dashboard:test",
+      messageProvider: "discord",
     };
     const searchTool = registrations[0]!.factory(ctx) as {
       execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
@@ -119,7 +251,7 @@ describe("memory passthrough tools", () => {
     expect(result.content[0]?.text).toContain("\"error\": \"auth failed\"");
     expect(getHonchoMemorySearchManagerMock).toHaveBeenCalledWith({}, {
       agentId: "main",
-      sessionKey: "agent-main-dashboard-test-unknown",
+      sessionKey: "agent-main-dashboard-test-discord",
     });
   });
 });

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -98,9 +98,7 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const maxResults = readNumberParam(params, "maxResults");
         // Keep parity with the generic schema even though Honcho does not use minScore.
         readNumberParam(params, "minScore");
-        const honchoSessionKey = buildSessionKey({
-          sessionKey: ctx.sessionKey,
-        });
+        const honchoSessionKey = buildSessionKey(ctx);
 
         try {
           const { manager } = await getHonchoMemorySearchManager(state, {
@@ -138,9 +136,7 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const relPath = readStringParam(params, "path", { required: true });
         const from = readNumberParam(params, "from", { integer: true });
         const lines = readNumberParam(params, "lines", { integer: true });
-        const honchoSessionKey = buildSessionKey({
-          sessionKey: ctx.sessionKey,
-        });
+        const honchoSessionKey = buildSessionKey(ctx);
 
         try {
           const { manager } = await getHonchoMemorySearchManager(state, {

--- a/tools/message-search.ts
+++ b/tools/message-search.ts
@@ -67,7 +67,7 @@ export function registerMessageSearchTool(api: OpenClawPluginApi, state: PluginS
           limit?: number;
         };
 
-        await state.ensureInitialized();
+        const ws = await state.ensureInitializedFor(toolCtx.agentId);
 
         // Build filters from remaining parameters (metadata, date range)
         const filters: Record<string, unknown> = {};
@@ -90,12 +90,12 @@ export function registerMessageSearchTool(api: OpenClawPluginApi, state: PluginS
         // Route to the appropriate search method based on `from`
         let messages: Message[];
         if (from === "user") {
-          messages = await state.ownerPeer!.search(query, searchOpts);
+          messages = await ws.ownerPeer!.search(query, searchOpts);
         } else if (from === "agent") {
-          const agentPeer = await state.getAgentPeer(toolCtx.agentId);
+          const agentPeer = await state.getAgentPeerFor(toolCtx.agentId);
           messages = await agentPeer.search(query, searchOpts);
         } else {
-          messages = await state.honcho.search(query, searchOpts);
+          messages = await ws.honcho.search(query, searchOpts);
         }
 
         if (!messages.length) {
@@ -111,7 +111,7 @@ export function registerMessageSearchTool(api: OpenClawPluginApi, state: PluginS
         }
 
         const results = messages.map((msg) => {
-          const speaker = msg.peerId === state.ownerPeer!.id ? "User" : "Agent";
+          const speaker = msg.peerId === ws.ownerPeer!.id ? "User" : "Agent";
           return {
             id: msg.id,
             content: msg.content,

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -5,7 +5,7 @@ import type { PluginState } from "../state.js";
 
 export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
-    {
+    (toolCtx) => ({
       name: "honcho_search_conclusions",
       label: "Search Honcho conclusions",
       description:
@@ -39,9 +39,9 @@ export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): 
           maxDistance?: number;
         };
 
-        await state.ensureInitialized();
+        const ws = await state.ensureInitializedFor(toolCtx.agentId);
 
-        const representation = await state.ownerPeer!.representation({
+        const representation = await ws.ownerPeer!.representation({
           searchQuery: query,
           searchTopK: topK ?? 10,
           searchMaxDistance: maxDistance ?? 0.5,
@@ -64,7 +64,7 @@ export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): 
           details: { query, resultCount: representation.split("\n").filter(Boolean).length },
         };
       },
-    },
+    }),
     { name: "honcho_search_conclusions" }
   );
 }

--- a/tools/session.test.ts
+++ b/tools/session.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { registerSessionTool } from "./session.js";
+
+type Registration = {
+  factory: (ctx: Record<string, unknown>) => Record<string, unknown>;
+  opts?: Record<string, unknown>;
+};
+
+function buildState(opts: { contextResponse: any; workspaceId?: string }) {
+  const ownerPeer = { id: "owner" };
+  const agentPeer = { id: "agent-developer" };
+  const ws = {
+    workspaceId: opts.workspaceId ?? "personal_workspace",
+    ownerPeer,
+    honcho: {
+      session: vi.fn(async () => ({
+        context: vi.fn(async () => opts.contextResponse),
+      })),
+    },
+  };
+  return {
+    state: {
+      ensureInitializedFor: vi.fn(async () => ws),
+      getAgentPeerFor: vi.fn(async () => agentPeer),
+    },
+    ws,
+  };
+}
+
+function registerAndGet(stateLike: any) {
+  const registrations: Registration[] = [];
+  const api = {
+    registerTool: (
+      factory: (ctx: Record<string, unknown>) => Record<string, unknown>,
+      opts?: Record<string, unknown>
+    ) => {
+      registrations.push({ factory, opts });
+    },
+  };
+  registerSessionTool(api as never, stateLike as never);
+  expect(registrations).toHaveLength(1);
+  expect(registrations[0]?.opts).toEqual({ name: "honcho_session" });
+  return registrations[0]!;
+}
+
+describe("honcho_session tool", () => {
+  it("includes workspaceId in details when no history is available", async () => {
+    const { state, ws } = buildState({
+      contextResponse: {
+        summary: { content: "" },
+        peerCard: [],
+        peerRepresentation: "",
+        messages: [],
+      },
+    });
+    const reg = registerAndGet(state);
+    const tool = reg.factory({
+      agentId: "developer",
+      sessionKey: "agent-developer-discord-channel-1234567890123456789",
+      messageProvider: "discord",
+    }) as { execute: (id: string, params: unknown) => Promise<any> };
+
+    const result = await tool.execute("call-1", {});
+
+    expect(result.content[0].text).toBe(
+      "No conversation history available for this session yet."
+    );
+    expect(result.details).toEqual({
+      messageCount: 0,
+      hasSummary: false,
+      sessionKey: "agent-developer-discord-channel-1234567890123456789-discord",
+      workspaceId: ws.workspaceId,
+    });
+  });
+
+  it("includes workspaceId in details when context returns messages", async () => {
+    const { state, ws } = buildState({
+      contextResponse: {
+        summary: { content: "earlier summary" },
+        peerCard: ["fact"],
+        peerRepresentation: "rep",
+        messages: [
+          { peerId: "owner", content: "hi", createdAt: new Date().toISOString() },
+        ],
+      },
+    });
+    const reg = registerAndGet(state);
+    const tool = reg.factory({
+      agentId: "developer",
+      sessionKey: "agent-developer-discord-channel-1234567890123456789",
+      messageProvider: "discord",
+    }) as { execute: (id: string, params: unknown) => Promise<any> };
+
+    const result = await tool.execute("call-1", {});
+
+    expect(result.details.messageCount).toBe(1);
+    expect(result.details.workspaceId).toBe(ws.workspaceId);
+    expect(result.details.sessionKey).toBe(
+      "agent-developer-discord-channel-1234567890123456789-discord"
+    );
+  });
+
+  it("resolves session key from messageChannel when tool ctx omits messageProvider", async () => {
+    // Real OpenClaw tool ctx exposes messageChannel, not messageProvider. The tool
+    // must still build a `…-discord` session key so it reads the slot the capture
+    // hook wrote to — never fall back to `-unknown`.
+    const { state, ws } = buildState({
+      contextResponse: {
+        summary: { content: "earlier summary" },
+        peerCard: [],
+        peerRepresentation: "",
+        messages: [
+          { peerId: "owner", content: "hi", createdAt: new Date().toISOString() },
+        ],
+      },
+    });
+    const reg = registerAndGet(state);
+    const tool = reg.factory({
+      agentId: "developer",
+      sessionKey: "agent:developer:discord:channel:1234567890123456789",
+      messageChannel: "discord",
+    }) as { execute: (id: string, params: unknown) => Promise<any> };
+
+    const result = await tool.execute("call-1", {});
+
+    expect(result.details.sessionKey).toBe(
+      "agent-developer-discord-channel-1234567890123456789-discord"
+    );
+    expect(result.details.sessionKey).not.toContain("-unknown");
+    expect(result.details.workspaceId).toBe(ws.workspaceId);
+    expect(result.details.messageCount).toBe(1);
+  });
+
+  it("includes workspaceId on NotFound short-circuit", async () => {
+    const ownerPeer = { id: "owner" };
+    const agentPeer = { id: "agent-developer" };
+    const notFound = Object.assign(new Error("Session not found"), {
+      name: "NotFoundError",
+    });
+    const ws = {
+      workspaceId: "personal_workspace",
+      ownerPeer,
+      honcho: {
+        session: vi.fn(async () => {
+          throw notFound;
+        }),
+      },
+    };
+    const state = {
+      ensureInitializedFor: vi.fn(async () => ws),
+      getAgentPeerFor: vi.fn(async () => agentPeer),
+    };
+
+    const reg = registerAndGet(state);
+    const tool = reg.factory({
+      agentId: "developer",
+      sessionKey: "agent-developer-discord-channel-1234567890123456789",
+      messageProvider: "discord",
+    }) as { execute: (id: string, params: unknown) => Promise<any> };
+
+    const result = await tool.execute("call-1", {});
+    expect(result.details).toEqual({
+      messageCount: 0,
+      hasSummary: false,
+      sessionKey: "agent-developer-discord-channel-1234567890123456789-discord",
+      workspaceId: "personal_workspace",
+    });
+  });
+});

--- a/tools/session.ts
+++ b/tools/session.ts
@@ -51,17 +51,17 @@ export function registerSessionTool(api: OpenClawPluginApi, state: PluginState):
           messageLimit?: number;
         };
 
-        await state.ensureInitialized();
-        const agentPeer = await state.getAgentPeer(toolCtx.agentId);
+        const ws = await state.ensureInitializedFor(toolCtx.agentId);
+        const agentPeer = await state.getAgentPeerFor(toolCtx.agentId);
         const sessionKey = buildSessionKey(toolCtx);
 
         try {
-          const session = await state.honcho.session(sessionKey);
+          const session = await ws.honcho.session(sessionKey);
 
           const context = await session.context({
             summary: includeSummary,
             tokens: messageLimit,
-            peerTarget: state.ownerPeer!,
+            peerTarget: ws.ownerPeer!,
             peerPerspective: agentPeer,
             searchQuery: searchQuery,
           });
@@ -88,7 +88,7 @@ export function registerSessionTool(api: OpenClawPluginApi, state: PluginState):
 
           if (includeMessages && context.messages.length > 0) {
             const messageLines = context.messages.map((msg) => {
-              const speaker = msg.peerId === state.ownerPeer!.id ? "User" : "OpenClaw";
+              const speaker = msg.peerId === ws.ownerPeer!.id ? "User" : "OpenClaw";
               const timestamp = msg.createdAt
                 ? new Date(msg.createdAt).toLocaleString()
                 : "";
@@ -107,7 +107,12 @@ export function registerSessionTool(api: OpenClawPluginApi, state: PluginState):
                   text: "No conversation history available for this session yet.",
                 },
               ],
-              details: { messageCount: 0, hasSummary: false, sessionKey },
+              details: {
+                messageCount: 0,
+                hasSummary: false,
+                sessionKey,
+                workspaceId: ws.workspaceId,
+              },
             };
           }
 
@@ -126,6 +131,7 @@ export function registerSessionTool(api: OpenClawPluginApi, state: PluginState):
               messageCount: context.messages.length,
               hasSummary: !!context.summary?.content,
               sessionKey,
+              workspaceId: ws.workspaceId,
             },
           };
         } catch (error) {
@@ -142,7 +148,12 @@ export function registerSessionTool(api: OpenClawPluginApi, state: PluginState):
                   text: "No conversation history found. This appears to be a new session.",
                 },
               ],
-              details: { messageCount: 0, hasSummary: false, sessionKey },
+              details: {
+                messageCount: 0,
+                hasSummary: false,
+                sessionKey,
+                workspaceId: ws.workspaceId,
+              },
             };
           }
 


### PR DESCRIPTION
## Motivation

Multi-agent OpenClaw setups benefit from per-agent Honcho workspaces so
clusters of agents (for example, a personal-assistant cluster and an
operations-assistant cluster) can keep their memory isolated from each
other while still sharing a single plugin installation.

Today the plugin pins every agent to a single top-level `workspaceId`,
so there is no way to route `agent:personal` and `agent:manager` to
different Honcho workspaces without running two plugin instances.

## What this adds

- New optional `agentWorkspaces` config field — a map of
  `agentId → workspaceId`. Agent IDs are normalized to lowercase.
- A per-workspace client cache (`PerWorkspaceState`) so each resolved
  workspace gets its own `Honcho` client, owner peer, and agent-peer
  cache, all created lazily and memoized.
- Hooks (capture, context, gateway), tools (ask, context,
  message-search, search, session, memory-passthrough) and the CLI
  resolve the caller's workspace through `state.*For(agentId)`
  accessors, so two agents mapped to different workspaces never
  cross-contaminate state.
- `buildSessionKey` in `helpers.ts` now honours both
  `ctx.messageProvider` (hook ctx) and `ctx.messageChannel` (tool ctx)
  when composing Honcho session keys, so `honcho_session`,
  `memory_search`, and `memory_get` read from the slot the capture hook
  writes to, regardless of which ctx shape the host runtime exposes.
- `openclaw.plugin.json` exposes `agentWorkspaces` in both
  `configSchema` and `uiHints` (advanced section).
- New `docs/agent-workspaces.md` walks through config and behaviour.

## Backward compatibility

When `agentWorkspaces` is absent (or an empty object), every agent
resolves to the top-level `workspaceId` — identical behaviour to the
current release. No migration is required.

## Tests

- New: `config.test.ts` (schema parsing + validation — 6 tests)
- New: `state.test.ts` (per-workspace client cache and routing — 5 tests)
- New: `helpers.test.ts` (`buildSessionKey` provider/channel fallback — 6 tests)
- New: `tools/session.test.ts` (`honcho_session` workspace details + channel fallback — 4 tests)
- Extended: `runtime.test.ts` (per-workspace memory manager threading — 6 tests)
- Extended: `tools/memory-passthrough.test.ts` (messageChannel session-key resolution — 6 tests)

All 33 tests pass under `npx vitest run`.

## Out of scope

- No migration utilities (workspaces are opt-in and additive).
- No cross-workspace sync or search — each workspace is independent.
- No upstream version bump (publish strategy up to maintainers).

## Sanitisation disclosure

Tests use synthetic workspace names (e.g. `personal_workspace`,
`ops_workspace`) and a synthetic channel id (`1234567890123456789`);
no real account or tenant data is referenced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `agentWorkspaces` configuration option to route different agents to distinct Honcho workspaces
  * Enhanced CLI commands to support per-agent workspace selection
  * Session information now includes workspace identifier in tool output

* **Documentation**
  * Added new guide explaining agent workspace routing configuration and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->