### PR TITLE
Add startup activation to plugin manifests

### DIFF
--- a/clawdbot.plugin.json
+++ b/clawdbot.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "openclaw-honcho",
   "kind": "memory",
+  "activation": {
+    "onStartup": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "openclaw-honcho",
   "kind": "memory",
+  "activation": {
+    "onStartup": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
## Summary
- add `activation.onStartup: true` to the upstream OpenClaw plugin manifests
- keep the change limited to `openclaw.plugin.json` and `clawdbot.plugin.json`

## Validation
- `jq empty openclaw.plugin.json clawdbot.plugin.json`
- `git diff --check`
- `../openclaw-honcho-pr/node_modules/.bin/vitest run test/helpers.test.ts test/peers.test.ts`

Note: full `vitest run` was attempted from the fresh worktree but the dependency-backed suites could not resolve dependencies without installing; no dependency install was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins now automatically activate on application startup. This improvement streamlines your workflow by ensuring all configured plugins are properly initialized and ready to use immediately when you launch the application, removing the need for any manual activation steps. Experience a seamless out-of-the-box environment with full plugin functionality available from the moment you start using the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->