### PR TITLE
feat: add honcho capture hygiene controls

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -4,9 +4,16 @@
 
 export const DEFAULT_NOISE_PATTERNS: string[] = [
   "HEARTBEAT_OK",
+  "NO_REPLY",
   "A scheduled reminder has been triggered",
   "Execute your Session Startup sequence now",
   "Queued messages from",
+];
+
+export const DEFAULT_ISOLATED_SESSION_PATTERNS: string[] = [
+  "/(^|[:-])cron([:-]|$)/i",
+  "/(^|[:-])heartbeat([:-]|$)/i",
+  "/temp[-:]slug[-:]generator/i",
 ];
 
 export type HonchoConfig = {
@@ -18,6 +25,8 @@ export type HonchoConfig = {
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
   crossSessionSearch: boolean;
+  stripRuntimeScaffolding: boolean;
+  isolatedSessionPatterns: string[];
 };
 
 /**
@@ -34,6 +43,15 @@ function resolveEnvVars(value: string): string {
   });
 }
 
+function parseStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .filter((p): p is string => typeof p === "string")
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+    : [];
+}
+
 export const honchoConfigSchema = {
   parse(value: unknown): HonchoConfig {
     const cfg = (value ?? {}) as Record<string, unknown>;
@@ -47,14 +65,12 @@ export const honchoConfigSchema = {
     }
 
     const disableDefaultNoisePatterns = cfg.disableDefaultNoisePatterns === true;
-    const userPatterns = Array.isArray(cfg.noisePatterns)
-      ? (cfg.noisePatterns as unknown[])
-          .filter((p): p is string => typeof p === "string")
-          .map((p) => p.trim())
-          .filter((p) => p.length > 0)
-      : [];
+    const userPatterns = parseStringArray(cfg.noisePatterns)
     const noisePatterns = [
       ...new Set([...(disableDefaultNoisePatterns ? [] : DEFAULT_NOISE_PATTERNS), ...userPatterns]),
+    ];
+    const isolatedSessionPatterns = [
+      ...new Set([...DEFAULT_ISOLATED_SESSION_PATTERNS, ...parseStringArray(cfg.isolatedSessionPatterns)]),
     ];
 
     return {
@@ -81,6 +97,9 @@ export const honchoConfigSchema = {
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
       crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,
+      stripRuntimeScaffolding:
+        typeof cfg.stripRuntimeScaffolding === "boolean" ? cfg.stripRuntimeScaffolding : true,
+      isolatedSessionPatterns,
     };
   },
 };

--- a/helpers.ts
+++ b/helpers.ts
@@ -6,6 +6,13 @@ import type { Peer, MessageInput } from "@honcho-ai/sdk";
 
 type ContentBlock = { type?: string; text?: unknown };
 type RawMessage = { role?: string; content?: string | ContentBlock[]; timestamp?: number };
+export type CleanMessageOptions = { stripRuntimeScaffolding?: boolean };
+
+const LEADING_SYSTEM_LINE_RE = /^System(?: \(untrusted\))?: /;
+const STARTUP_CONTEXT_BLOCK_RE =
+  /\[Startup context loaded by runtime\][\s\S]*?(?:Current time:[^\n]*(?:\n|$)|$)/gi;
+const STARTUP_ONLY_LINE_RE =
+  /^(?:A new session was started via \/new or \/reset\..*|Note: The previous agent run was aborted by the user\..*|Current time: .*|Resume carefully or ask for clarification\.)$/gim;
 
 /**
  * Extract plain text from a message's `content` (string or array of content blocks).
@@ -38,6 +45,58 @@ export function buildSessionKey(ctx?: { sessionKey?: string; messageProvider?: s
 
 export function isSubagentSession(ctx?: { sessionKey?: string }): boolean {
   return (ctx?.sessionKey ?? "").includes(":subagent:");
+}
+
+function stripLeadingSystemEnvelope(text: string): string {
+  const lines = text.split("\n");
+  let index = 0;
+
+  while (index < lines.length && lines[index].trim() === "") {
+    index += 1;
+  }
+
+  while (index < lines.length && LEADING_SYSTEM_LINE_RE.test(lines[index].trim())) {
+    index += 1;
+    while (
+      index < lines.length &&
+      (lines[index].trim() === "" || LEADING_SYSTEM_LINE_RE.test(lines[index].trim()))
+    ) {
+      index += 1;
+    }
+  }
+
+  return lines.slice(index).join("\n");
+}
+
+function compilePattern(pattern: string): RegExp | null {
+  if (!pattern.startsWith("/")) return null;
+  const lastSlash = pattern.lastIndexOf("/", pattern.length - 1);
+  if (lastSlash <= 0) return null;
+  const source = pattern.slice(1, lastSlash);
+  const flags = pattern.slice(lastSlash + 1);
+  try {
+    return new RegExp(source, flags);
+  } catch {
+    return null;
+  }
+}
+
+function matchesPattern(value: string, pattern: string): boolean {
+  if (pattern.startsWith("/")) {
+    const re = compilePattern(pattern);
+    return re ? re.test(value) : false;
+  }
+  return value.includes(pattern);
+}
+
+export function shouldIsolateSession(
+  ctx?: { sessionKey?: string; messageProvider?: string },
+  patterns: string[] = [],
+): boolean {
+  if (patterns.length === 0) return false;
+  const raw = String(ctx?.sessionKey ?? "");
+  const built = buildSessionKey(ctx);
+  return patterns.some((pattern) => matchesPattern(raw, pattern) || matchesPattern(built, pattern));
 }
 
 /**
@@ -147,13 +206,21 @@ function stripInboundMetadata(text: string): string {
  * Also strips leading OpenClaw reply directive tags (e.g. [[reply_to_current]])
  * so control tokens are never persisted or re-surfaced as user-visible text.
  */
-export function cleanMessageContent(content: string): string {
+export function cleanMessageContent(content: string, options: CleanMessageOptions = {}): string {
+  const { stripRuntimeScaffolding = true } = options;
   let cleaned = content;
   // Strip Honcho memory context tags (prevent re-injection loops).
   cleaned = cleaned.replace(/<honcho-memory[^>]*>[\s\S]*?<\/honcho-memory>\s*/gi, "");
   cleaned = cleaned.replace(/<!--[^>]*honcho[^>]*-->\s*/gi, "");
   // Strip OpenClaw inbound metadata using OpenClaw-equivalent parser logic.
   cleaned = stripInboundMetadata(cleaned);
+  if (stripRuntimeScaffolding) {
+    // Strip runtime/system envelope lines before checking for startup-only content.
+    cleaned = stripLeadingSystemEnvelope(cleaned);
+    // Strip first-turn startup scaffolding and reset-resume hints.
+    cleaned = cleaned.replace(STARTUP_CONTEXT_BLOCK_RE, "");
+    cleaned = cleaned.replace(STARTUP_ONLY_LINE_RE, "");
+  }
   // Strip leading reply directive control tokens.
   cleaned = cleaned.replace(
     /^(\s*\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*)+/gi,
@@ -234,6 +301,7 @@ export function extractMessages(
   agentPeer: Peer,
   noisePatterns: string[] = [],
   resolvePeer?: (senderId: string) => Peer | undefined,
+  cleanOptions: CleanMessageOptions = {},
 ): MessageInput[] {
   const result: MessageInput[] = [];
 
@@ -255,7 +323,7 @@ export function extractMessages(
       peer = agentPeer;
     }
 
-    let content = cleanMessageContent(rawContent);
+    let content = cleanMessageContent(rawContent, cleanOptions);
     content = content.trim();
 
     if (!content) continue;

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -5,6 +5,7 @@ import { OWNER_ID } from "../state.js";
 import {
   buildSessionKey,
   isSubagentSession,
+  shouldIsolateSession,
   extractMessages,
   extractSenderId,
   getRawContent,
@@ -22,6 +23,7 @@ async function flushMessages(
   ctx: { sessionKey?: string; agentId?: string; messageProvider?: string },
 ): Promise<number> {
   if (!messages?.length) return 0;
+  if (shouldIsolateSession(ctx, state.cfg.isolatedSessionPatterns)) return 0;
 
   const sessionKey = buildSessionKey(ctx);
   const agentId = ctx.agentId ?? state.resolveDefaultAgentId();
@@ -120,6 +122,7 @@ async function flushMessages(
     agentPeer,
     state.cfg.noisePatterns,
     (senderId) => resolvedPeers.get(senderId),
+    { stripRuntimeScaffolding: state.cfg.stripRuntimeScaffolding },
   );
 
   // participantSenderId = last active sender, used by tools to resolve the

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,7 +24,9 @@
       },
       "noisePatterns": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Additional substring patterns to skip messages. Built-in defaults (HEARTBEAT_OK, cron reminders, etc.) always apply."
       },
       "ownerObserveOthers": {
@@ -41,6 +43,23 @@
         "type": "boolean",
         "default": true,
         "description": "When true (default), memory_search/memory_get can return results from any session in the workspace. When false, results are scoped to the active session and its child sessions only."
+      },
+      "stripRuntimeScaffolding": {
+        "type": "boolean",
+        "default": true,
+        "description": "Strip OpenClaw startup/reset/runtime scaffolding from messages before saving them to Honcho."
+      },
+      "isolatedSessionPatterns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Regex-like patterns for session keys that should not be captured into Honcho. Use /pattern/flags syntax for regular expressions, or plain substrings. Subagent sessions are captured by default; add a subagent pattern only if you explicitly want to isolate them.",
+        "default": [
+          "/(^|[:-])cron([:-]|$)/i",
+          "/(^|[:-])heartbeat([:-]|$)/i",
+          "/temp[-:]slug[-:]generator/i"
+        ]
       }
     }
   },
@@ -86,6 +105,16 @@
       "label": "Cross-Session Search",
       "advanced": true,
       "help": "When enabled (default), memory tools can return results from any session in the workspace. Disable to scope results to the active session only."
+    },
+    "stripRuntimeScaffolding": {
+      "label": "Strip Runtime Scaffolding",
+      "advanced": true,
+      "help": "Remove /new, reset, and runtime metadata boilerplate before storing messages."
+    },
+    "isolatedSessionPatterns": {
+      "label": "Isolated Session Patterns",
+      "advanced": true,
+      "help": "Skip Honcho capture for matching session keys, such as cron or heartbeat sessions. Subagents are not skipped by default."
     }
   }
 }

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { extractSenderId } from "../helpers.js";
+import { cleanMessageContent, extractSenderId, shouldIsolateSession } from "../helpers.js";
+import { DEFAULT_ISOLATED_SESSION_PATTERNS } from "../config.js";
 
 const SENTINEL = "Conversation info (untrusted metadata):";
 
@@ -78,5 +79,57 @@ describe("extractSenderId", () => {
   it("returns undefined when the content has no metadata block", () => {
     expect(extractSenderId("just a normal DM")).toBeUndefined();
     expect(extractSenderId("")).toBeUndefined();
+  });
+});
+
+
+describe("cleanMessageContent", () => {
+  it("drops runtime startup scaffolding entirely", () => {
+    const raw = `System: [2026-04-22 16:07:57 GMT+8] Feishu[default] DM | ou_xxx [msg:om_123]
+
+[Startup context loaded by runtime]
+Bootstrap files like SOUL.md are already provided separately.
+A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user.
+Current time: Wednesday, April 22nd, 2026 - 4:08 PM (Asia/Shanghai)`;
+    expect(cleanMessageContent(raw)).toBe("");
+  });
+
+  it("keeps the actual user text after stripping leading system envelope", () => {
+    const raw = `System: [2026-04-22 19:17:01 GMT+8] Feishu[saber-cn] DM | ou_xxx [msg:om_456]
+
+
+这个直接删掉，没用了`;
+    expect(cleanMessageContent(raw)).toBe("这个直接删掉，没用了");
+  });
+
+  it("can keep runtime scaffolding when configured", () => {
+    const raw = `System: [2026-04-22 19:17:01 GMT+8] Feishu[saber-cn] DM | ou_xxx [msg:om_456]
+
+正文`;
+    expect(cleanMessageContent(raw, { stripRuntimeScaffolding: false })).toContain("System:");
+  });
+
+  it("drops reply control tags after cleanup", () => {
+    expect(cleanMessageContent("[[reply_to_current]] 已收到")).toBe("已收到");
+  });
+});
+
+describe("shouldIsolateSession", () => {
+  it("isolates cron, heartbeat, and temp slug sessions by default", () => {
+    expect(shouldIsolateSession({ sessionKey: "agent:saber:cron:job-123" }, DEFAULT_ISOLATED_SESSION_PATTERNS)).toBe(true);
+    expect(shouldIsolateSession({ sessionKey: "agent:main:main-heartbeat" }, DEFAULT_ISOLATED_SESSION_PATTERNS)).toBe(true);
+    expect(shouldIsolateSession({ sessionKey: "temp-slug-generator" }, DEFAULT_ISOLATED_SESSION_PATTERNS)).toBe(true);
+  });
+
+  it("does not isolate subagent sessions by default", () => {
+    expect(shouldIsolateSession({ sessionKey: "agent:saber:subagent:child-123" }, DEFAULT_ISOLATED_SESSION_PATTERNS)).toBe(false);
+  });
+
+  it("keeps normal direct chat sessions in the main bank", () => {
+    expect(shouldIsolateSession({ sessionKey: "agent:saber:feishu:default:direct:ou_xxx" }, DEFAULT_ISOLATED_SESSION_PATTERNS)).toBe(false);
+  });
+
+  it("does not treat invalid regex-like patterns as literal substring matches", () => {
+    expect(shouldIsolateSession({ sessionKey: "agent:saber:cron:job-123" }, ["/[cron/"])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- strip OpenClaw startup/reset/runtime scaffolding before persisting messages to Honcho
- add configurable session isolation patterns for capture, defaulting to cron/heartbeat/temp utility sessions only
- add `NO_REPLY` to default noise patterns and keep subagent sessions captured by default

This is split out from #78 and intentionally excludes prompt-injection controls and dedupe/flush-lock behavior.

## Notes

- `inferProviderFromSessionKey` is intentionally not included here to avoid relying on OpenClaw session-key heuristics.
- Subagent sessions are not skipped by default; users can opt in with a custom `isolatedSessionPatterns` entry if needed.

## Validation

- `pnpm exec vitest run test/helpers.test.ts`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stripRuntimeScaffolding` configuration option (enabled by default) to clean up system scaffolding from captured messages.
  * Introduced `isolatedSessionPatterns` configuration to exclude specified session types from message capture.
  * Enhanced message cleaning with support for filtering runtime metadata and system envelope content.

* **Tests**
  * Added comprehensive test coverage for message cleaning and session isolation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->