### PR TITLE
fix: harden honcho_ask dialect calls with error handling

### DIFF
--- a/test/ask.test.ts
+++ b/test/ask.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerAskTool } from "../tools/ask.js";
+
+function createRegistration() {
+  const registrations: Array<{
+    factory: (ctx: Record<string, unknown>) => Record<string, unknown>;
+    opts?: Record<string, unknown>;
+  }> = [];
+  const api = {
+    registerTool: (
+      factory: (ctx: Record<string, unknown>) => Record<string, unknown>,
+      opts?: Record<string, unknown>,
+    ) => registrations.push({ factory, opts }),
+  };
+  return { api, registrations };
+}
+
+describe("honcho_ask tool", () => {
+  it("registers the tool contract and returns chat answers", async () => {
+    const { api, registrations } = createRegistration();
+    const participantPeer = { id: "owner" };
+    const agentPeer = {
+      id: "agent-main",
+      chat: vi.fn(async () => "dialect answer"),
+    };
+    const state = {
+      api: { logger: { debug: vi.fn(), warn: vi.fn() } },
+      ensureInitialized: vi.fn(async () => {}),
+      getAgentPeer: vi.fn(async () => agentPeer),
+      resolveSessionParticipantPeer: vi.fn(async () => participantPeer),
+      getParticipantPeer: vi.fn(),
+    };
+
+    registerAskTool(api as never, state as never);
+
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0]?.opts).toEqual({ name: "honcho_ask" });
+
+    const tool = registrations[0]!.factory({
+      agentId: "main",
+      sessionKey: "agent:main:discord:dm:user-1",
+    }) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    };
+    const result = await tool.execute("call-1", {
+      query: "Can dialect calls answer?",
+      depth: "quick",
+    });
+
+    expect(agentPeer.chat).toHaveBeenCalledWith("Can dialect calls answer?", {
+      target: participantPeer,
+      reasoningLevel: "low",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "dialect answer" }]);
+    expect(result.details).toMatchObject({ query: "Can dialect calls answer?", depth: "quick" });
+    expect(result.details.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns structured tool errors instead of throwing raw SDK failures", async () => {
+    const { api, registrations } = createRegistration();
+    const agentPeer = {
+      id: "agent-main",
+      chat: vi.fn(async () => {
+        throw new Error("Request timed out after 30000ms");
+      }),
+    };
+    const state = {
+      api: { logger: { debug: vi.fn(), warn: vi.fn() } },
+      ensureInitialized: vi.fn(async () => {}),
+      getAgentPeer: vi.fn(async () => agentPeer),
+      resolveSessionParticipantPeer: vi.fn(async () => ({ id: "owner" })),
+      getParticipantPeer: vi.fn(),
+    };
+
+    registerAskTool(api as never, state as never);
+    const tool = registrations[0]!.factory({
+      agentId: "main",
+      sessionKey: "agent:main:discord:dm:user-1",
+    }) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{
+        content: Array<{ text: string }>;
+        isError?: boolean;
+        details?: Record<string, unknown>;
+      }>;
+    };
+
+    const result = await tool.execute("call-1", {
+      query: "Will this fail?",
+      depth: "thorough",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Honcho dialect call failed");
+    expect(result.content[0]?.text).toContain("Request timed out after 30000ms");
+    expect(result.content[0]?.text).toContain("honcho_context");
+    expect(result.details).toMatchObject({
+      query: "Will this fail?",
+      depth: "thorough",
+      error: "Request timed out after 30000ms",
+    });
+    expect(state.api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[honcho_ask] Dialect call failed"),
+    );
+  });
+
+  it("uses explicit participant peers and maps thorough depth to high reasoning", async () => {
+    const { api, registrations } = createRegistration();
+    const participantPeer = { id: "participant-other" };
+    const agentPeer = {
+      id: "agent-main",
+      chat: vi.fn(async () => null),
+    };
+    const state = {
+      api: { logger: { debug: vi.fn(), warn: vi.fn() } },
+      ensureInitialized: vi.fn(async () => {}),
+      getAgentPeer: vi.fn(async () => agentPeer),
+      resolveSessionParticipantPeer: vi.fn(),
+      getParticipantPeer: vi.fn(async () => participantPeer),
+    };
+
+    registerAskTool(api as never, state as never);
+    const tool = registrations[0]!.factory({ agentId: "main" }) as {
+      execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{
+        content: Array<{ text: string }>;
+      }>;
+    };
+
+    const result = await tool.execute("call-1", {
+      query: "Summarize",
+      depth: "thorough",
+      about: "other",
+    });
+
+    expect(state.getParticipantPeer).toHaveBeenCalledWith("other");
+    expect(state.resolveSessionParticipantPeer).not.toHaveBeenCalled();
+    expect(agentPeer.chat).toHaveBeenCalledWith("Summarize", {
+      target: participantPeer,
+      reasoningLevel: "high",
+    });
+    expect(result.content[0]?.text).toBe("No information available.");
+  });
+});

--- a/tools/ask.ts
+++ b/tools/ask.ts
@@ -38,25 +38,50 @@ export function registerAskTool(api: OpenClawPluginApi, state: PluginState): voi
           depth?: "quick" | "thorough";
           about?: string;
         };
+        const startedAt = Date.now();
 
-        await state.ensureInitialized();
-        const agentPeer = await state.getAgentPeer(toolCtx.agentId);
-        const participantPeer = about
-          ? await state.getParticipantPeer(about)
-          : await state.resolveSessionParticipantPeer(
-              buildSessionKey({ sessionKey: toolCtx.sessionKey, agentId: toolCtx.agentId }),
-            );
+        try {
+          await state.ensureInitialized();
+          const agentPeer = await state.getAgentPeer(toolCtx.agentId);
+          const participantPeer = about
+            ? await state.getParticipantPeer(about)
+            : await state.resolveSessionParticipantPeer(
+                buildSessionKey({ sessionKey: toolCtx.sessionKey, agentId: toolCtx.agentId }),
+              );
 
-        const reasoningLevel = depth === "thorough" ? "high" : "low";
-        const answer = await agentPeer.chat(query, {
-          target: participantPeer,
-          reasoningLevel,
-        });
+          const reasoningLevel = depth === "thorough" ? "high" : "low";
+          const answer = await agentPeer.chat(query, {
+            target: participantPeer,
+            reasoningLevel,
+          });
+          const elapsedMs = Date.now() - startedAt;
+          state.api.logger.debug(
+            `[honcho_ask] Dialect call completed in ${elapsedMs}ms depth=${depth}`
+          );
 
-        return {
-          content: [{ type: "text", text: answer! }],
-          details: { query, depth },
-        };
+          return {
+            content: [{ type: "text", text: answer ?? "No information available." }],
+            details: { query, depth, elapsedMs },
+          };
+        } catch (error) {
+          const elapsedMs = Date.now() - startedAt;
+          const message = error instanceof Error ? error.message : String(error);
+          state.api.logger.warn(
+            `[honcho_ask] Dialect call failed after ${elapsedMs}ms depth=${depth}: ${message}`
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `Honcho dialect call failed after ${elapsedMs}ms: ${message}\n\n` +
+                  "Use honcho_context or honcho_search_conclusions for a non-LLM memory lookup fallback.",
+              },
+            ],
+            isError: true,
+            details: { query, depth, elapsedMs, error: message },
+          };
+        }
       },
     }),
     { name: "honcho_ask" }


### PR DESCRIPTION
## Summary

**Rebased onto v1.5.0.** Previous fixes (session key truncation, contracts.tools, message length cap) have been superseded by #96 (structured session IDs) and are now upstream. This PR preserves only the dialectic call error handling that was lost during the v1.5.0 merge.

### What this PR now does

- Wrap `agentPeer.chat()` in try/catch so SDK failures (timeout, rate limit, server error) return structured `isError` responses instead of propagating raw exceptions through the tool framework
- Add timing instrumentation: debug log on success, warn log on failure, `elapsedMs` in response details
- Null-safe answer fallback: `answer ?? "No information available."`
- Structured error return with fallback tool suggestions (`honcho_context`, `honcho_search_conclusions`)
- Test suite for success, failure, and peer resolution paths

### What was removed (superseded by upstream)

| Fix | This PR (original) | Upstream |
|-----|-------------------|----------|
| `contracts.tools` declaration | #88 | #96 |
| Session key 100-char truncation (sha1) | #88 | #96 (sha256 + structured IDs) |
| Message 25,000-char truncation | #88 | Merged into helpers.ts |

## Validation

- `pnpm exec vitest run` — 57 tests passed (including 3 new ask.test.ts)
- `npx tsc` — clean build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the ask tool covering success, error handling, and explicit participant selection.

* **Bug Fixes**
  * Improved error handling to return user-facing fallback messages and structured error responses.
  * Added execution timing and logging for dialect/chat calls to surface performance metrics and aid troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->