### PR TITLE
fix: make OWNER_ID configurable via config or HONCHO_OWNER_ID env var

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -18,6 +18,7 @@ export type HonchoConfig = {
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
   crossSessionSearch: boolean;
+  ownerId: string;
 };
 
 /**
@@ -81,6 +82,10 @@ export const honchoConfigSchema = {
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
       crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,
+      ownerId:
+        typeof cfg.ownerId === "string" && cfg.ownerId.length > 0
+          ? cfg.ownerId
+          : process.env.HONCHO_OWNER_ID ?? "owner",
     };
   },
 };

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -36,6 +36,10 @@
         "type": "boolean",
         "default": false,
         "description": "When true, built-in noise patterns are not applied — only noisePatterns entries are used."
+      },
+      "ownerId": {
+        "type": "string",
+        "description": "The Honcho peer ID for the owner. Defaults to 'owner'. Set to your Telegram/WhatsApp user ID if using multi-user Honcho workspaces where the owner peer ID is not 'owner'."
       }
     }
   },
@@ -76,6 +80,12 @@
       "label": "Disable Default Noise Patterns",
       "advanced": true,
       "help": "When enabled, only custom noisePatterns entries are used — built-in defaults are skipped."
+    },
+    "ownerId": {
+      "label": "Owner Peer ID",
+      "advanced": true,
+      "placeholder": "owner",
+      "help": "The Honcho peer ID for the owner. Defaults to 'owner'. Set to your Telegram/WhatsApp user ID if using multi-user Honcho workspaces where the owner peer ID is not 'owner'."
     }
   }
 }

--- a/state.ts
+++ b/state.ts
@@ -97,7 +97,8 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
       await honcho.setMetadata({ ...wsMeta, agentPeerMap: state.agentPeerMap });
     }
 
-    state.ownerPeer = await honcho.peer(OWNER_ID, { metadata: {} });
+    const ownerId = state.cfg.ownerId ?? OWNER_ID;
+    state.ownerPeer = await honcho.peer(ownerId, { metadata: {} });
     state.initialized = true;
   }
 
@@ -110,9 +111,10 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     let peerId = state.agentPeerMap[id];
 
     if (!peerId) {
+      const ownerId = state.cfg.ownerId ?? OWNER_ID;
       const allPeers = await honcho.peers();
       for await (const p of allPeers) {
-        if (p.id === OWNER_ID) continue;
+        if (p.id === ownerId) continue;
         const meta = await p.getMetadata();
         if (meta?.agentId === id) {
           peerId = p.id;


### PR DESCRIPTION
## Bug

The `OWNER_ID` constant in `state.ts` is hardcoded to `"owner"`:

```typescript
export const OWNER_ID = "owner";
```

This assumes the owner's peer ID in Honcho is literally `"owner"`. However, in multi-user setups (e.g., when Honcho uses Telegram user IDs as peer IDs), the owner may have a different peer ID (e.g., `"5127331089"`). This causes `honcho_context` and other owner-peer-dependent tools to read from the wrong (empty) peer.

## Fix

Make `ownerId` configurable via:
1. Plugin config field `ownerId`
2. Environment variable `HONCHO_OWNER_ID`
3. Falls back to `"owner"` for backward compatibility

Follows the same pattern used for `apiKey`, `workspaceId`, `baseUrl`, and `timeoutMs`.

## Changes

- **config.ts**: Added `ownerId: string` to `HonchoConfig` type and parse logic with `HONCHO_OWNER_ID` env var fallback
- **state.ts**: Updated `ensureInitialized()` and `getAgentPeer()` to use `cfg.ownerId ?? OWNER_ID` instead of hardcoded `OWNER_ID`
- **openclaw.plugin.json**: Added `ownerId` to config schema and uiHints

## Example usage

Set via environment variable:
```bash
HONCHO_OWNER_ID=5127331089 openclaw gateway start
```

Or via plugin config:
```json
{
  "plugins": {
    "entries": {
      "openclaw-honcho": {
        "config": {
          "ownerId": "5127331089"
        }
      }
    }
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Owner peer identifier is now configurable through plugin settings, enabling customization of the Honcho peer ID
  * Configuration can be set via plugin settings or environment variable
  * Automatically defaults to `'owner'` when not explicitly specified
  * Configuration interface includes descriptive help text and guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->