### PR TITLE
feat: add configurable honcho memory hygiene

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -4,10 +4,27 @@
 
 export const DEFAULT_NOISE_PATTERNS: string[] = [
   "HEARTBEAT_OK",
+  "NO_REPLY",
   "A scheduled reminder has been triggered",
   "Execute your Session Startup sequence now",
   "Queued messages from",
 ];
+
+export const DEFAULT_ISOLATED_SESSION_PATTERNS: string[] = [
+  "/(^|[:-])cron([:-]|$)/i",
+  "/(^|[:-])subagent([:-]|$)/i",
+  "/(^|[:-])heartbeat([:-]|$)/i",
+  "/temp[-:]slug[-:]generator/i",
+];
+
+export type ContextInjectionMode = "off" | "full";
+export type MemoryBackendMode = "qmd" | "builtin";
+
+export type HonchoContextInjectionConfig = {
+  peerCard: boolean;
+  sessionSummary: boolean;
+  representation: ContextInjectionMode;
+};
 
 export type HonchoConfig = {
   apiKey?: string;
@@ -18,6 +35,11 @@ export type HonchoConfig = {
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
   crossSessionSearch: boolean;
+  contextInjection: HonchoContextInjectionConfig;
+  stripRuntimeScaffolding: boolean;
+  isolatedSessionPatterns: string[];
+  recentTailDedupeSize: number;
+  memoryBackend: MemoryBackendMode;
 };
 
 /**
@@ -34,6 +56,22 @@ function resolveEnvVars(value: string): string {
   });
 }
 
+function parsePositiveInteger(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.trunc(value);
+  }
+  return fallback;
+}
+
+function parseStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .filter((p): p is string => typeof p === "string")
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+    : [];
+}
+
 export const honchoConfigSchema = {
   parse(value: unknown): HonchoConfig {
     const cfg = (value ?? {}) as Record<string, unknown>;
@@ -47,15 +85,33 @@ export const honchoConfigSchema = {
     }
 
     const disableDefaultNoisePatterns = cfg.disableDefaultNoisePatterns === true;
-    const userPatterns = Array.isArray(cfg.noisePatterns)
-      ? (cfg.noisePatterns as unknown[])
-          .filter((p): p is string => typeof p === "string")
-          .map((p) => p.trim())
-          .filter((p) => p.length > 0)
-      : [];
+    const userPatterns = parseStringArray(cfg.noisePatterns);
     const noisePatterns = [
       ...new Set([...(disableDefaultNoisePatterns ? [] : DEFAULT_NOISE_PATTERNS), ...userPatterns]),
     ];
+
+    const contextInjectionCfg =
+      typeof cfg.contextInjection === "object" && cfg.contextInjection !== null
+        ? (cfg.contextInjection as Record<string, unknown>)
+        : {};
+    const representationRaw =
+      typeof contextInjectionCfg.representation === "string"
+        ? contextInjectionCfg.representation
+        : process.env.HONCHO_CONTEXT_REPRESENTATION;
+    const representation: ContextInjectionMode =
+      representationRaw === "off" || representationRaw === "full" ? representationRaw : "full";
+    const contextInjection: HonchoContextInjectionConfig = {
+      peerCard: typeof contextInjectionCfg.peerCard === "boolean" ? contextInjectionCfg.peerCard : true,
+      sessionSummary:
+        typeof contextInjectionCfg.sessionSummary === "boolean" ? contextInjectionCfg.sessionSummary : true,
+      representation,
+    };
+
+    const isolatedSessionPatterns = [
+      ...new Set([...DEFAULT_ISOLATED_SESSION_PATTERNS, ...parseStringArray(cfg.isolatedSessionPatterns)]),
+    ];
+
+    const memoryBackend: MemoryBackendMode = cfg.memoryBackend === "builtin" ? "builtin" : "qmd";
 
     return {
       apiKey,
@@ -81,6 +137,12 @@ export const honchoConfigSchema = {
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
       crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,
+      contextInjection,
+      stripRuntimeScaffolding:
+        typeof cfg.stripRuntimeScaffolding === "boolean" ? cfg.stripRuntimeScaffolding : true,
+      isolatedSessionPatterns,
+      recentTailDedupeSize: parsePositiveInteger(cfg.recentTailDedupeSize, 200),
+      memoryBackend,
     };
   },
 };

--- a/helpers.ts
+++ b/helpers.ts
@@ -6,6 +6,24 @@ import type { Peer, MessageInput } from "@honcho-ai/sdk";
 
 type ContentBlock = { type?: string; text?: unknown };
 type RawMessage = { role?: string; content?: string | ContentBlock[]; timestamp?: number };
+export type CleanMessageOptions = { stripRuntimeScaffolding?: boolean };
+
+const SESSION_KIND_TOKENS = new Set(["direct", "group", "channel"]);
+const NON_PROVIDER_SESSION_PREFIXES = new Set([
+  "acp",
+  "channel",
+  "cron",
+  "direct",
+  "group",
+  "main",
+  "subagent",
+  "thread",
+]);
+const LEADING_SYSTEM_LINE_RE = /^System(?: \(untrusted\))?: /;
+const STARTUP_CONTEXT_BLOCK_RE =
+  /\[Startup context loaded by runtime\][\s\S]*?(?:Current time:[^\n]*(?:\n|$)|$)/gi;
+const STARTUP_ONLY_LINE_RE =
+  /^(?:A new session was started via \/new or \/reset\..*|Note: The previous agent run was aborted by the user\..*|Current time: .*|Resume carefully or ask for clarification\.)$/gim;
 
 /**
  * Extract plain text from a message's `content` (string or array of content blocks).
@@ -27,17 +45,86 @@ export function getRawContent(msg: unknown): string {
 /**
  * Build a Honcho session key from OpenClaw context.
  * Combines sessionKey + messageProvider to create unique sessions per platform.
+ * When hook contexts omit messageProvider, infer it from canonical OpenClaw
+ * agent session keys before falling back to "unknown".
  * Uses hyphens as separators (Honcho requires hyphens, not underscores).
  */
+function inferProviderFromSessionKey(sessionKey?: string): string | undefined {
+  if (typeof sessionKey !== "string") return undefined;
+  const parts = sessionKey.trim().toLowerCase().split(":").filter(Boolean);
+  if (parts.length < 5 || parts[0] !== "agent") return undefined;
+  const rest = parts.slice(2);
+  const candidate = rest[0];
+  if (!candidate || NON_PROVIDER_SESSION_PREFIXES.has(candidate)) return undefined;
+  if (SESSION_KIND_TOKENS.has(rest[1])) return candidate;
+  if (SESSION_KIND_TOKENS.has(rest[2])) {
+    const accountId = rest[1];
+    if (accountId && !NON_PROVIDER_SESSION_PREFIXES.has(accountId)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
 export function buildSessionKey(ctx?: { sessionKey?: string; messageProvider?: string }): string {
   const baseKey = ctx?.sessionKey ?? "default";
-  const provider = ctx?.messageProvider ?? "unknown";
+  const provider = ctx?.messageProvider ?? inferProviderFromSessionKey(ctx?.sessionKey) ?? "unknown";
   const combined = `${baseKey}-${provider}`;
   return combined.replace(/[^a-zA-Z0-9-]/g, "-");
 }
 
 export function isSubagentSession(ctx?: { sessionKey?: string }): boolean {
   return (ctx?.sessionKey ?? "").includes(":subagent:");
+}
+
+function stripLeadingSystemEnvelope(text: string): string {
+  const lines = text.split("\n");
+  let index = 0;
+
+  while (index < lines.length && lines[index].trim() === "") {
+    index += 1;
+  }
+
+  while (index < lines.length && LEADING_SYSTEM_LINE_RE.test(lines[index].trim())) {
+    index += 1;
+    while (
+      index < lines.length &&
+      (lines[index].trim() === "" || LEADING_SYSTEM_LINE_RE.test(lines[index].trim()))
+    ) {
+      index += 1;
+    }
+  }
+
+  return lines.slice(index).join("\n");
+}
+
+function compilePattern(pattern: string): RegExp | null {
+  if (!pattern.startsWith("/")) return null;
+  const lastSlash = pattern.lastIndexOf("/", pattern.length - 1);
+  if (lastSlash <= 0) return null;
+  const source = pattern.slice(1, lastSlash);
+  const flags = pattern.slice(lastSlash + 1);
+  try {
+    return new RegExp(source, flags);
+  } catch {
+    return null;
+  }
+}
+
+function matchesPattern(value: string, pattern: string): boolean {
+  const re = compilePattern(pattern);
+  if (re) return re.test(value);
+  return value.includes(pattern);
+}
+
+export function shouldIsolateSession(
+  ctx?: { sessionKey?: string; messageProvider?: string },
+  patterns: string[] = [],
+): boolean {
+  if (patterns.length === 0) return false;
+  const raw = String(ctx?.sessionKey ?? "");
+  const built = buildSessionKey(ctx);
+  return patterns.some((pattern) => matchesPattern(raw, pattern) || matchesPattern(built, pattern));
 }
 
 /**
@@ -147,13 +234,21 @@ function stripInboundMetadata(text: string): string {
  * Also strips leading OpenClaw reply directive tags (e.g. [[reply_to_current]])
  * so control tokens are never persisted or re-surfaced as user-visible text.
  */
-export function cleanMessageContent(content: string): string {
+export function cleanMessageContent(content: string, options: CleanMessageOptions = {}): string {
+  const { stripRuntimeScaffolding = true } = options;
   let cleaned = content;
   // Strip Honcho memory context tags (prevent re-injection loops).
   cleaned = cleaned.replace(/<honcho-memory[^>]*>[\s\S]*?<\/honcho-memory>\s*/gi, "");
   cleaned = cleaned.replace(/<!--[^>]*honcho[^>]*-->\s*/gi, "");
   // Strip OpenClaw inbound metadata using OpenClaw-equivalent parser logic.
   cleaned = stripInboundMetadata(cleaned);
+  if (stripRuntimeScaffolding) {
+    // Strip runtime/system envelope lines before checking for startup-only content.
+    cleaned = stripLeadingSystemEnvelope(cleaned);
+    // Strip first-turn startup scaffolding and reset-resume hints.
+    cleaned = cleaned.replace(STARTUP_CONTEXT_BLOCK_RE, "");
+    cleaned = cleaned.replace(STARTUP_ONLY_LINE_RE, "");
+  }
   // Strip leading reply directive control tokens.
   cleaned = cleaned.replace(
     /^(\s*\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*)+/gi,
@@ -212,18 +307,8 @@ export function extractSenderId(content: string): string | undefined {
  */
 export function shouldSkipMessage(content: string, noisePatterns: string[]): boolean {
   return noisePatterns.some((pattern) => {
-    if (pattern.startsWith("/")) {
-      const lastSlash = pattern.lastIndexOf("/", pattern.length - 1);
-      if (lastSlash > 0) {
-        const source = pattern.slice(1, lastSlash);
-        const flags = pattern.slice(lastSlash + 1);
-        try {
-          return new RegExp(source, flags).test(content);
-        } catch {
-          // fall through to literal match if regex is invalid
-        }
-      }
-    }
+    const re = compilePattern(pattern);
+    if (re) return re.test(content);
     return content === pattern || content.startsWith(pattern);
   });
 }
@@ -234,6 +319,7 @@ export function extractMessages(
   agentPeer: Peer,
   noisePatterns: string[] = [],
   resolvePeer?: (senderId: string) => Peer | undefined,
+  cleanOptions: CleanMessageOptions = {},
 ): MessageInput[] {
   const result: MessageInput[] = [];
 
@@ -255,7 +341,7 @@ export function extractMessages(
       peer = agentPeer;
     }
 
-    let content = cleanMessageContent(rawContent);
+    let content = cleanMessageContent(rawContent, cleanOptions);
     content = content.trim();
 
     if (!content) continue;

--- a/helpers.ts
+++ b/helpers.ts
@@ -112,8 +112,10 @@ function compilePattern(pattern: string): RegExp | null {
 }
 
 function matchesPattern(value: string, pattern: string): boolean {
-  const re = compilePattern(pattern);
-  if (re) return re.test(value);
+  if (pattern.startsWith("/")) {
+    const re = compilePattern(pattern);
+    return re ? re.test(value) : false;
+  }
   return value.includes(pattern);
 }
 

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -1,15 +1,76 @@
 // @ts-ignore - resolved by openclaw runtime
+import type { MessageInput, Session } from "@honcho-ai/sdk";
+// @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { OWNER_ID } from "../state.js";
 import {
   buildSessionKey,
   isSubagentSession,
+  shouldIsolateSession,
   extractMessages,
   extractSenderId,
   getRawContent,
 } from "../helpers.js";
 import { subagentParentMap } from "./subagent.js";
+
+const sessionFlushLocks = new Map<string, Promise<void>>();
+
+function messageSignature(message: MessageInput | { peerId: string; createdAt?: string; content: string }): string | null {
+  if (!message?.createdAt) return null;
+  return `${message.peerId}\u0000${message.createdAt}\u0000${message.content}`;
+}
+
+async function withSessionFlushLock<T>(sessionKey: string, fn: () => Promise<T>): Promise<T> {
+  const previous = sessionFlushLocks.get(sessionKey) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  sessionFlushLocks.set(sessionKey, current);
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (sessionFlushLocks.get(sessionKey) === current) {
+      sessionFlushLocks.delete(sessionKey);
+    }
+  }
+}
+
+async function dedupeAgainstRecentTail(
+  session: Session,
+  extracted: MessageInput[],
+  recentTailSize: number,
+): Promise<MessageInput[]> {
+  const batchSeen = new Set<string>();
+  const batchUnique: MessageInput[] = [];
+
+  for (const message of extracted) {
+    const signature = messageSignature(message) ?? `${message.peerId}\u0000${message.content}`;
+    if (batchSeen.has(signature)) continue;
+    batchSeen.add(signature);
+    batchUnique.push(message);
+  }
+
+  if (batchUnique.length === 0 || recentTailSize <= 0) return batchUnique;
+
+  const recentPage = await session.messages({
+    size: Math.min(Math.max(recentTailSize, 1), 500),
+    reverse: true,
+  });
+  const recentSignatures = new Set(
+    recentPage.items
+      .map((message) => messageSignature(message))
+      .filter((signature): signature is string => typeof signature === "string"),
+  );
+
+  return batchUnique.filter((message) => {
+    const signature = messageSignature(message);
+    return !signature || !recentSignatures.has(signature);
+  });
+}
 
 /**
  * Core message capture logic shared by agent_end, before_compaction, and before_reset.
@@ -22,6 +83,7 @@ async function flushMessages(
   ctx: { sessionKey?: string; agentId?: string; messageProvider?: string },
 ): Promise<number> {
   if (!messages?.length) return 0;
+  if (shouldIsolateSession(ctx, state.cfg.isolatedSessionPatterns)) return 0;
 
   const sessionKey = buildSessionKey(ctx);
   const agentId = ctx.agentId ?? state.resolveDefaultAgentId();
@@ -43,105 +105,109 @@ async function flushMessages(
     } : {}),
   };
 
-  const session = await state.honcho.session(sessionKey, { metadata: sessionMeta });
-  const meta = await session.getMetadata();
-  const existingMeta: Record<string, unknown> =
-    meta && typeof meta === "object" ? (meta as Record<string, unknown>) : {};
+  return withSessionFlushLock(sessionKey, async () => {
+    const session = await state.honcho.session(sessionKey, { metadata: sessionMeta });
+    const meta = await session.getMetadata();
+    const existingMeta: Record<string, unknown> =
+      meta && typeof meta === "object" ? (meta as Record<string, unknown>) : {};
 
-  const turnStartIndex = Math.min(
-    Math.max(state.turnStartIndex.get(sessionKey) ?? 0, 0),
-    messages.length,
-  );
-  const rawLastSavedIndex =
-    typeof existingMeta.lastSavedIndex === "number" ? existingMeta.lastSavedIndex : 0;
-  const lastSavedIndex = Math.min(Math.max(rawLastSavedIndex, 0), messages.length);
-  const startIndex = Math.max(turnStartIndex, lastSavedIndex);
+    const turnStartIndex = Math.min(
+      Math.max(state.turnStartIndex.get(sessionKey) ?? 0, 0),
+      messages.length,
+    );
+    const rawLastSavedIndex =
+      typeof existingMeta.lastSavedIndex === "number" ? existingMeta.lastSavedIndex : 0;
+    const lastSavedIndex = Math.min(Math.max(rawLastSavedIndex, 0), messages.length);
+    const startIndex = Math.max(turnStartIndex, lastSavedIndex);
 
-  if (messages.length <= startIndex) {
-    return 0;
-  }
-
-  const newRawMessages = messages.slice(startIndex);
-
-  // Pre-resolve participant peers for all unique sender IDs in this batch
-  const senderIds = new Set<string>();
-  let lastSenderId: string | undefined;
-  let userMsgCount = 0;
-  for (const msg of newRawMessages) {
-    if (!msg || typeof msg !== "object") continue;
-    const m = msg as Record<string, unknown>;
-    if (m.role !== "user") continue;
-    userMsgCount++;
-    const rawContent = getRawContent(msg);
-    const senderId = extractSenderId(rawContent);
-    if (senderId) {
-      senderIds.add(senderId);
-      lastSenderId = senderId;
-    } else {
-      const hasConvInfo = rawContent.includes("Conversation info (untrusted metadata):");
-      api.logger.debug?.(`[honcho] User message without sender_id (hasConvInfo=${hasConvInfo}, contentLen=${rawContent.length})`);
+    if (messages.length <= startIndex) {
+      return 0;
     }
-  }
-  if (senderIds.size > 0) {
-    api.logger.debug?.(`[honcho] Resolved ${senderIds.size} unique sender(s) from ${userMsgCount} user message(s)`);
-  }
 
-  // Parallel peer resolution — avoids sequential await bottleneck in group chats.
-  const resolvedPeers = new Map<string, Awaited<ReturnType<typeof state.getParticipantPeer>>>();
-  const senderIdArray = [...senderIds];
-  const peers = await Promise.all(senderIdArray.map((id) => state.getParticipantPeer(id)));
-  for (let i = 0; i < senderIdArray.length; i++) {
-    resolvedPeers.set(senderIdArray[i], peers[i]);
-  }
+    const newRawMessages = messages.slice(startIndex);
 
-  const defaultParticipantPeer = await state.getParticipantPeer();
-
-  // Build peer configs: default owner + all resolved participant peers + agent + parent
-  const peerConfigMap = new Map<string, { observeMe: boolean; observeOthers: boolean }>();
-  peerConfigMap.set(OWNER_ID, { observeMe: true, observeOthers: state.cfg.ownerObserveOthers });
-  for (const [, peer] of resolvedPeers) {
-    if (peer.id !== OWNER_ID) {
-      peerConfigMap.set(peer.id, { observeMe: true, observeOthers: state.cfg.ownerObserveOthers });
+    // Pre-resolve participant peers for all unique sender IDs in this batch
+    const senderIds = new Set<string>();
+    let lastSenderId: string | undefined;
+    let userMsgCount = 0;
+    for (const msg of newRawMessages) {
+      if (!msg || typeof msg !== "object") continue;
+      const m = msg as Record<string, unknown>;
+      if (m.role !== "user") continue;
+      userMsgCount++;
+      const rawContent = getRawContent(msg);
+      const senderId = extractSenderId(rawContent);
+      if (senderId) {
+        senderIds.add(senderId);
+        lastSenderId = senderId;
+      } else {
+        const hasConvInfo = rawContent.includes("Conversation info (untrusted metadata):");
+        api.logger.debug?.(`[honcho] User message without sender_id (hasConvInfo=${hasConvInfo}, contentLen=${rawContent.length})`);
+      }
     }
-  }
-  peerConfigMap.set(agentPeer.id, { observeMe: true, observeOthers: true });
-  if (parentPeer) {
-    peerConfigMap.set(parentPeer.id, { observeMe: false, observeOthers: true });
-  }
+    if (senderIds.size > 0) {
+      api.logger.debug?.(`[honcho] Resolved ${senderIds.size} unique sender(s) from ${userMsgCount} user message(s)`);
+    }
 
-  const peerConfigs = Array.from(peerConfigMap.entries()) as Array<
-    [string, { observeMe: boolean; observeOthers: boolean }]
-  >;
-  await session.addPeers(peerConfigs);
+    // Parallel peer resolution — avoids sequential await bottleneck in group chats.
+    const resolvedPeers = new Map<string, Awaited<ReturnType<typeof state.getParticipantPeer>>>();
+    const senderIdArray = [...senderIds];
+    const peers = await Promise.all(senderIdArray.map((id) => state.getParticipantPeer(id)));
+    for (let i = 0; i < senderIdArray.length; i++) {
+      resolvedPeers.set(senderIdArray[i], peers[i]);
+    }
 
-  const extracted = extractMessages(
-    newRawMessages,
-    defaultParticipantPeer,
-    agentPeer,
-    state.cfg.noisePatterns,
-    (senderId) => resolvedPeers.get(senderId),
-  );
+    const defaultParticipantPeer = await state.getParticipantPeer();
 
-  // participantSenderId = last active sender, used by tools to resolve the
-  // session's current participant peer. Named "sender" (not "peer") to
-  // distinguish raw channel IDs from resolved Honcho peer IDs.
-  const updatedMeta: Record<string, unknown> = {
-    ...existingMeta,
-    ...sessionMeta,
-    lastSavedIndex: messages.length,
-  };
-  if (lastSenderId) {
-    updatedMeta.participantSenderId = lastSenderId;
-  }
+    // Build peer configs: default owner + all resolved participant peers + agent + parent
+    const peerConfigMap = new Map<string, { observeMe: boolean; observeOthers: boolean }>();
+    peerConfigMap.set(OWNER_ID, { observeMe: true, observeOthers: state.cfg.ownerObserveOthers });
+    for (const [, peer] of resolvedPeers) {
+      if (peer.id !== OWNER_ID) {
+        peerConfigMap.set(peer.id, { observeMe: true, observeOthers: state.cfg.ownerObserveOthers });
+      }
+    }
+    peerConfigMap.set(agentPeer.id, { observeMe: true, observeOthers: true });
+    if (parentPeer) {
+      peerConfigMap.set(parentPeer.id, { observeMe: false, observeOthers: true });
+    }
 
-  if (extracted.length === 0) {
+    const peerConfigs = Array.from(peerConfigMap.entries()) as Array<
+      [string, { observeMe: boolean; observeOthers: boolean }]
+    >;
+    await session.addPeers(peerConfigs);
+
+    const extracted = extractMessages(
+      newRawMessages,
+      defaultParticipantPeer,
+      agentPeer,
+      state.cfg.noisePatterns,
+      (senderId) => resolvedPeers.get(senderId),
+      { stripRuntimeScaffolding: state.cfg.stripRuntimeScaffolding },
+    );
+    const deduped = await dedupeAgainstRecentTail(session, extracted, state.cfg.recentTailDedupeSize);
+
+    // participantSenderId = last active sender, used by tools to resolve the
+    // session's current participant peer. Named "sender" (not "peer") to
+    // distinguish raw channel IDs from resolved Honcho peer IDs.
+    const updatedMeta: Record<string, unknown> = {
+      ...existingMeta,
+      ...sessionMeta,
+      lastSavedIndex: messages.length,
+    };
+    if (lastSenderId) {
+      updatedMeta.participantSenderId = lastSenderId;
+    }
+
+    if (deduped.length === 0) {
+      await session.setMetadata(updatedMeta);
+      return 0;
+    }
+
+    await session.addMessages(deduped);
     await session.setMetadata(updatedMeta);
-    return 0;
-  }
-
-  await session.addMessages(extracted);
-  await session.setMetadata(updatedMeta);
-  return extracted.length;
+    return deduped.length;
+  });
 }
 
 export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState): void {

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -15,6 +15,7 @@ import {
 import { subagentParentMap } from "./subagent.js";
 
 const sessionFlushLocks = new Map<string, Promise<void>>();
+export const HONCHO_MESSAGES_LIST_MAX_SIZE = 100;
 
 function messageSignature(message: MessageInput | { peerId: string; createdAt?: string; content: string }): string | null {
   if (!message?.createdAt) return null;
@@ -39,7 +40,35 @@ async function withSessionFlushLock<T>(sessionKey: string, fn: () => Promise<T>)
   }
 }
 
-async function dedupeAgainstRecentTail(
+function normalizeRecentTailSize(recentTailSize: number): number {
+  if (!Number.isFinite(recentTailSize) || recentTailSize <= 0) return 0;
+  return Math.trunc(recentTailSize);
+}
+
+async function collectRecentTailMessages(
+  session: Session,
+  recentTailSize: number,
+): Promise<Array<{ peerId: string; createdAt?: string; content: string }>> {
+  const limit = normalizeRecentTailSize(recentTailSize);
+  if (limit <= 0) return [];
+
+  let page = await session.messages({
+    size: Math.min(limit, HONCHO_MESSAGES_LIST_MAX_SIZE),
+    reverse: true,
+  });
+  const messages = [...page.items];
+
+  while (messages.length < limit && page.hasNextPage) {
+    const nextPage = await page.getNextPage();
+    if (!nextPage) break;
+    page = nextPage;
+    messages.push(...page.items);
+  }
+
+  return messages.slice(0, limit);
+}
+
+export async function dedupeAgainstRecentTail(
   session: Session,
   extracted: MessageInput[],
   recentTailSize: number,
@@ -54,14 +83,12 @@ async function dedupeAgainstRecentTail(
     batchUnique.push(message);
   }
 
-  if (batchUnique.length === 0 || recentTailSize <= 0) return batchUnique;
+  const tailSize = normalizeRecentTailSize(recentTailSize);
+  if (batchUnique.length === 0 || tailSize <= 0) return batchUnique;
 
-  const recentPage = await session.messages({
-    size: Math.min(Math.max(recentTailSize, 1), 500),
-    reverse: true,
-  });
+  const recentMessages = await collectRecentTailMessages(session, tailSize);
   const recentSignatures = new Set(
-    recentPage.items
+    recentMessages
       .map((message) => messageSignature(message))
       .filter((signature): signature is string => typeof signature === "string"),
   );

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -1,11 +1,12 @@
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
-import { buildSessionKey, extractSenderId, isSubagentSession } from "../helpers.js";
+import { buildSessionKey, extractSenderId, isSubagentSession, shouldIsolateSession } from "../helpers.js";
 
 export function registerContextHook(api: OpenClawPluginApi, state: PluginState): void {
   api.on("before_prompt_build", async (event, ctx) => {
     if (!event.prompt || event.prompt.length < 5) return;
+    if (shouldIsolateSession(ctx, state.cfg.isolatedSessionPatterns) && !isSubagentSession(ctx)) return;
 
     const sessionKey = buildSessionKey(ctx);
     const agentId = ctx.agentId ?? state.resolveDefaultAgentId();
@@ -30,10 +31,10 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
       if (isSubagent) {
         try {
           const peerCtx = await agentPeer.context({ target: participantPeer });
-          if (peerCtx.peerCard?.length) {
+          if (state.cfg.contextInjection.peerCard && peerCtx.peerCard?.length) {
             sections.push(`Key facts:\n${peerCtx.peerCard.map((f: string) => `• ${f}`).join("\n")}`);
           }
-          if (peerCtx.representation) {
+          if (state.cfg.contextInjection.representation === "full" && peerCtx.representation) {
             sections.push(`User context:\n${peerCtx.representation}`);
           }
         } catch (e: unknown) {
@@ -49,7 +50,7 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
         let context;
         try {
           context = await session.context({
-            summary: true,
+            summary: state.cfg.contextInjection.sessionSummary,
             tokens: 2000,
             peerTarget: participantPeer,
             peerPerspective: agentPeer,
@@ -62,13 +63,13 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
           throw e;
         }
 
-        if (context.peerCard?.length) {
+        if (state.cfg.contextInjection.peerCard && context.peerCard?.length) {
           sections.push(`Key facts:\n${context.peerCard.map((f) => `• ${f}`).join("\n")}`);
         }
-        if (context.peerRepresentation) {
+        if (state.cfg.contextInjection.representation === "full" && context.peerRepresentation) {
           sections.push(`User context:\n${context.peerRepresentation}`);
         }
-        if (context.summary?.content) {
+        if (state.cfg.contextInjection.sessionSummary && context.summary?.content) {
           sections.push(`Earlier in this conversation:\n${context.summary.content}`);
         }
       }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,7 +24,9 @@
       },
       "noisePatterns": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Additional substring patterns to skip messages. Built-in defaults (HEARTBEAT_OK, cron reminders, etc.) always apply."
       },
       "ownerObserveOthers": {
@@ -35,12 +37,71 @@
       "disableDefaultNoisePatterns": {
         "type": "boolean",
         "default": false,
-        "description": "When true, built-in noise patterns are not applied — only noisePatterns entries are used."
+        "description": "When true, built-in noise patterns are not applied \u2014 only noisePatterns entries are used."
       },
       "crossSessionSearch": {
         "type": "boolean",
         "default": true,
         "description": "When true (default), memory_search/memory_get can return results from any session in the workspace. When false, results are scoped to the active session and its child sessions only."
+      },
+      "contextInjection": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Controls which Honcho context sections are injected into the prompt by default.",
+        "properties": {
+          "peerCard": {
+            "type": "boolean",
+            "default": true,
+            "description": "Inject compact key facts about the active participant."
+          },
+          "sessionSummary": {
+            "type": "boolean",
+            "default": true,
+            "description": "Inject the current session summary when available."
+          },
+          "representation": {
+            "type": "string",
+            "enum": [
+              "off",
+              "full"
+            ],
+            "default": "full",
+            "description": "Whether to inject the full Honcho peer representation by default. Set to off to reduce prompt size."
+          }
+        }
+      },
+      "stripRuntimeScaffolding": {
+        "type": "boolean",
+        "default": true,
+        "description": "Strip OpenClaw startup/reset/runtime scaffolding from messages before saving them to Honcho."
+      },
+      "isolatedSessionPatterns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Regex-like patterns for session keys that should not be captured into Honcho. Use /pattern/flags syntax for regular expressions, or plain substrings.",
+        "default": [
+          "/(^|[:-])cron([:-]|$)/i",
+          "/(^|[:-])subagent([:-]|$)/i",
+          "/(^|[:-])heartbeat([:-]|$)/i",
+          "/temp[-:]slug[-:]generator/i"
+        ]
+      },
+      "recentTailDedupeSize": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 200,
+        "description": "When greater than 0, compare new captured messages against this many recent Honcho messages and skip duplicates."
+      },
+      "memoryBackend": {
+        "type": "string",
+        "enum": [
+          "qmd",
+          "builtin"
+        ],
+        "default": "qmd",
+        "description": "Memory runtime backend descriptor exposed to OpenClaw. qmd preserves legacy compatibility; builtin avoids pretending Honcho is QMD on newer OpenClaw builds."
       }
     }
   },
@@ -80,12 +141,38 @@
     "disableDefaultNoisePatterns": {
       "label": "Disable Default Noise Patterns",
       "advanced": true,
-      "help": "When enabled, only custom noisePatterns entries are used — built-in defaults are skipped."
+      "help": "When enabled, only custom noisePatterns entries are used \u2014 built-in defaults are skipped."
     },
     "crossSessionSearch": {
       "label": "Cross-Session Search",
       "advanced": true,
       "help": "When enabled (default), memory tools can return results from any session in the workspace. Disable to scope results to the active session only."
+    },
+    "contextInjection": {
+      "label": "Context Injection",
+      "advanced": true,
+      "help": "Choose whether prompt injection includes peer facts, session summary, and full representation."
+    },
+    "stripRuntimeScaffolding": {
+      "label": "Strip Runtime Scaffolding",
+      "advanced": true,
+      "help": "Remove /new, reset, and runtime metadata boilerplate before storing messages."
+    },
+    "isolatedSessionPatterns": {
+      "label": "Isolated Session Patterns",
+      "advanced": true,
+      "help": "Skip Honcho capture for matching session keys, such as cron or heartbeat sessions."
+    },
+    "recentTailDedupeSize": {
+      "label": "Recent Tail Dedupe Size",
+      "advanced": true,
+      "placeholder": "200",
+      "help": "Set to 0 to disable. Higher values reduce duplicate persistence after compaction/reset retries."
+    },
+    "memoryBackend": {
+      "label": "Memory Backend Descriptor",
+      "advanced": true,
+      "help": "Use qmd for compatibility or builtin for newer OpenClaw memory runtimes."
     }
   }
 }

--- a/runtime.ts
+++ b/runtime.ts
@@ -230,7 +230,7 @@ export async function getHonchoMemorySearchManager(
 
       status() {
         return {
-          backend: "qmd",
+          backend: state.cfg.memoryBackend,
           provider: isLocalHonchoBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
           model: "n/a",
           sources: ["sessions"],
@@ -255,9 +255,16 @@ export async function getHonchoMemorySearchManager(
 
 /** Resolve the memory backend descriptor expected by the OpenClaw memory slot. */
 export function resolveHonchoMemoryBackendConfig(
-  params: { sessionKey?: string; messageProvider?: string } = {}
+  params: { sessionKey?: string; messageProvider?: string } = {},
+  memoryBackend: PluginState["cfg"]["memoryBackend"] = "qmd",
 ) {
   const sessionKey = buildSessionKey(params);
+  if (memoryBackend === "builtin") {
+    return {
+      backend: "builtin",
+      sessionKey,
+    };
+  }
   return {
     backend: "qmd",
     qmd: {},
@@ -277,7 +284,7 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
     },
 
     resolveMemoryBackendConfig(params: { sessionKey?: string; messageProvider?: string } = {}) {
-      return resolveHonchoMemoryBackendConfig(params);
+      return resolveHonchoMemoryBackendConfig(params, state.cfg.memoryBackend);
     },
   });
 }

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { dedupeAgainstRecentTail, HONCHO_MESSAGES_LIST_MAX_SIZE } from "../hooks/capture.js";
+import type { MessageInput } from "@honcho-ai/sdk";
+
+type FakeMessage = { peerId: string; createdAt?: string; content: string };
+
+function page(items: FakeMessage[], pageNo: number, pages: number) {
+  return {
+    items,
+    hasNextPage: pageNo < pages,
+    getNextPage: vi.fn(async () => null),
+  };
+}
+
+describe("dedupeAgainstRecentTail", () => {
+  it("never requests more than Honcho's messages/list max page size", async () => {
+    const recent = page([
+      { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "already saved" },
+    ], 1, 1);
+    const session = {
+      messages: vi.fn(async () => recent),
+    };
+    const extracted: MessageInput[] = [
+      { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "already saved" },
+      { peerId: "owner", createdAt: "2026-04-30T00:00:01Z", content: "new" },
+    ];
+
+    const result = await dedupeAgainstRecentTail(session as never, extracted, 200);
+
+    expect(session.messages).toHaveBeenCalledWith({
+      size: HONCHO_MESSAGES_LIST_MAX_SIZE,
+      reverse: true,
+    });
+    expect(result).toEqual([
+      { peerId: "owner", createdAt: "2026-04-30T00:00:01Z", content: "new" },
+    ]);
+  });
+
+  it("walks additional pages when the configured tail is larger than one Honcho page", async () => {
+    const second = page(
+      [{ peerId: "owner", createdAt: "2026-04-30T00:00:42Z", content: "older duplicate" }],
+      2,
+      2,
+    );
+    const first = page([], 1, 2);
+    first.getNextPage = vi.fn(async () => second);
+    const session = {
+      messages: vi.fn(async () => first),
+    };
+    const extracted: MessageInput[] = [
+      { peerId: "owner", createdAt: "2026-04-30T00:00:42Z", content: "older duplicate" },
+      { peerId: "owner", createdAt: "2026-04-30T00:00:43Z", content: "new" },
+    ];
+
+    const result = await dedupeAgainstRecentTail(session as never, extracted, 200);
+
+    expect(first.getNextPage).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { peerId: "owner", createdAt: "2026-04-30T00:00:43Z", content: "new" },
+    ]);
+  });
+});

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractSenderId } from "../helpers.js";
+import { buildSessionKey, cleanMessageContent, extractSenderId, shouldIsolateSession } from "../helpers.js";
 
 const SENTINEL = "Conversation info (untrusted metadata):";
 
@@ -78,5 +78,81 @@ describe("extractSenderId", () => {
   it("returns undefined when the content has no metadata block", () => {
     expect(extractSenderId("just a normal DM")).toBeUndefined();
     expect(extractSenderId("")).toBeUndefined();
+  });
+});
+
+describe("buildSessionKey", () => {
+  it("preserves explicit messageProvider behavior", () => {
+    expect(
+      buildSessionKey({
+        sessionKey: "agent:saber:feishu:default:direct:ou_xxx",
+        messageProvider: "telegram",
+      })
+    ).toBe("agent-saber-feishu-default-direct-ou-xxx-telegram");
+  });
+
+  it("infers the provider from canonical agent session keys when omitted", () => {
+    expect(
+      buildSessionKey({
+        sessionKey: "agent:saber:feishu:default:direct:ou_xxx",
+      })
+    ).toBe("agent-saber-feishu-default-direct-ou-xxx-feishu");
+  });
+
+  it("infers the provider from per-channel direct session keys", () => {
+    expect(
+      buildSessionKey({
+        sessionKey: "agent:saber:discord:direct:user_123",
+      })
+    ).toBe("agent-saber-discord-direct-user-123-discord");
+  });
+
+  it("keeps unknown as the last-resort fallback", () => {
+    expect(
+      buildSessionKey({
+        sessionKey: "agent:saber:direct:user_123",
+      })
+    ).toBe("agent-saber-direct-user-123-unknown");
+  });
+});
+
+describe("cleanMessageContent", () => {
+  it("drops runtime startup scaffolding entirely", () => {
+    const raw = `System: [2026-04-22 16:07:57 GMT+8] Feishu[default] DM | ou_xxx [msg:om_123]\n\n[Startup context loaded by runtime]\nBootstrap files like SOUL.md are already provided separately.\nA new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user.\nCurrent time: Wednesday, April 22nd, 2026 - 4:08 PM (Asia/Shanghai)`;
+    expect(cleanMessageContent(raw)).toBe("");
+  });
+
+  it("keeps the actual user text after stripping leading system envelope", () => {
+    const raw = `System: [2026-04-22 19:17:01 GMT+8] Feishu[saber-cn] DM | ou_xxx [msg:om_456]\n\n\n这个直接删掉，没用了`;
+    expect(cleanMessageContent(raw)).toBe("这个直接删掉，没用了");
+  });
+
+  it("can keep runtime scaffolding when configured", () => {
+    const raw = `System: [2026-04-22 19:17:01 GMT+8] Feishu[saber-cn] DM | ou_xxx [msg:om_456]\n\n正文`;
+    expect(cleanMessageContent(raw, { stripRuntimeScaffolding: false })).toContain("System:");
+  });
+
+  it("drops reply control tags after cleanup", () => {
+    expect(cleanMessageContent("[[reply_to_current]] 已收到")).toBe("已收到");
+  });
+});
+
+describe("shouldIsolateSession", () => {
+  const patterns = [
+    "/(^|[:-])cron([:-]|$)/i",
+    "/(^|[:-])subagent([:-]|$)/i",
+    "/(^|[:-])heartbeat([:-]|$)/i",
+    "/temp[-:]slug[-:]generator/i",
+  ];
+
+  it("isolates cron, subagent, heartbeat, and temp slug sessions", () => {
+    expect(shouldIsolateSession({ sessionKey: "agent:saber:cron:job-123" }, patterns)).toBe(true);
+    expect(shouldIsolateSession({ sessionKey: "agent:saber:subagent:child-123" }, patterns)).toBe(true);
+    expect(shouldIsolateSession({ sessionKey: "agent:main:main-heartbeat" }, patterns)).toBe(true);
+    expect(shouldIsolateSession({ sessionKey: "temp-slug-generator" }, patterns)).toBe(true);
+  });
+
+  it("keeps normal direct chat sessions in the main bank", () => {
+    expect(shouldIsolateSession({ sessionKey: "agent:saber:feishu:default:direct:ou_xxx" }, patterns)).toBe(false);
   });
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -155,4 +155,8 @@ describe("shouldIsolateSession", () => {
   it("keeps normal direct chat sessions in the main bank", () => {
     expect(shouldIsolateSession({ sessionKey: "agent:saber:feishu:default:direct:ou_xxx" }, patterns)).toBe(false);
   });
+
+  it("does not treat invalid regex-like patterns as literal substring matches", () => {
+    expect(shouldIsolateSession({ sessionKey: "agent:saber:cron:job-123" }, ["/[cron/"])).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- add configurable Honcho context injection controls for peer cards, session summaries, and full representations
- make capture hygiene configurable: runtime-scaffolding stripping, isolated session patterns, and recent-tail dedupe
- preserve legacy QMD memory backend behavior while allowing newer OpenClaw builds to request the builtin backend descriptor
- add tests covering message cleaning, isolation patterns, and dedupe helpers

## Validation

- `pnpm exec vitest run`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context injection controls to customize what conversation context is stored and shared
  * Added session isolation patterns to skip capturing specific session types
  * Implemented message deduplication to prevent duplicate messages in memory
  * Added option to clean up runtime scaffolding from message content
  * Added configurable memory backend selection for different storage modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->