### PR TITLE
feat: add optional honcho capture dedupe

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -18,6 +18,7 @@ export type HonchoConfig = {
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
   crossSessionSearch: boolean;
+  recentTailDedupeSize: number;
 };
 
 /**
@@ -32,6 +33,13 @@ function resolveEnvVars(value: string): string {
     }
     return envValue;
   });
+}
+
+function parsePositiveInteger(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.trunc(value);
+  }
+  return fallback;
 }
 
 export const honchoConfigSchema = {
@@ -81,6 +89,7 @@ export const honchoConfigSchema = {
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
       crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,
+      recentTailDedupeSize: parsePositiveInteger(cfg.recentTailDedupeSize, 0),
     };
   },
 };

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -1,5 +1,5 @@
 // @ts-ignore - resolved by openclaw runtime
-import type { MessageInput, Session } from "@honcho-ai/sdk";
+import { Message, Page, type MessageInput, type MessageResponse, type PageResponse, type Session } from "@honcho-ai/sdk";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
@@ -15,6 +15,19 @@ import { subagentParentMap } from "./subagent.js";
 
 const sessionFlushLocks = new Map<string, Promise<void>>();
 export const HONCHO_MESSAGES_LIST_MAX_SIZE = 100;
+const HONCHO_API_VERSION = "v3";
+
+type SessionListInternals = {
+  _ensureWorkspace?: () => Promise<void>;
+  _http?: {
+    post: (
+      path: string,
+      options?: { body?: unknown; query?: Record<string, unknown> },
+    ) => Promise<PageResponse<MessageResponse>>;
+  };
+  workspaceId: string;
+  id: string;
+};
 
 function messageSignature(message: MessageInput | { peerId: string; createdAt?: string; content: string }): string | null {
   if (!message?.createdAt) return null;
@@ -51,7 +64,7 @@ async function collectRecentTailMessages(
   const limit = normalizeRecentTailSize(recentTailSize);
   if (limit <= 0) return [];
 
-  let page = await session.messages({
+  let page = await listSessionMessagesPage(session, {
     size: Math.min(limit, HONCHO_MESSAGES_LIST_MAX_SIZE),
     reverse: true,
   });
@@ -65,6 +78,35 @@ async function collectRecentTailMessages(
   }
 
   return messages.slice(0, limit);
+}
+
+async function listSessionMessagesPage(
+  session: Session,
+  options: { page?: number; size: number; reverse: boolean },
+): Promise<Page<Message, MessageResponse>> {
+  const internals = session as unknown as SessionListInternals;
+  if (typeof internals._http?.post !== "function") {
+    throw new Error("Honcho SDK session internals unavailable for paginated message listing");
+  }
+
+  await internals._ensureWorkspace?.();
+
+  const fetchPage = async (page?: number, size?: number): Promise<PageResponse<MessageResponse>> => (
+    internals._http!.post(
+      `/${HONCHO_API_VERSION}/workspaces/${internals.workspaceId}/sessions/${internals.id}/messages/list`,
+      {
+        body: { filters: undefined },
+        query: {
+          page,
+          size,
+          reverse: options.reverse,
+        },
+      },
+    )
+  );
+
+  const data = await fetchPage(options.page, options.size);
+  return new Page(data, Message.fromApiResponse, fetchPage);
 }
 
 export async function dedupeAgainstRecentTail(

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -15,6 +15,7 @@ import { subagentParentMap } from "./subagent.js";
 
 const sessionFlushLocks = new Map<string, Promise<void>>();
 export const HONCHO_MESSAGES_LIST_MAX_SIZE = 100;
+export const HONCHO_MESSAGES_CREATE_MAX_SIZE = 100;
 const HONCHO_API_VERSION = "v3";
 
 type SessionListInternals = {
@@ -32,6 +33,16 @@ type SessionListInternals = {
 function messageSignature(message: MessageInput | { peerId: string; createdAt?: string; content: string }): string | null {
   if (!message?.createdAt) return null;
   return `${message.peerId}\u0000${message.createdAt}\u0000${message.content}`;
+}
+
+function formatHonchoError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+
+  const details: string[] = [error.toString()];
+  const anyError = error as unknown as Record<string, unknown>;
+  if (anyError.status) details.push(`status=${String(anyError.status)}`);
+  if (anyError.body) details.push(`body=${JSON.stringify(anyError.body)}`);
+  return details.join(" ");
 }
 
 async function withSessionFlushLock<T>(sessionKey: string, fn: () => Promise<T>): Promise<T> {
@@ -140,6 +151,15 @@ export async function dedupeAgainstRecentTail(
   });
 }
 
+export async function addMessagesInBatches(
+  session: Session,
+  messages: MessageInput[],
+): Promise<void> {
+  for (let start = 0; start < messages.length; start += HONCHO_MESSAGES_CREATE_MAX_SIZE) {
+    await session.addMessages(messages.slice(start, start + HONCHO_MESSAGES_CREATE_MAX_SIZE));
+  }
+}
+
 /**
  * Core message capture logic shared by agent_end, before_compaction, and before_reset.
  * Returns the number of new messages saved (or 0 if none).
@@ -173,7 +193,7 @@ async function flushMessages(
   };
 
   return withSessionFlushLock(sessionKey, async () => {
-    const session = await state.honcho.session(sessionKey, { metadata: sessionMeta });
+    const session = await state.honcho.session(sessionKey);
     const meta = await session.getMetadata();
     const existingMeta: Record<string, unknown> =
       meta && typeof meta === "object" ? (meta as Record<string, unknown>) : {};
@@ -276,7 +296,7 @@ async function flushMessages(
     return 0;
   }
 
-  await session.addMessages(deduped);
+  await addMessagesInBatches(session, deduped);
   await session.setMetadata(updatedMeta);
   return deduped.length;
   });
@@ -292,7 +312,7 @@ export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState):
     try {
       await flushMessages(api, state, event.messages, ctx);
     } catch (error) {
-      api.logger.error(`[honcho] Failed to save messages to Honcho: ${error}`);
+      api.logger.error(`[honcho] Failed to save messages to Honcho: ${formatHonchoError(error)}`);
       if (error instanceof Error) {
         api.logger.error(`[honcho] Stack: ${error.stack}`);
         const anyError = error as unknown as Record<string, unknown>;
@@ -321,7 +341,7 @@ export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState):
         api.logger.debug?.(`[honcho] Flushed ${saved} messages before compaction`);
       }
     } catch (error) {
-      api.logger.warn?.(`[honcho] Failed to flush messages before compaction: ${error}`);
+      api.logger.warn?.(`[honcho] Failed to flush messages before compaction: ${formatHonchoError(error)}`);
     }
   });
 
@@ -338,7 +358,7 @@ export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState):
         api.logger.debug?.(`[honcho] Flushed ${saved} messages before session reset`);
       }
     } catch (error) {
-      api.logger.warn?.(`[honcho] Failed to flush messages before reset: ${error}`);
+      api.logger.warn?.(`[honcho] Failed to flush messages before reset: ${formatHonchoError(error)}`);
     }
   });
 }

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -1,4 +1,6 @@
 // @ts-ignore - resolved by openclaw runtime
+import type { MessageInput, Session } from "@honcho-ai/sdk";
+// @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { OWNER_ID } from "../state.js";
@@ -10,6 +12,91 @@ import {
   getRawContent,
 } from "../helpers.js";
 import { subagentParentMap } from "./subagent.js";
+
+const sessionFlushLocks = new Map<string, Promise<void>>();
+export const HONCHO_MESSAGES_LIST_MAX_SIZE = 100;
+
+function messageSignature(message: MessageInput | { peerId: string; createdAt?: string; content: string }): string | null {
+  if (!message?.createdAt) return null;
+  return `${message.peerId}\u0000${message.createdAt}\u0000${message.content}`;
+}
+
+async function withSessionFlushLock<T>(sessionKey: string, fn: () => Promise<T>): Promise<T> {
+  const previous = sessionFlushLocks.get(sessionKey) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  sessionFlushLocks.set(sessionKey, current);
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (sessionFlushLocks.get(sessionKey) === current) {
+      sessionFlushLocks.delete(sessionKey);
+    }
+  }
+}
+
+function normalizeRecentTailSize(recentTailSize: number): number {
+  if (!Number.isFinite(recentTailSize) || recentTailSize <= 0) return 0;
+  return Math.trunc(recentTailSize);
+}
+
+async function collectRecentTailMessages(
+  session: Session,
+  recentTailSize: number,
+): Promise<Array<{ peerId: string; createdAt?: string; content: string }>> {
+  const limit = normalizeRecentTailSize(recentTailSize);
+  if (limit <= 0) return [];
+
+  let page = await session.messages({
+    size: Math.min(limit, HONCHO_MESSAGES_LIST_MAX_SIZE),
+    reverse: true,
+  });
+  const messages = [...page.items];
+
+  while (messages.length < limit && page.hasNextPage) {
+    const nextPage = await page.getNextPage();
+    if (!nextPage) break;
+    page = nextPage;
+    messages.push(...page.items);
+  }
+
+  return messages.slice(0, limit);
+}
+
+export async function dedupeAgainstRecentTail(
+  session: Session,
+  extracted: MessageInput[],
+  recentTailSize: number,
+): Promise<MessageInput[]> {
+  const batchSeen = new Set<string>();
+  const batchUnique: MessageInput[] = [];
+
+  for (const message of extracted) {
+    const signature = messageSignature(message) ?? `${message.peerId}\u0000${message.content}`;
+    if (batchSeen.has(signature)) continue;
+    batchSeen.add(signature);
+    batchUnique.push(message);
+  }
+
+  const tailSize = normalizeRecentTailSize(recentTailSize);
+  if (batchUnique.length === 0 || tailSize <= 0) return batchUnique;
+
+  const recentMessages = await collectRecentTailMessages(session, tailSize);
+  const recentSignatures = new Set(
+    recentMessages
+      .map((message) => messageSignature(message))
+      .filter((signature): signature is string => typeof signature === "string"),
+  );
+
+  return batchUnique.filter((message) => {
+    const signature = messageSignature(message);
+    return !signature || !recentSignatures.has(signature);
+  });
+}
 
 /**
  * Core message capture logic shared by agent_end, before_compaction, and before_reset.
@@ -43,25 +130,26 @@ async function flushMessages(
     } : {}),
   };
 
-  const session = await state.honcho.session(sessionKey, { metadata: sessionMeta });
-  const meta = await session.getMetadata();
-  const existingMeta: Record<string, unknown> =
-    meta && typeof meta === "object" ? (meta as Record<string, unknown>) : {};
+  return withSessionFlushLock(sessionKey, async () => {
+    const session = await state.honcho.session(sessionKey, { metadata: sessionMeta });
+    const meta = await session.getMetadata();
+    const existingMeta: Record<string, unknown> =
+      meta && typeof meta === "object" ? (meta as Record<string, unknown>) : {};
 
-  const turnStartIndex = Math.min(
-    Math.max(state.turnStartIndex.get(sessionKey) ?? 0, 0),
-    messages.length,
-  );
-  const rawLastSavedIndex =
-    typeof existingMeta.lastSavedIndex === "number" ? existingMeta.lastSavedIndex : 0;
-  const lastSavedIndex = Math.min(Math.max(rawLastSavedIndex, 0), messages.length);
-  const startIndex = Math.max(turnStartIndex, lastSavedIndex);
+    const turnStartIndex = Math.min(
+      Math.max(state.turnStartIndex.get(sessionKey) ?? 0, 0),
+      messages.length,
+    );
+    const rawLastSavedIndex =
+      typeof existingMeta.lastSavedIndex === "number" ? existingMeta.lastSavedIndex : 0;
+    const lastSavedIndex = Math.min(Math.max(rawLastSavedIndex, 0), messages.length);
+    const startIndex = Math.max(turnStartIndex, lastSavedIndex);
 
-  if (messages.length <= startIndex) {
-    return 0;
-  }
+    if (messages.length <= startIndex) {
+      return 0;
+    }
 
-  const newRawMessages = messages.slice(startIndex);
+    const newRawMessages = messages.slice(startIndex);
 
   // Pre-resolve participant peers for all unique sender IDs in this batch
   const senderIds = new Set<string>();
@@ -139,9 +227,17 @@ async function flushMessages(
     return 0;
   }
 
-  await session.addMessages(extracted);
+  const deduped = await dedupeAgainstRecentTail(session, extracted, state.cfg.recentTailDedupeSize);
+
+  if (deduped.length === 0) {
+    await session.setMetadata(updatedMeta);
+    return 0;
+  }
+
+  await session.addMessages(deduped);
   await session.setMetadata(updatedMeta);
-  return extracted.length;
+  return deduped.length;
+  });
 }
 
 export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState): void {

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -44,7 +44,7 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
           throw e;
         }
       } else {
-        const session = await state.honcho.session(sessionKey, { metadata: { agentId } });
+        const session = await state.honcho.session(sessionKey);
 
         let context;
         try {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,7 +24,9 @@
       },
       "noisePatterns": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Additional substring patterns to skip messages. Built-in defaults (HEARTBEAT_OK, cron reminders, etc.) always apply."
       },
       "ownerObserveOthers": {
@@ -41,6 +43,12 @@
         "type": "boolean",
         "default": true,
         "description": "When true (default), memory_search/memory_get can return results from any session in the workspace. When false, results are scoped to the active session and its child sessions only."
+      },
+      "recentTailDedupeSize": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 0,
+        "description": "When greater than 0, compare new captured messages against this many recent Honcho messages and skip duplicates. Default 0 disables tail fetching to avoid adding latency on every flush."
       }
     }
   },
@@ -86,6 +94,12 @@
       "label": "Cross-Session Search",
       "advanced": true,
       "help": "When enabled (default), memory tools can return results from any session in the workspace. Disable to scope results to the active session only."
+    },
+    "recentTailDedupeSize": {
+      "label": "Recent Tail Dedupe Size",
+      "advanced": true,
+      "placeholder": "0",
+      "help": "Set above 0 to compare captured messages against a recent Honcho tail. Disabled by default to avoid extra flush latency."
     }
   }
 }

--- a/runtime.ts
+++ b/runtime.ts
@@ -38,7 +38,7 @@ async function buildSessionTranscript(
 
   const participantPeer = await state.resolveSessionParticipantPeer(sessionId);
   const agentPeer = await state.getAgentPeer(agentId);
-  const session = await state.honcho.session(sessionId, { metadata: { agentId } });
+  const session = await state.honcho.session(sessionId);
   const context = await session.context({
     summary: true,
     tokens: 20000,
@@ -167,9 +167,7 @@ export async function getHonchoMemorySearchManager(
         };
 
         if (requestedSessionKey) {
-          const exactSession = await state.honcho.session(requestedSessionKey, {
-            metadata: { agentId },
-          });
+          const exactSession = await state.honcho.session(requestedSessionKey);
           collect(await exactSession.search(query, { limit }));
 
           if (filtered.length < limit) {

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,14 +1,47 @@
 import { describe, expect, it, vi } from "vitest";
 import { dedupeAgainstRecentTail, HONCHO_MESSAGES_LIST_MAX_SIZE } from "../hooks/capture.js";
-import type { MessageInput } from "@honcho-ai/sdk";
+import type { MessageInput, MessageResponse, PageResponse } from "@honcho-ai/sdk";
 
 type FakeMessage = { peerId: string; createdAt?: string; content: string };
 
-function page(items: FakeMessage[], pageNo: number, pages: number) {
+function apiMessage(message: FakeMessage): MessageResponse {
   return {
-    items,
-    hasNextPage: pageNo < pages,
-    getNextPage: vi.fn(async () => null),
+    id: `msg-${message.createdAt ?? message.content}`,
+    content: message.content,
+    peer_id: message.peerId,
+    session_id: "session-1",
+    workspace_id: "workspace-1",
+    metadata: {},
+    created_at: message.createdAt ?? "2026-04-30T00:00:00Z",
+    token_count: 1,
+  };
+}
+
+function response(items: FakeMessage[], page: number, pages: number, size = HONCHO_MESSAGES_LIST_MAX_SIZE): PageResponse<MessageResponse> {
+  return {
+    items: items.map(apiMessage),
+    page,
+    size,
+    total: items.length,
+    pages,
+  };
+}
+
+function fakeSession(responses: PageResponse<MessageResponse>[]) {
+  const post = vi.fn(async () => {
+    const next = responses.shift();
+    if (!next) throw new Error("unexpected extra page request");
+    return next;
+  });
+
+  return {
+    id: "session-1",
+    workspaceId: "workspace-1",
+    _ensureWorkspace: vi.fn(async () => undefined),
+    _http: { post },
+    messages: vi.fn(async () => {
+      throw new Error("Session.messages() treats pagination options as filters in @honcho-ai/sdk@2");
+    }),
   };
 }
 
@@ -32,13 +65,12 @@ describe("dedupeAgainstRecentTail", () => {
     ]);
   });
 
-  it("never requests more than Honcho's messages/list max page size", async () => {
-    const recent = page([
-      { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "already saved" },
-    ], 1, 1);
-    const session = {
-      messages: vi.fn(async () => recent),
-    };
+  it("passes pagination as query params instead of Honcho message filters", async () => {
+    const session = fakeSession([
+      response([
+        { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "already saved" },
+      ], 1, 1),
+    ]);
     const extracted: MessageInput[] = [
       { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "already saved" },
       { peerId: "owner", createdAt: "2026-04-30T00:00:01Z", content: "new" },
@@ -46,26 +78,32 @@ describe("dedupeAgainstRecentTail", () => {
 
     const result = await dedupeAgainstRecentTail(session as never, extracted, 200);
 
-    expect(session.messages).toHaveBeenCalledWith({
-      size: HONCHO_MESSAGES_LIST_MAX_SIZE,
-      reverse: true,
-    });
+    expect(session.messages).not.toHaveBeenCalled();
+    expect(session._http.post).toHaveBeenCalledWith(
+      "/v3/workspaces/workspace-1/sessions/session-1/messages/list",
+      {
+        body: { filters: undefined },
+        query: {
+          page: undefined,
+          size: HONCHO_MESSAGES_LIST_MAX_SIZE,
+          reverse: true,
+        },
+      },
+    );
     expect(result).toEqual([
       { peerId: "owner", createdAt: "2026-04-30T00:00:01Z", content: "new" },
     ]);
   });
 
   it("walks additional pages when the configured tail is larger than one Honcho page", async () => {
-    const second = page(
-      [{ peerId: "owner", createdAt: "2026-04-30T00:00:42Z", content: "older duplicate" }],
-      2,
-      2,
-    );
-    const first = page([], 1, 2);
-    first.getNextPage = vi.fn(async () => second);
-    const session = {
-      messages: vi.fn(async () => first),
-    };
+    const session = fakeSession([
+      response([], 1, 2),
+      response(
+        [{ peerId: "owner", createdAt: "2026-04-30T00:00:42Z", content: "older duplicate" }],
+        2,
+        2,
+      ),
+    ]);
     const extracted: MessageInput[] = [
       { peerId: "owner", createdAt: "2026-04-30T00:00:42Z", content: "older duplicate" },
       { peerId: "owner", createdAt: "2026-04-30T00:00:43Z", content: "new" },
@@ -73,7 +111,18 @@ describe("dedupeAgainstRecentTail", () => {
 
     const result = await dedupeAgainstRecentTail(session as never, extracted, 200);
 
-    expect(first.getNextPage).toHaveBeenCalledTimes(1);
+    expect(session._http.post).toHaveBeenCalledTimes(2);
+    expect(session._http.post).toHaveBeenLastCalledWith(
+      "/v3/workspaces/workspace-1/sessions/session-1/messages/list",
+      {
+        body: { filters: undefined },
+        query: {
+          page: 2,
+          size: HONCHO_MESSAGES_LIST_MAX_SIZE,
+          reverse: true,
+        },
+      },
+    );
     expect(result).toEqual([
       { peerId: "owner", createdAt: "2026-04-30T00:00:43Z", content: "new" },
     ]);

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { dedupeAgainstRecentTail, HONCHO_MESSAGES_LIST_MAX_SIZE } from "../hooks/capture.js";
+import { addMessagesInBatches, dedupeAgainstRecentTail, HONCHO_MESSAGES_CREATE_MAX_SIZE, HONCHO_MESSAGES_LIST_MAX_SIZE } from "../hooks/capture.js";
 import type { MessageInput, MessageResponse, PageResponse } from "@honcho-ai/sdk";
 
 type FakeMessage = { peerId: string; createdAt?: string; content: string };
@@ -126,5 +126,25 @@ describe("dedupeAgainstRecentTail", () => {
     expect(result).toEqual([
       { peerId: "owner", createdAt: "2026-04-30T00:00:43Z", content: "new" },
     ]);
+  });
+});
+
+
+describe("addMessagesInBatches", () => {
+  it("splits message creation into Honcho's 100-message API limit", async () => {
+    const addMessages = vi.fn(async () => []);
+    const session = { addMessages };
+    const messages: MessageInput[] = Array.from({ length: 205 }, (_, i) => ({
+      peerId: "owner",
+      createdAt: `2026-04-30T00:00:${String(i % 60).padStart(2, "0")}Z`,
+      content: `message ${i}`,
+    }));
+
+    await addMessagesInBatches(session as never, messages);
+
+    expect(addMessages).toHaveBeenCalledTimes(3);
+    expect(addMessages.mock.calls[0][0]).toHaveLength(HONCHO_MESSAGES_CREATE_MAX_SIZE);
+    expect(addMessages.mock.calls[1][0]).toHaveLength(HONCHO_MESSAGES_CREATE_MAX_SIZE);
+    expect(addMessages.mock.calls[2][0]).toHaveLength(5);
   });
 });

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { dedupeAgainstRecentTail, HONCHO_MESSAGES_LIST_MAX_SIZE } from "../hooks/capture.js";
+import type { MessageInput } from "@honcho-ai/sdk";
+
+type FakeMessage = { peerId: string; createdAt?: string; content: string };
+
+function page(items: FakeMessage[], pageNo: number, pages: number) {
+  return {
+    items,
+    hasNextPage: pageNo < pages,
+    getNextPage: vi.fn(async () => null),
+  };
+}
+
+describe("dedupeAgainstRecentTail", () => {
+  it("dedupes within the current batch without fetching the recent tail when disabled", async () => {
+    const session = {
+      messages: vi.fn(),
+    };
+    const extracted: MessageInput[] = [
+      { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "same" },
+      { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "same" },
+      { peerId: "owner", createdAt: "2026-04-30T00:00:01Z", content: "new" },
+    ];
+
+    const result = await dedupeAgainstRecentTail(session as never, extracted, 0);
+
+    expect(session.messages).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "same" },
+      { peerId: "owner", createdAt: "2026-04-30T00:00:01Z", content: "new" },
+    ]);
+  });
+
+  it("never requests more than Honcho's messages/list max page size", async () => {
+    const recent = page([
+      { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "already saved" },
+    ], 1, 1);
+    const session = {
+      messages: vi.fn(async () => recent),
+    };
+    const extracted: MessageInput[] = [
+      { peerId: "owner", createdAt: "2026-04-30T00:00:00Z", content: "already saved" },
+      { peerId: "owner", createdAt: "2026-04-30T00:00:01Z", content: "new" },
+    ];
+
+    const result = await dedupeAgainstRecentTail(session as never, extracted, 200);
+
+    expect(session.messages).toHaveBeenCalledWith({
+      size: HONCHO_MESSAGES_LIST_MAX_SIZE,
+      reverse: true,
+    });
+    expect(result).toEqual([
+      { peerId: "owner", createdAt: "2026-04-30T00:00:01Z", content: "new" },
+    ]);
+  });
+
+  it("walks additional pages when the configured tail is larger than one Honcho page", async () => {
+    const second = page(
+      [{ peerId: "owner", createdAt: "2026-04-30T00:00:42Z", content: "older duplicate" }],
+      2,
+      2,
+    );
+    const first = page([], 1, 2);
+    first.getNextPage = vi.fn(async () => second);
+    const session = {
+      messages: vi.fn(async () => first),
+    };
+    const extracted: MessageInput[] = [
+      { peerId: "owner", createdAt: "2026-04-30T00:00:42Z", content: "older duplicate" },
+      { peerId: "owner", createdAt: "2026-04-30T00:00:43Z", content: "new" },
+    ];
+
+    const result = await dedupeAgainstRecentTail(session as never, extracted, 200);
+
+    expect(first.getNextPage).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { peerId: "owner", createdAt: "2026-04-30T00:00:43Z", content: "new" },
+    ]);
+  });
+});

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -153,7 +153,8 @@ describe("addMessagesInBatches", () => {
     expect(addMessages.mock.calls[0][0]).toHaveLength(HONCHO_MESSAGES_CREATE_MAX_SIZE);
     expect(addMessages.mock.calls[1][0]).toHaveLength(HONCHO_MESSAGES_CREATE_MAX_SIZE);
     expect(addMessages.mock.calls[2][0]).toHaveLength(5);
-
+  });
+});
 
 const SENTINEL = "Conversation info (untrusted metadata):";
 
@@ -182,8 +183,8 @@ function createMockState(): { state: PluginState; session: SessionStub } {
     addMessages: vi.fn(async () => undefined),
   };
 
-  const agentPeer = { id: "agent-main", message: vi.fn((text: string) => ({ text })) };
-  const ownerPeer = { id: "owner", message: vi.fn((text: string) => ({ text })) };
+  const agentPeer = { id: "agent-main", message: vi.fn((content: string, opts?: { createdAt?: Date }) => ({ peerId: "agent-main", content, createdAt: opts?.createdAt?.toISOString() })) };
+  const ownerPeer = { id: "owner", message: vi.fn((content: string, opts?: { createdAt?: Date }) => ({ peerId: "owner", content, createdAt: opts?.createdAt?.toISOString() })) };
 
   const state = {
     cfg: {
@@ -313,3 +314,5 @@ describe("flushMessages metadata", () => {
 
     expect(session.metadata).not.toHaveProperty("messageProvider");
     expect(session.metadata).not.toHaveProperty("lastSessionId");
+  });
+});


### PR DESCRIPTION
## Summary

- add per-session flush locking so concurrent capture flushes for the same session do not race on metadata and saved ranges
- dedupe captured messages within the current batch
- optionally compare captures against a recent Honcho message tail when `recentTailDedupeSize > 0`

This is split out from #78 and intentionally excludes context-injection controls and runtime-scaffolding cleanup.

## Latency / concurrency notes

- `recentTailDedupeSize` defaults to `0`, so the PR does not add Honcho tail-fetch latency by default.
- When enabled, one or more `session.messages({ reverse: true })` requests are made per flush, capped at Honcho's page size of 100 messages per request.
- The flush lock is scoped per Honcho session key only; different sessions can still flush concurrently.

## Validation

- `pnpm exec vitest run test/capture.test.ts`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional message deduplication against a configurable recent-session tail (off by default) and batched message persistence to avoid oversized creates.

* **Configuration**
  * Added a user-facing setting for recentTailDedupeSize with UI hints and a non-negative default.

* **Tests**
  * Added comprehensive tests covering deduplication (including multi-page tails) and batched message creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->