### PR TITLE
Declare contracts.tools in plugin manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@honcho-ai/openclaw-honcho` will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Manifest declares `contracts.tools`**: OpenClaw 2026.5.3-1 strictly enforces that non-bundled plugins declare their agent-callable tools in the manifest before runtime registration. Without this, `honcho_ask`, `honcho_context`, `honcho_search_conclusions`, `honcho_search_messages`, and `honcho_session` were rejected at load time with `plugin must declare contracts.tools before registering agent tools`, leaving the agent unable to query Honcho memory.
+
 ## [1.4.1] - 2026-04-29
 
 ### Fixed

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,15 @@
 {
   "id": "openclaw-honcho",
   "kind": "memory",
+  "contracts": {
+    "tools": [
+      "honcho_ask",
+      "honcho_context",
+      "honcho_search_conclusions",
+      "honcho_search_messages",
+      "honcho_session"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
OpenClaw 2026.5.3-1 strictly enforces that non-bundled plugins declare their agent-callable tools in the manifest before runtime registration. Without this, the gateway logs:

  plugin must declare contracts.tools before registering agent tools
  (plugin=openclaw-honcho)

once per tool at load time, and refuses to register them. The agent then has no way to query Honcho memory (honcho_ask, honcho_context, honcho_search_conclusions, honcho_search_messages, honcho_session) even though the plugin loads and the memory slot is correctly assigned.

Add the missing contracts.tools array listing all five tools the plugin registers in runtime.ts so they pass the contract check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to document that non-bundled plugin manifests must now declare `contracts.tools`. Plugins missing this declaration will have their agent tools rejected at load time, preventing agents from accessing Honcho memory features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->