### PR TITLE
feat: add honcho context injection controls

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -9,6 +9,15 @@ export const DEFAULT_NOISE_PATTERNS: string[] = [
   "Queued messages from",
 ];
 
+export type ContextInjectionMode = "off" | "full";
+export type MemoryBackendMode = "qmd" | "builtin";
+
+export type HonchoContextInjectionConfig = {
+  peerCard: boolean;
+  sessionSummary: boolean;
+  representation: ContextInjectionMode;
+};
+
 export type HonchoConfig = {
   apiKey?: string;
   workspaceId: string;
@@ -18,6 +27,8 @@ export type HonchoConfig = {
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
   crossSessionSearch: boolean;
+  contextInjection: HonchoContextInjectionConfig;
+  memoryBackend: MemoryBackendMode;
 };
 
 /**
@@ -57,6 +68,25 @@ export const honchoConfigSchema = {
       ...new Set([...(disableDefaultNoisePatterns ? [] : DEFAULT_NOISE_PATTERNS), ...userPatterns]),
     ];
 
+    const contextInjectionCfg =
+      typeof cfg.contextInjection === "object" && cfg.contextInjection !== null
+        ? (cfg.contextInjection as Record<string, unknown>)
+        : {};
+    const representationRaw =
+      typeof contextInjectionCfg.representation === "string"
+        ? contextInjectionCfg.representation
+        : process.env.HONCHO_CONTEXT_REPRESENTATION;
+    const representation: ContextInjectionMode =
+      representationRaw === "off" || representationRaw === "full" ? representationRaw : "full";
+    const contextInjection: HonchoContextInjectionConfig = {
+      peerCard: typeof contextInjectionCfg.peerCard === "boolean" ? contextInjectionCfg.peerCard : true,
+      sessionSummary:
+        typeof contextInjectionCfg.sessionSummary === "boolean" ? contextInjectionCfg.sessionSummary : true,
+      representation,
+    };
+
+    const memoryBackend: MemoryBackendMode = cfg.memoryBackend === "builtin" ? "builtin" : "qmd";
+
     return {
       apiKey,
       workspaceId:
@@ -81,6 +111,8 @@ export const honchoConfigSchema = {
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
       crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,
+      contextInjection,
+      memoryBackend,
     };
   },
 };

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -30,10 +30,10 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
       if (isSubagent) {
         try {
           const peerCtx = await agentPeer.context({ target: participantPeer });
-          if (peerCtx.peerCard?.length) {
+          if (state.cfg.contextInjection.peerCard && peerCtx.peerCard?.length) {
             sections.push(`Key facts:\n${peerCtx.peerCard.map((f: string) => `• ${f}`).join("\n")}`);
           }
-          if (peerCtx.representation) {
+          if (state.cfg.contextInjection.representation === "full" && peerCtx.representation) {
             sections.push(`User context:\n${peerCtx.representation}`);
           }
         } catch (e: unknown) {
@@ -49,7 +49,7 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
         let context;
         try {
           context = await session.context({
-            summary: true,
+            summary: state.cfg.contextInjection.sessionSummary,
             tokens: 2000,
             peerTarget: participantPeer,
             peerPerspective: agentPeer,
@@ -62,13 +62,13 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
           throw e;
         }
 
-        if (context.peerCard?.length) {
+        if (state.cfg.contextInjection.peerCard && context.peerCard?.length) {
           sections.push(`Key facts:\n${context.peerCard.map((f) => `• ${f}`).join("\n")}`);
         }
-        if (context.peerRepresentation) {
+        if (state.cfg.contextInjection.representation === "full" && context.peerRepresentation) {
           sections.push(`User context:\n${context.peerRepresentation}`);
         }
-        if (context.summary?.content) {
+        if (state.cfg.contextInjection.sessionSummary && context.summary?.content) {
           sections.push(`Earlier in this conversation:\n${context.summary.content}`);
         }
       }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,7 +24,9 @@
       },
       "noisePatterns": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Additional substring patterns to skip messages. Built-in defaults (HEARTBEAT_OK, cron reminders, etc.) always apply."
       },
       "ownerObserveOthers": {
@@ -41,6 +43,41 @@
         "type": "boolean",
         "default": true,
         "description": "When true (default), memory_search/memory_get can return results from any session in the workspace. When false, results are scoped to the active session and its child sessions only."
+      },
+      "contextInjection": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Controls which Honcho context sections are injected into the prompt by default.",
+        "properties": {
+          "peerCard": {
+            "type": "boolean",
+            "default": true,
+            "description": "Inject compact key facts about the active participant."
+          },
+          "sessionSummary": {
+            "type": "boolean",
+            "default": true,
+            "description": "Inject the current session summary when available."
+          },
+          "representation": {
+            "type": "string",
+            "enum": [
+              "off",
+              "full"
+            ],
+            "default": "full",
+            "description": "Whether to inject the full Honcho peer representation by default. Set to off to reduce prompt size."
+          }
+        }
+      },
+      "memoryBackend": {
+        "type": "string",
+        "enum": [
+          "qmd",
+          "builtin"
+        ],
+        "default": "qmd",
+        "description": "Memory runtime backend descriptor exposed to OpenClaw. qmd preserves legacy compatibility; builtin avoids pretending Honcho is QMD on newer OpenClaw builds."
       }
     }
   },
@@ -86,6 +123,16 @@
       "label": "Cross-Session Search",
       "advanced": true,
       "help": "When enabled (default), memory tools can return results from any session in the workspace. Disable to scope results to the active session only."
+    },
+    "contextInjection": {
+      "label": "Context Injection",
+      "advanced": true,
+      "help": "Choose whether prompt injection includes peer facts, session summary, and full representation."
+    },
+    "memoryBackend": {
+      "label": "Memory Backend Descriptor",
+      "advanced": true,
+      "help": "Use qmd for compatibility or builtin for newer OpenClaw memory runtimes."
     }
   }
 }

--- a/runtime.ts
+++ b/runtime.ts
@@ -230,7 +230,7 @@ export async function getHonchoMemorySearchManager(
 
       status() {
         return {
-          backend: "qmd",
+          backend: state.cfg.memoryBackend,
           provider: isLocalHonchoBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
           model: "n/a",
           sources: ["sessions"],
@@ -255,9 +255,16 @@ export async function getHonchoMemorySearchManager(
 
 /** Resolve the memory backend descriptor expected by the OpenClaw memory slot. */
 export function resolveHonchoMemoryBackendConfig(
-  params: { sessionKey?: string; messageProvider?: string } = {}
+  params: { sessionKey?: string; messageProvider?: string } = {},
+  memoryBackend: PluginState["cfg"]["memoryBackend"] = "qmd",
 ) {
   const sessionKey = buildSessionKey(params);
+  if (memoryBackend === "builtin") {
+    return {
+      backend: "builtin",
+      sessionKey,
+    };
+  }
   return {
     backend: "qmd",
     qmd: {},
@@ -277,7 +284,7 @@ export function registerHonchoMemoryRuntime(api: any, state: PluginState): void 
     },
 
     resolveMemoryBackendConfig(params: { sessionKey?: string; messageProvider?: string } = {}) {
-      return resolveHonchoMemoryBackendConfig(params);
+      return resolveHonchoMemoryBackendConfig(params, state.cfg.memoryBackend);
     },
   });
 }

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -124,6 +124,8 @@ function createState(baseUrl = "https://api.honcho.dev", { crossSessionSearch = 
       disableDefaultNoisePatterns: false,
       ownerObserveOthers: false,
       crossSessionSearch,
+      contextInjection: { peerCard: true, sessionSummary: true, representation: "full" },
+      memoryBackend: "qmd",
     },
     honcho: {
       session: vi.fn(async (sessionId: string) => createSession(sessionId)),
@@ -221,6 +223,7 @@ describe("Honcho memory runtime", () => {
     expect(file.path).toBe("sessions/session-1.txt");
     expect(file.text).toContain("# Summary");
     expect(file.text).toContain("Summary for session one");
+    expect(manager.status().backend).toBe("qmd");
     expect(manager.status().provider).toBe("honcho-selfhosted");
     await expect(
       manager.readFile({
@@ -236,6 +239,18 @@ describe("Honcho memory runtime", () => {
     ).toEqual({
       backend: "qmd",
       qmd: {},
+      sessionKey: "agent-main-dashboard-test-telegram",
+    });
+    expect(
+      resolveHonchoMemoryBackendConfig(
+        {
+          sessionKey: "agent:main:dashboard:test",
+          messageProvider: "telegram",
+        },
+        "builtin",
+      ),
+    ).toEqual({
+      backend: "builtin",
       sessionKey: "agent-main-dashboard-test-telegram",
     });
   });


### PR DESCRIPTION
## Summary

- add configurable Honcho prompt context injection controls for peer cards, session summaries, and full representations
- allow newer OpenClaw runtimes to request a builtin memory backend descriptor while preserving qmd as the default
- update plugin schema/UI hints and runtime coverage for the new backend descriptor

This is split out from #78 and intentionally avoids capture-path changes.

## Validation

- `pnpm exec vitest run test/runtime.test.ts`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable context injection: toggle peer card, toggle session summary, and choose representation (off/full).
  * Selectable memory backend (qmd or builtin); system status now reports the active backend.
  * All options exposed and manageable via the plugin settings UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->