### PR TITLE
fix: CodeRabbit review comments on #68

### DIFF
--- a/peers.test.ts
+++ b/peers.test.ts
@@ -195,4 +195,38 @@ describe("PeersPersister", () => {
     await p.flushNow();
     await expect(fs.access(file)).rejects.toBeTruthy();
   });
+
+  it("keeps dirty=true and propagates errors when fs.writeFile fails, then retries on next flush", async () => {
+    // Regression test for CodeRabbit comment on #68 (peers.ts:129-158):
+    // flush() must not clear dirty before the write succeeds, and write
+    // failures must propagate so callers can react / retry.
+    const dir = await mktmp();
+    const file = path.join(dir, "peers.json");
+    const p = new PeersPersister(
+      file,
+      { version: PEERS_FILE_VERSION, peers: {} },
+      { debounceMs: 10 },
+    );
+
+    const writeSpy = vi.spyOn(fs, "writeFile");
+    writeSpy.mockRejectedValueOnce(new Error("disk full"));
+
+    p.enqueue("slack:U1");
+
+    // First flush rejects — error must reach the awaiter, not be swallowed.
+    await expect(p.flushNow()).rejects.toThrow(/disk full/);
+
+    // Second flush retries (dirty was preserved across the failed write) and
+    // this time fs.writeFile is the real implementation, so it succeeds.
+    await p.flushNow();
+    expect(writeSpy).toHaveBeenCalledTimes(2);
+
+    const body = JSON.parse(await fs.readFile(file, "utf8"));
+    expect(body).toEqual({
+      version: 1,
+      peers: { "slack:U1": "owner" },
+    });
+
+    writeSpy.mockRestore();
+  });
 });

--- a/peers.ts
+++ b/peers.ts
@@ -128,7 +128,15 @@ export class PeersPersister {
     if (this.timer) return;
     this.timer = setTimeout(() => {
       this.timer = null;
-      this.chain = this.chain.then(() => this.flush()).catch(() => undefined);
+      // Chain so writes serialize, but do NOT swallow errors here — keep them
+      // visible on the chain so subsequent flushes / flushNow await callers see
+      // the failure. dirty stays true on failure (set inside flush()) so the
+      // next enqueue/flushNow retries the write.
+      this.chain = this.chain.then(() => this.flush());
+      // Detach a non-throwing observer so an unhandled-rejection warning isn't
+      // emitted when no flushNow() is awaited; the underlying chain still
+      // carries the rejection for any future awaiter.
+      this.chain.catch(() => undefined);
     }, this.debounceMs);
     // unref so the timer doesn't block process exit in short-lived runs.
     this.timer.unref?.();
@@ -136,25 +144,37 @@ export class PeersPersister {
 
   /**
    * Flush any pending changes immediately, awaiting completion. Safe to call
-   * concurrently with enqueue().
+   * concurrently with enqueue(). Throws if the underlying write fails so
+   * callers can react (and dirty stays true for the next retry).
    */
   async flushNow(): Promise<void> {
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
     }
-    this.chain = this.chain.then(() => this.flush()).catch(() => undefined);
-    await this.chain;
+    const next = this.chain.then(() => this.flush());
+    // Reset chain to a resolved state regardless of this flush's outcome so a
+    // single failure doesn't poison every subsequent flush attempt.
+    this.chain = next.catch(() => undefined);
+    await next;
   }
 
   private async flush(): Promise<void> {
     if (!this.dirty) return;
-    this.dirty = false;
-    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
-    const body: PeersFile = {
-      version: PEERS_FILE_VERSION,
-      peers: this.peers,
-    };
-    await fs.writeFile(this.filePath, JSON.stringify(body, null, 2) + "\n");
+    try {
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+      const body: PeersFile = {
+        version: PEERS_FILE_VERSION,
+        peers: this.peers,
+      };
+      await fs.writeFile(this.filePath, JSON.stringify(body, null, 2) + "\n");
+      // Only clear dirty after the write succeeds — a failed write must leave
+      // dirty=true so the next flush retries and we don't lose mappings.
+      this.dirty = false;
+    } catch (err) {
+      // Make the retry intent explicit; dirty was never cleared but be defensive.
+      this.dirty = true;
+      throw err;
+    }
   }
 }

--- a/state.test.ts
+++ b/state.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const { HonchoMock, peerCtor, sessionCtor } = vi.hoisted(() => {
+  const peerCtor = vi.fn();
+  const sessionCtor = vi.fn();
+  class HonchoMock {
+    workspaceId: string | undefined;
+    constructor(opts: { workspaceId?: string } = {}) {
+      this.workspaceId = opts.workspaceId;
+    }
+    async getMetadata() {
+      return {};
+    }
+    async setMetadata(_meta: Record<string, unknown>) {
+      return undefined;
+    }
+    async peer(id: string, opts?: Record<string, unknown>) {
+      return peerCtor(id, opts);
+    }
+    async session(key: string) {
+      return sessionCtor(key);
+    }
+    async *peers() {
+      // empty iterator
+    }
+  }
+  return { HonchoMock, peerCtor, sessionCtor };
+});
+
+vi.mock("@honcho-ai/sdk", () => ({
+  Honcho: HonchoMock,
+}));
+
+// Import after vi.mock so the mocked SDK is used.
+const { OWNER_ID, createPluginState } = await import("./state.js");
+
+function makeApi(extra: Partial<{ pluginConfig: Record<string, unknown> }> = {}) {
+  return {
+    pluginConfig: extra.pluginConfig ?? { workspaceId: "test", baseUrl: "http://localhost:8000" },
+    config: { agents: { list: [{ id: "main", default: true }] } },
+    logger: {
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as unknown as Parameters<typeof createPluginState>[0];
+}
+
+describe("createPluginState.getParticipantPeer", () => {
+  let peersFile: string;
+
+  beforeEach(async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-state-"));
+    peersFile = path.join(dir, "peers.json");
+    process.env.OPENCLAW_HONCHO_PEERS_FILE = peersFile;
+    peerCtor.mockReset();
+    sessionCtor.mockReset();
+    peerCtor.mockImplementation(async (id: string, opts?: Record<string, unknown>) => ({
+      id,
+      metadata: opts?.metadata ?? {},
+      async getMetadata() {
+        return {};
+      },
+      async setMetadata() {
+        return undefined;
+      },
+    }));
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCLAW_HONCHO_PEERS_FILE;
+  });
+
+  it("creates a distinct transient peer for first-seen senders instead of caching owner", async () => {
+    // Regression for CodeRabbit comment on #68 (state.ts:165-179): an
+    // auto-seeded sender must NOT be cached as the owner peer.
+    const state = createPluginState(makeApi());
+    await state.ensureInitialized();
+
+    const peer = await state.getParticipantPeer("slack:Ualice");
+    expect(peer.id).toBe("participant-slack:Ualice");
+    expect(peer.id).not.toBe(OWNER_ID);
+
+    // The owner peer cache entry must be unaffected.
+    const ownerPeer = await state.getParticipantPeer();
+    expect(ownerPeer.id).toBe(OWNER_ID);
+
+    // A second resolution for the same channelPeerId returns the same
+    // transient peer (not owner) — the cache holds the participant entry.
+    const again = await state.getParticipantPeer("slack:Ualice");
+    expect(again.id).toBe("participant-slack:Ualice");
+
+    // The auto-seeded mapping was enqueued to the persister with the
+    // transient peer id, not OWNER_ID.
+    expect(state.peersPersister.peers["slack:Ualice"]).toBe("participant-slack:Ualice");
+  });
+
+  it("honors explicit owner mapping in the peers file", async () => {
+    // When the user has hand-edited peers.json to map a channel id to
+    // OWNER_ID, that explicit mapping should resolve to the owner peer.
+    await fs.mkdir(path.dirname(peersFile), { recursive: true });
+    await fs.writeFile(
+      peersFile,
+      JSON.stringify({ version: 1, peers: { "slack:Ubob": "owner" } }),
+    );
+
+    const state = createPluginState(makeApi());
+    await state.ensureInitialized();
+
+    const peer = await state.getParticipantPeer("slack:Ubob");
+    expect(peer.id).toBe(OWNER_ID);
+  });
+});
+
+describe("createPluginState.resolveSessionParticipantPeer", () => {
+  beforeEach(async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-state-"));
+    process.env.OPENCLAW_HONCHO_PEERS_FILE = path.join(dir, "peers.json");
+    peerCtor.mockReset();
+    sessionCtor.mockReset();
+    peerCtor.mockImplementation(async (id: string) => ({
+      id,
+      async getMetadata() {
+        return {};
+      },
+      async setMetadata() {
+        return undefined;
+      },
+    }));
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCLAW_HONCHO_PEERS_FILE;
+  });
+
+  it("propagates honcho.session() errors instead of falling back to owner", async () => {
+    // Regression for CodeRabbit comment on #68 (state.ts:182-196): SDK/read
+    // failures must surface, not silently route to the owner peer.
+    sessionCtor.mockRejectedValueOnce(new Error("network down"));
+
+    const state = createPluginState(makeApi());
+    await state.ensureInitialized();
+
+    await expect(state.resolveSessionParticipantPeer("session-X")).rejects.toThrow(
+      /network down/,
+    );
+  });
+
+  it("falls back to owner only when metadata exists but has no senderId", async () => {
+    sessionCtor.mockResolvedValueOnce({
+      async getMetadata() {
+        return { agentId: "main" }; // no participantSenderId
+      },
+    });
+
+    const state = createPluginState(makeApi());
+    await state.ensureInitialized();
+
+    const peer = await state.resolveSessionParticipantPeer("session-Y");
+    expect(peer.id).toBe(OWNER_ID);
+  });
+});

--- a/state.ts
+++ b/state.ts
@@ -12,7 +12,6 @@ import {
   PeersPersister,
   loadPeersFileSync,
   resolvePeersFilePath,
-  resolveParticipantPeerId,
 } from "./peers.js";
 
 export const OWNER_ID = "owner";
@@ -162,35 +161,56 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
   async function getParticipantPeer(channelPeerId?: string): Promise<Peer> {
     if (!channelPeerId) return ensureOwnerPeer();
 
-    // Known senders resolve via the peers file (plugin auto-seeds unknown
-    // senders to OWNER_ID; user hand-edits to split them off). Unknown
-    // senders enqueue for persistence and fall back to owner.
+    // Known senders resolve via the peers file (user hand-edits to split
+    // specific senders off to dedicated peer IDs).
     let peer = state.participantPeers.get(channelPeerId);
     if (peer) return peer;
 
-    const resolvedPeerId = resolveParticipantPeerId(channelPeerId, peersPersister, OWNER_ID);
+    // Distinguish "explicitly persisted mapping" from "first-seen, auto-seeded":
+    //   - explicit mapping → honor it (owner if user mapped to owner, else
+    //     custom peer id).
+    //   - first-seen → create a distinct transient peer namespaced by the
+    //     channelPeerId so we never silently merge a stranger's history into
+    //     the owner peer; enqueue the resulting peer id for persistence.
+    const persistedPeerId = peersPersister.peers[channelPeerId];
 
-    if (resolvedPeerId === OWNER_ID) {
-      peer = await ensureOwnerPeer();
-    } else {
-      peer = await honcho.peer(resolvedPeerId, { metadata: { channelPeerId } });
+    if (persistedPeerId !== undefined) {
+      if (persistedPeerId === OWNER_ID) {
+        peer = await ensureOwnerPeer();
+      } else {
+        peer = await honcho.peer(persistedPeerId, { metadata: { channelPeerId } });
+      }
+      state.participantPeers.set(channelPeerId, peer);
+      return peer;
     }
+
+    // First-seen sender. Give the sender a distinct transient peer namespaced
+    // by the channel id so we never cross-attribute its messages to the owner.
+    // Persist the channel→peer mapping so subsequent runs resolve it as an
+    // explicit mapping (and a user wanting to merge into owner can hand-edit
+    // the file to point this entry at "owner").
+    const transientPeerId = `participant-${channelPeerId}`;
+    peersPersister.enqueue(channelPeerId, transientPeerId);
+    peer = await honcho.peer(transientPeerId, {
+      metadata: { channelPeerId, autoSeeded: true },
+    });
     state.participantPeers.set(channelPeerId, peer);
     return peer;
   }
 
   async function resolveSessionParticipantPeer(sessionKey: string): Promise<Peer> {
-    try {
-      const session = await honcho.session(sessionKey);
-      const meta = await session.getMetadata();
-      if (meta && typeof meta === "object") {
-        const senderId = (meta as Record<string, unknown>).participantSenderId;
-        if (typeof senderId === "string" && senderId.length > 0) {
-          return await getParticipantPeer(senderId);
-        }
+    // Errors from honcho.session() / session.getMetadata() are propagated to
+    // the caller — silently falling back to the owner peer on transient SDK
+    // failures was masking misrouted lookups (CodeRabbit comment on #68). The
+    // default-peer fallback is reserved for the legitimate case: metadata
+    // exists but doesn't carry a participantSenderId yet.
+    const session = await honcho.session(sessionKey);
+    const meta = await session.getMetadata();
+    if (meta && typeof meta === "object") {
+      const senderId = (meta as Record<string, unknown>).participantSenderId;
+      if (typeof senderId === "string" && senderId.length > 0) {
+        return await getParticipantPeer(senderId);
       }
-    } catch {
-      // Fall through to default
     }
     return await getParticipantPeer();
   }


### PR DESCRIPTION
Addresses 3 actionable comments left by CodeRabbit on #68 to unblock multi-peer-support merge.

## Fixes

1. **`peers.ts` flush() dirty flag ordering** — clear `this.dirty` *after* the `fs.writeFile` succeeds so failures retry on the next flush instead of losing mappings. Removed the silent `.catch(() => undefined)` in the setTimeout callback and `flushNow` so write errors propagate to callers (and dirty stays true on failure for retry).

2. **`state.ts` (`getParticipantPeer`) — don't cache OWNER_ID fallback** — when there is no persisted mapping for a `channelPeerId` (i.e. the sender was only auto-seeded), create a distinct transient peer via `honcho.peer("participant-<channelPeerId>", { metadata: { channelPeerId, autoSeeded: true } })` and enqueue that peer id for persistence. Previously the owner peer was cached under `channelPeerId`, silently merging strangers' history into the owner. The OWNER_ID branch now only fires when the peers file explicitly maps the sender to `"owner"`.

3. **`state.ts` (`resolveSessionParticipantPeer`) — don't swallow `honcho.session` errors** — removed the broad `try/catch` that fell back to the owner peer on any SDK/read failure. Errors from `honcho.session()` / `session.getMetadata()` now propagate so transient failures surface instead of misrouting to the default. The default-peer fallback remains only for the legitimate case where metadata exists but doesn't carry a `participantSenderId` yet.

## Tests

- `peers.test.ts`: new test for fix #1 — `fs.writeFile` failure leaves `dirty=true`, error propagates, next `flushNow` retries and succeeds.
- `state.test.ts` (new file): tests for fixes #2 and #3 —
  - first-seen sender gets a distinct `participant-<channelPeerId>` peer (not owner) and the mapping is enqueued with that peer id;
  - explicit `"owner"` mapping in `peers.json` is honored;
  - `honcho.session()` rejection propagates from `resolveSessionParticipantPeer`;
  - metadata-without-`participantSenderId` falls back to owner.

`pnpm test` → 33/33 passing (28 prior + 5 new). `pnpm build` clean.

cc @ajspig — these are the CodeRabbit comments on #68; merging this into your branch should unblock #68 merge into main.