### PR TITLE
fix: truncate session keys longer than Honcho's 100-char limit

### DIFF
--- a/helpers.test.ts
+++ b/helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import { buildSessionKey } from "./helpers.js";
+
+describe("buildSessionKey", () => {
+  it("returns a normalized key for short inputs unchanged", () => {
+    expect(buildSessionKey({ sessionKey: "default", messageProvider: "telegram" })).toBe(
+      "default-telegram",
+    );
+  });
+
+  it("replaces colons and other non-alphanumerics with hyphens", () => {
+    expect(
+      buildSessionKey({ sessionKey: "agent:main:dashboard:test", messageProvider: "telegram" }),
+    ).toBe("agent-main-dashboard-test-telegram");
+  });
+
+  it("falls back to defaults when fields are missing", () => {
+    expect(buildSessionKey()).toBe("default-unknown");
+    expect(buildSessionKey({})).toBe("default-unknown");
+  });
+
+  it("truncates and appends a sha1 suffix when the normalized key exceeds 100 chars", () => {
+    const longSessionKey =
+      "agent:default:cron:e07cc0d8-0182-417b-a80e-db01ac7bc5b0:run:c4b112f2-dcb0-40c2-ba5d-1b512b1cbd17";
+    const result = buildSessionKey({ sessionKey: longSessionKey, messageProvider: "unknown" });
+    expect(result.length).toBeLessThanOrEqual(100);
+
+    const fullNormalized = `${longSessionKey}-unknown`.replace(/[^a-zA-Z0-9-]/g, "-");
+    const expectedHash = createHash("sha1").update(fullNormalized).digest("hex").slice(0, 7);
+    expect(result.endsWith(`-${expectedHash}`)).toBe(true);
+    expect(result.startsWith(fullNormalized.slice(0, 100 - 8))).toBe(true);
+  });
+
+  it("disambiguates two long keys that share a long common prefix", () => {
+    const a =
+      "agent:default:cron:e07cc0d8-0182-417b-a80e-db01ac7bc5b0:run:c4b112f2-dcb0-40c2-ba5d-1b512b1cbd17";
+    const b =
+      "agent:default:cron:e07cc0d8-0182-417b-a80e-db01ac7bc5b0:run:af1c9530-94c7-4f08-b66a-576fd492657e";
+    const ka = buildSessionKey({ sessionKey: a, messageProvider: "unknown" });
+    const kb = buildSessionKey({ sessionKey: b, messageProvider: "unknown" });
+    expect(ka).not.toBe(kb);
+    expect(ka.length).toBe(100);
+    expect(kb.length).toBe(100);
+  });
+
+  it("is deterministic — the same input always produces the same key", () => {
+    const ctx = {
+      sessionKey:
+        "agent:default:cron:e07cc0d8-0182-417b-a80e-db01ac7bc5b0:run:c4b112f2-dcb0-40c2-ba5d-1b512b1cbd17",
+      messageProvider: "unknown",
+    };
+    expect(buildSessionKey(ctx)).toBe(buildSessionKey(ctx));
+  });
+});

--- a/helpers.ts
+++ b/helpers.ts
@@ -2,18 +2,37 @@
  * Pure helper functions — no mutable state dependencies.
  */
 
+import { createHash } from "node:crypto";
+
 import type { Peer, MessageInput } from "@honcho-ai/sdk";
+
+/**
+ * Honcho enforces a 100-character maximum on session IDs (validated client-side
+ * by the SDK before any HTTP request). OpenClaw session keys for isolated cron
+ * runs and similar surfaces can exceed this — e.g.
+ * `agent:default:cron:<jobUuid>:run:<runUuid>` is 96 chars before the
+ * `-${provider}` suffix is appended, so the resulting key blows past 100.
+ */
+const HONCHO_MAX_SESSION_ID_LEN = 100;
 
 /**
  * Build a Honcho session key from OpenClaw context.
  * Combines sessionKey + messageProvider to create unique sessions per platform.
  * Uses hyphens as separators (Honcho requires hyphens, not underscores).
+ *
+ * Keys longer than the Honcho 100-char limit are truncated and disambiguated
+ * with a short sha1 suffix of the full normalized key, so distinct OpenClaw
+ * sessions don't collide on the truncated prefix.
  */
 export function buildSessionKey(ctx?: { sessionKey?: string; messageProvider?: string }): string {
   const baseKey = ctx?.sessionKey ?? "default";
   const provider = ctx?.messageProvider ?? "unknown";
   const combined = `${baseKey}-${provider}`;
-  return combined.replace(/[^a-zA-Z0-9-]/g, "-");
+  const normalized = combined.replace(/[^a-zA-Z0-9-]/g, "-");
+  if (normalized.length <= HONCHO_MAX_SESSION_ID_LEN) return normalized;
+  const hash = createHash("sha1").update(normalized).digest("hex").slice(0, 7);
+  const suffix = `-${hash}`;
+  return normalized.slice(0, HONCHO_MAX_SESSION_ID_LEN - suffix.length) + suffix;
 }
 
 export function isSubagentSession(ctx?: { sessionKey?: string }): boolean {


### PR DESCRIPTION
## Summary

`buildSessionKey` produces session IDs that can exceed Honcho's 100-character limit. The SDK validates this client-side, so capture fails before any request reaches the server:

```
ZodError: Session ID can be at most 100 characters
  at Honcho.session (.../@honcho-ai/sdk/dist/client.js)
  at flushMessages (.../hooks/capture.js)
```

The most reliable trigger is OpenClaw's isolated cron runs. The session key for those is `agent:default:cron:<jobUuid>:run:<runUuid>` — 96 chars before the `-${provider}` suffix is appended, which pushes it past 100.

This change normalizes the key as before, then — only when the result is longer than 100 chars — truncates and appends a 7-hex-char sha1 suffix of the full normalized key, so two distinct OpenClaw sessions sharing a long common prefix don't collide on the truncated form. Short keys flow through unchanged, so already-stored conversations keep their existing Honcho session IDs.

This matches the pattern Honcho's own docs use for normalizing peer/session IDs ([guides/granola.mdx](https://github.com/plastic-labs/honcho/blob/main/docs/v3/guides/granola.mdx), [guides/gmail.mdx](https://github.com/plastic-labs/honcho/blob/main/docs/v3/guides/gmail.mdx)) — `(norm or "session")[:100]` — with the addition of a hash suffix to avoid collisions on long unique identifiers.

## Verification

Reproduced locally on plugin 1.2.2 / SDK 2.1.0: cron `agent_end` hooks failed with the ZodError above. After applying the patch and restarting the gateway, two consecutive twag isolated-cron runs landed in Honcho with session IDs of length exactly 100:

```
agent-default-cron-e07cc0d8-0182-417b-a80e-db01ac7bc5b0-run-af1c9530-94c7-4f08-b66a-576fd492-5128315
agent-default-cron-e07cc0d8-0182-417b-a80e-db01ac7bc5b0-run-c4b112f2-dcb0-40c2-ba5d-1b512b1c-fdff16c
```

(`-XXXXXXX` suffix is the sha1 disambiguator.) Telegram sessions, which fit comfortably under the limit, retained their existing keys.

## Test plan

- [x] New `helpers.test.ts` covers: short keys unchanged, colon normalization, default fallbacks, truncation length and shape, collision avoidance for keys with long shared prefixes, determinism.
- [x] `pnpm exec vitest run` — 13/13 passing.
- [x] `pnpm build` — clean `tsc`.
- [x] Manual end-to-end: gateway restart → manual cron trigger → Honcho session created with length-100 truncated ID, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for session key generation, validation, and edge cases.

* **Improvements**
  * Enhanced session key handling to ensure consistent, deterministic output with proper character normalization and length constraints. Improved fallback behavior for missing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->