### PR TITLE
Fix stripped sender attribution from message_received

### DIFF
--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -13,11 +13,9 @@ import { subagentParentMap } from "./subagent.js";
 
 const STRUCTURED_SENDER_TTL_MS = 10 * 60 * 1000;
 
-type SenderEntry = {
-  senderId?: string;
-  seenAt: number;
-  ambiguous: boolean;
-};
+type SenderEntry =
+  | { senderId: string; seenAt: number; ambiguous: false }
+  | { seenAt: number; ambiguous: true };
 
 const senderByMessageKey = new Map<string, SenderEntry>();
 const senderByTimestampKey = new Map<string, SenderEntry>();
@@ -92,9 +90,11 @@ function rememberSender(map: Map<string, SenderEntry>, key: string, senderId: st
   }
 
   const existing = map.get(key);
-  if (existing && existing.senderId !== senderId) {
-    map.set(key, { seenAt: now, ambiguous: true });
-    return;
+  if (existing) {
+    if (!("senderId" in existing) || existing.senderId !== senderId) {
+      map.set(key, { seenAt: now, ambiguous: true });
+      return;
+    }
   }
 
   map.set(key, { senderId, seenAt: now, ambiguous: false });
@@ -104,9 +104,8 @@ function takeSender(map: Map<string, SenderEntry>, key: string): string | undefi
   const entry = map.get(key);
   if (!entry) return undefined;
   map.delete(key);
-  if (Date.now() - entry.seenAt > STRUCTURED_SENDER_TTL_MS || entry.ambiguous) {
-    return undefined;
-  }
+  if (Date.now() - entry.seenAt > STRUCTURED_SENDER_TTL_MS) return undefined;
+  if (!("senderId" in entry)) return undefined;
   return entry.senderId;
 }
 
@@ -308,13 +307,17 @@ async function flushMessages(
 
 export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState): void {
   api.on("message_received", async (event, ctx) => {
-    const eventRecord = event as Record<string, unknown>;
-    const ctxRecord = ctx as Record<string, unknown>;
-    const senderId = normalizeString(eventRecord.senderId) ?? normalizeString(ctxRecord.senderId);
-    if (!senderId) return;
+    try {
+      const eventRecord = event as Record<string, unknown>;
+      const ctxRecord = ctx as Record<string, unknown>;
+      const senderId = normalizeString(eventRecord.senderId) ?? normalizeString(ctxRecord.senderId);
+      if (!senderId) return;
 
-    for (const sessionKey of getSenderSessionKeys(eventRecord, ctxRecord)) {
-      rememberStructuredSender(sessionKey, eventRecord, ctxRecord, senderId);
+      for (const sessionKey of getSenderSessionKeys(eventRecord, ctxRecord)) {
+        rememberStructuredSender(sessionKey, eventRecord, ctxRecord, senderId);
+      }
+    } catch (error) {
+      api.logger.debug?.(`[honcho] Failed to record structured sender: ${error}`);
     }
   });
 

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -11,6 +11,152 @@ import {
 } from "../helpers.js";
 import { subagentParentMap } from "./subagent.js";
 
+const STRUCTURED_SENDER_TTL_MS = 10 * 60 * 1000;
+
+type SenderEntry = {
+  senderId?: string;
+  seenAt: number;
+  ambiguous: boolean;
+};
+
+const senderByMessageKey = new Map<string, SenderEntry>();
+const senderByTimestampKey = new Map<string, SenderEntry>();
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function normalizeTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return Math.round(value);
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return Math.round(parsed);
+    const date = Date.parse(value);
+    if (Number.isFinite(date)) return date;
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function getMessageId(value: unknown): string | undefined {
+  const record = asRecord(value);
+  const openclaw = asRecord(record.__openclaw);
+  const metadata = asRecord(record.metadata);
+  return normalizeString(record.messageId) ??
+    normalizeString(record.message_id) ??
+    normalizeString(record.id) ??
+    normalizeString(openclaw.id) ??
+    normalizeString(metadata.messageId);
+}
+
+function getTimestamp(value: unknown): number | undefined {
+  const record = asRecord(value);
+  const metadata = asRecord(record.metadata);
+  return normalizeTimestamp(record.timestamp) ??
+    normalizeTimestamp(record.createdAt) ??
+    normalizeTimestamp(record.ts) ??
+    normalizeTimestamp(metadata.timestamp);
+}
+
+function getMessageProviderCandidates(event: Record<string, unknown>): string[] {
+  const metadata = asRecord(event.metadata);
+  return [metadata.provider, metadata.surface, metadata.originatingChannel]
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.trim())
+    .filter((value, index, values) => value.length > 0 && values.indexOf(value) === index);
+}
+
+function getSenderSessionKeys(
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+): string[] {
+  const sessionKey = normalizeString(event.sessionKey) ?? normalizeString(ctx.sessionKey);
+  if (!sessionKey) return [];
+
+  const keys = new Set([sessionKey]);
+  for (const messageProvider of getMessageProviderCandidates(event)) {
+    keys.add(buildSessionKey({ sessionKey, messageProvider }));
+  }
+  return [...keys];
+}
+
+function rememberSender(map: Map<string, SenderEntry>, key: string, senderId: string): void {
+  const now = Date.now();
+  for (const [storedKey, entry] of map) {
+    if (now - entry.seenAt > STRUCTURED_SENDER_TTL_MS) {
+      map.delete(storedKey);
+    }
+  }
+
+  const existing = map.get(key);
+  if (existing && existing.senderId !== senderId) {
+    map.set(key, { seenAt: now, ambiguous: true });
+    return;
+  }
+
+  map.set(key, { senderId, seenAt: now, ambiguous: false });
+}
+
+function takeSender(map: Map<string, SenderEntry>, key: string): string | undefined {
+  const entry = map.get(key);
+  if (!entry) return undefined;
+  map.delete(key);
+  if (Date.now() - entry.seenAt > STRUCTURED_SENDER_TTL_MS || entry.ambiguous) {
+    return undefined;
+  }
+  return entry.senderId;
+}
+
+function rememberStructuredSender(
+  sessionKey: string,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+  senderId: string,
+): void {
+  const messageId = getMessageId(event) ?? getMessageId(ctx);
+  if (messageId) {
+    rememberSender(senderByMessageKey, `${sessionKey}\n${messageId}`, senderId);
+  }
+
+  const timestamp = getTimestamp(event);
+  if (timestamp !== undefined) {
+    rememberSender(senderByTimestampKey, `${sessionKey}\n${timestamp}`, senderId);
+  }
+}
+
+function takeStructuredSender(sessionKey: string, msg: unknown): string | undefined {
+  const messageId = getMessageId(msg);
+  if (messageId) {
+    const senderId = takeSender(senderByMessageKey, `${sessionKey}\n${messageId}`);
+    if (senderId) return senderId;
+  }
+
+  const timestamp = getTimestamp(msg);
+  if (timestamp !== undefined) {
+    return takeSender(senderByTimestampKey, `${sessionKey}\n${timestamp}`);
+  }
+
+  return undefined;
+}
+
+function prependSenderMetadata(msg: unknown, senderId: string): unknown {
+  const rawContent = getRawContent(msg);
+  const metadata = [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({ sender_id: senderId }),
+    "```",
+    "",
+  ].join("\n");
+  return {
+    ...(msg as Record<string, unknown>),
+    content: `${metadata}${rawContent}`,
+  };
+}
+
 /**
  * Core message capture logic shared by agent_end, before_compaction, and before_reset.
  * Returns the number of new messages saved (or 0 if none).
@@ -62,25 +208,41 @@ async function flushMessages(
   }
 
   const newRawMessages = messages.slice(startIndex);
+  const adjustedRawMessages: unknown[] = [];
 
   // Pre-resolve participant peers for all unique sender IDs in this batch
   const senderIds = new Set<string>();
   let lastSenderId: string | undefined;
   let userMsgCount = 0;
   for (const msg of newRawMessages) {
-    if (!msg || typeof msg !== "object") continue;
+    if (!msg || typeof msg !== "object") {
+      adjustedRawMessages.push(msg);
+      continue;
+    }
     const m = msg as Record<string, unknown>;
-    if (m.role !== "user") continue;
+    if (m.role !== "user") {
+      adjustedRawMessages.push(msg);
+      continue;
+    }
     userMsgCount++;
     const rawContent = getRawContent(msg);
-    const senderId = extractSenderId(rawContent);
+    let senderId = extractSenderId(rawContent);
     if (senderId) {
+      takeStructuredSender(sessionKey, msg);
       senderIds.add(senderId);
       lastSenderId = senderId;
     } else {
+      senderId = takeStructuredSender(sessionKey, msg);
+      if (senderId) {
+        senderIds.add(senderId);
+        lastSenderId = senderId;
+        adjustedRawMessages.push(prependSenderMetadata(msg, senderId));
+        continue;
+      }
       const hasConvInfo = rawContent.includes("Conversation info (untrusted metadata):");
       api.logger.debug?.(`[honcho] User message without sender_id (hasConvInfo=${hasConvInfo}, contentLen=${rawContent.length})`);
     }
+    adjustedRawMessages.push(msg);
   }
   if (senderIds.size > 0) {
     api.logger.debug?.(`[honcho] Resolved ${senderIds.size} unique sender(s) from ${userMsgCount} user message(s)`);
@@ -115,7 +277,7 @@ async function flushMessages(
   await session.addPeers(peerConfigs);
 
   const extracted = extractMessages(
-    newRawMessages,
+    adjustedRawMessages,
     defaultParticipantPeer,
     agentPeer,
     state.cfg.noisePatterns,
@@ -145,6 +307,17 @@ async function flushMessages(
 }
 
 export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState): void {
+  api.on("message_received", async (event, ctx) => {
+    const eventRecord = event as Record<string, unknown>;
+    const ctxRecord = ctx as Record<string, unknown>;
+    const senderId = normalizeString(eventRecord.senderId) ?? normalizeString(ctxRecord.senderId);
+    if (!senderId) return;
+
+    for (const sessionKey of getSenderSessionKeys(eventRecord, ctxRecord)) {
+      rememberStructuredSender(sessionKey, eventRecord, ctxRecord, senderId);
+    }
+  });
+
   /**
    * agent_end — primary capture hook. Saves conversation messages after each turn.
    */

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -17,8 +17,7 @@ type SenderEntry =
   | { senderId: string; seenAt: number; ambiguous: false }
   | { seenAt: number; ambiguous: true };
 
-const senderByMessageKey = new Map<string, SenderEntry>();
-const senderByTimestampKey = new Map<string, SenderEntry>();
+const senderByStructuredKey = new Map<string, SenderEntry>();
 
 function normalizeString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
@@ -59,6 +58,46 @@ function getTimestamp(value: unknown): number | undefined {
     normalizeTimestamp(metadata.timestamp);
 }
 
+function getContentKey(value: unknown): string | undefined {
+  const record = asRecord(value);
+  return normalizeString(record.content) ??
+    normalizeString(record.bodyForAgent) ??
+    normalizeString(record.body) ??
+    normalizeString(record.rawBody);
+}
+
+function isOpenClawRuntimeContext(value: unknown): boolean {
+  const record = asRecord(value);
+  const role = normalizeString(record.role);
+  const type = normalizeString(record.type);
+  const customType = normalizeString(record.customType) ?? normalizeString(record.custom_type);
+  const hasConversationInfo = getRawContent(value).includes("Conversation info (untrusted metadata):");
+
+  return customType === "openclaw.runtime-context" ||
+    (type === "custom_message" && hasConversationInfo) ||
+    (role === "custom" && hasConversationInfo);
+}
+
+function getRuntimeContextSenderId(value: unknown): string | undefined {
+  if (!isOpenClawRuntimeContext(value)) return undefined;
+  return extractSenderId(getRawContent(value));
+}
+
+function getAdjacentRuntimeContextSenderId(messages: unknown[], index: number, userMsg: unknown): string | undefined {
+  const userTimestamp = getTimestamp(userMsg);
+  const adjacent = messages[index + 1];
+  const senderId = getRuntimeContextSenderId(adjacent);
+  if (!senderId) return undefined;
+
+  const contextTimestamp = getTimestamp(adjacent);
+  if (userTimestamp !== undefined && contextTimestamp !== undefined) {
+    const deltaMs = Math.abs(contextTimestamp - userTimestamp);
+    if (deltaMs > 30_000) return undefined;
+  }
+
+  return senderId;
+}
+
 function getMessageProviderCandidates(event: Record<string, unknown>): string[] {
   const metadata = asRecord(event.metadata);
   return [metadata.provider, metadata.surface, metadata.originatingChannel]
@@ -81,29 +120,52 @@ function getSenderSessionKeys(
   return [...keys];
 }
 
-function rememberSender(map: Map<string, SenderEntry>, key: string, senderId: string): void {
+function buildSenderCacheKey(kind: string, sessionKey: string, value: string | number): string {
+  return `${sessionKey}\n${kind}\n${value}`;
+}
+
+function getStructuredSenderKeys(
+  sessionKey: string,
+  value: unknown,
+  fallback?: unknown,
+): string[] {
+  const keys: string[] = [];
+
+  const messageId = getMessageId(value) ?? getMessageId(fallback);
+  if (messageId) keys.push(buildSenderCacheKey("message", sessionKey, messageId));
+
+  const timestamp = getTimestamp(value);
+  if (timestamp !== undefined) keys.push(buildSenderCacheKey("timestamp", sessionKey, timestamp));
+
+  const content = getContentKey(value);
+  if (content) keys.push(buildSenderCacheKey("content", sessionKey, content));
+
+  return keys;
+}
+
+function rememberSender(key: string, senderId: string): void {
   const now = Date.now();
-  for (const [storedKey, entry] of map) {
+  for (const [storedKey, entry] of senderByStructuredKey) {
     if (now - entry.seenAt > STRUCTURED_SENDER_TTL_MS) {
-      map.delete(storedKey);
+      senderByStructuredKey.delete(storedKey);
     }
   }
 
-  const existing = map.get(key);
+  const existing = senderByStructuredKey.get(key);
   if (existing) {
     if (!("senderId" in existing) || existing.senderId !== senderId) {
-      map.set(key, { seenAt: now, ambiguous: true });
+      senderByStructuredKey.set(key, { seenAt: now, ambiguous: true });
       return;
     }
   }
 
-  map.set(key, { senderId, seenAt: now, ambiguous: false });
+  senderByStructuredKey.set(key, { senderId, seenAt: now, ambiguous: false });
 }
 
-function takeSender(map: Map<string, SenderEntry>, key: string): string | undefined {
-  const entry = map.get(key);
+function takeSender(key: string): string | undefined {
+  const entry = senderByStructuredKey.get(key);
   if (!entry) return undefined;
-  map.delete(key);
+  senderByStructuredKey.delete(key);
   if (Date.now() - entry.seenAt > STRUCTURED_SENDER_TTL_MS) return undefined;
   if (!("senderId" in entry)) return undefined;
   return entry.senderId;
@@ -115,29 +177,16 @@ function rememberStructuredSender(
   ctx: Record<string, unknown>,
   senderId: string,
 ): void {
-  const messageId = getMessageId(event) ?? getMessageId(ctx);
-  if (messageId) {
-    rememberSender(senderByMessageKey, `${sessionKey}\n${messageId}`, senderId);
-  }
-
-  const timestamp = getTimestamp(event);
-  if (timestamp !== undefined) {
-    rememberSender(senderByTimestampKey, `${sessionKey}\n${timestamp}`, senderId);
+  for (const key of getStructuredSenderKeys(sessionKey, event, ctx)) {
+    rememberSender(key, senderId);
   }
 }
 
 function takeStructuredSender(sessionKey: string, msg: unknown): string | undefined {
-  const messageId = getMessageId(msg);
-  if (messageId) {
-    const senderId = takeSender(senderByMessageKey, `${sessionKey}\n${messageId}`);
+  for (const key of getStructuredSenderKeys(sessionKey, msg)) {
+    const senderId = takeSender(key);
     if (senderId) return senderId;
   }
-
-  const timestamp = getTimestamp(msg);
-  if (timestamp !== undefined) {
-    return takeSender(senderByTimestampKey, `${sessionKey}\n${timestamp}`);
-  }
-
   return undefined;
 }
 
@@ -213,7 +262,8 @@ async function flushMessages(
   const senderIds = new Set<string>();
   let lastSenderId: string | undefined;
   let userMsgCount = 0;
-  for (const msg of newRawMessages) {
+  for (let i = 0; i < newRawMessages.length; i++) {
+    const msg = newRawMessages[i];
     if (!msg || typeof msg !== "object") {
       adjustedRawMessages.push(msg);
       continue;
@@ -232,6 +282,9 @@ async function flushMessages(
       lastSenderId = senderId;
     } else {
       senderId = takeStructuredSender(sessionKey, msg);
+      if (!senderId) {
+        senderId = getAdjacentRuntimeContextSenderId(newRawMessages, i, msg);
+      }
       if (senderId) {
         senderIds.add(senderId);
         lastSenderId = senderId;

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerCaptureHook } from "../hooks/capture.js";
+import type { PluginState } from "../state.js";
+
+type HookMap = Map<string, (event: any, ctx: any) => Promise<void> | void>;
+type SavedMessage = { peerId: string; content: string; opts?: unknown };
+
+function createPeer(id: string, saved: SavedMessage[]) {
+  return {
+    id,
+    message(content: string, opts?: unknown) {
+      return { peerId: id, content, opts };
+    },
+    getMetadata: vi.fn(async () => ({})),
+    setMetadata: vi.fn(async () => {}),
+  } as never;
+}
+
+function createHarness() {
+  const hooks: HookMap = new Map();
+  const saved: SavedMessage[] = [];
+  const metadataBySession = new Map<string, Record<string, unknown>>();
+  const peers = new Map<string, ReturnType<typeof createPeer>>();
+
+  function peer(id: string) {
+    if (!peers.has(id)) peers.set(id, createPeer(id, saved));
+    return peers.get(id)!;
+  }
+
+  const sessions = new Map<string, Record<string, unknown>>();
+  function session(name: string) {
+    if (!sessions.has(name)) {
+      sessions.set(name, {
+        getMetadata: vi.fn(async () => metadataBySession.get(name) ?? {}),
+        setMetadata: vi.fn(async (meta: Record<string, unknown>) => {
+          metadataBySession.set(name, meta);
+        }),
+        addPeers: vi.fn(async () => {}),
+        addMessages: vi.fn(async (messages: SavedMessage[]) => {
+          saved.push(...messages);
+        }),
+      });
+    }
+    return sessions.get(name)!;
+  }
+
+  const api = {
+    on(name: string, handler: HookMap extends Map<string, infer H> ? H : never) {
+      hooks.set(name, handler);
+    },
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+
+  const state = {
+    cfg: {
+      workspaceId: "openclaw",
+      baseUrl: "http://localhost:8000",
+      noisePatterns: [],
+      disableDefaultNoisePatterns: false,
+      ownerObserveOthers: false,
+      crossSessionSearch: true,
+    },
+    honcho: { session: vi.fn(async (name: string) => session(name)) },
+    participantPeers: new Map(),
+    agentPeers: new Map(),
+    agentPeerMap: {},
+    turnStartIndex: new Map<string, number>(),
+    initialized: true,
+    api: api as never,
+    ensureInitialized: vi.fn(async () => {}),
+    getAgentPeer: vi.fn(async (agentId = "main") => peer(`agent-${agentId}`)),
+    getParticipantPeer: vi.fn(async (senderId = "owner") => peer(senderId)),
+    resolveSessionParticipantPeer: vi.fn(async () => peer("owner")),
+    isParticipantPeerId: vi.fn((peerId: string) => peerId === "owner"),
+    resolveDefaultAgentId: vi.fn(() => "main"),
+  } as unknown as PluginState;
+
+  registerCaptureHook(api as never, state);
+  return { hooks, saved };
+}
+
+describe("capture sender attribution", () => {
+  it("uses structured message_received senderId when text metadata was stripped", async () => {
+    const { hooks, saved } = createHarness();
+    const ctx = {
+      sessionKey: "agent-main-discord-channel-123",
+      messageProvider: "discord",
+      agentId: "main",
+    };
+
+    await hooks.get("message_received")?.({
+      senderId: "425084004937760780",
+      sessionKey: ctx.sessionKey,
+      messageId: "discord-message-1",
+      metadata: { provider: "discord" },
+    }, ctx);
+
+    await hooks.get("agent_end")?.({
+      success: true,
+      messages: [
+        { role: "user", content: "stripped hello", messageId: "discord-message-1" },
+      ],
+    }, ctx);
+
+    expect(saved).toEqual([
+      expect.objectContaining({
+        peerId: "425084004937760780",
+        content: "stripped hello",
+      }),
+    ]);
+  });
+
+  it("does not guess attribution when no structured key matches", async () => {
+    const { hooks, saved } = createHarness();
+    const ctx = {
+      sessionKey: "agent-main-discord-channel-456",
+      messageProvider: "discord",
+      agentId: "main",
+    };
+
+    await hooks.get("message_received")?.({
+      senderId: "425084004937760780",
+      sessionKey: ctx.sessionKey,
+      messageId: "discord-message-1",
+      metadata: { provider: "discord" },
+    }, ctx);
+
+    await hooks.get("agent_end")?.({
+      success: true,
+      messages: [
+        { role: "user", content: "no matching key", messageId: "different-message" },
+      ],
+    }, ctx);
+
+    expect(saved).toEqual([
+      expect.objectContaining({
+        peerId: "owner",
+        content: "no matching key",
+      }),
+    ]);
+  });
+
+  it("keeps textual Conversation info sender_id authoritative when present", async () => {
+    const { hooks, saved } = createHarness();
+    const ctx = {
+      sessionKey: "agent-main-discord-channel-789",
+      messageProvider: "discord",
+      agentId: "main",
+    };
+
+    await hooks.get("message_received")?.({
+      senderId: "wrong-sender",
+      sessionKey: ctx.sessionKey,
+      messageId: "discord-message-1",
+      metadata: { provider: "discord" },
+    }, ctx);
+
+    await hooks.get("agent_end")?.({
+      success: true,
+      messages: [
+        {
+          role: "user",
+          messageId: "discord-message-1",
+          content: [
+            "Conversation info (untrusted metadata):",
+            "```json",
+            JSON.stringify({ sender_id: "right-sender" }),
+            "```",
+            "",
+            "metadata hello",
+          ].join("\n"),
+        },
+      ],
+    }, ctx);
+
+    expect(saved).toEqual([
+      expect.objectContaining({
+        peerId: "right-sender",
+        content: "metadata hello",
+      }),
+    ]);
+  });
+});

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { registerCaptureHook } from "../hooks/capture.js";
 import type { PluginState } from "../state.js";
 
 type HookMap = Map<string, (event: any, ctx: any) => Promise<void> | void>;
@@ -16,7 +15,10 @@ function createPeer(id: string, saved: SavedMessage[]) {
   } as never;
 }
 
-function createHarness() {
+async function createHarness() {
+  vi.resetModules();
+  const { registerCaptureHook } = await import("../hooks/capture.js");
+
   const hooks: HookMap = new Map();
   const saved: SavedMessage[] = [];
   const metadataBySession = new Map<string, Record<string, unknown>>();
@@ -85,7 +87,7 @@ function createHarness() {
 
 describe("capture sender attribution", () => {
   it("uses structured message_received senderId when text metadata was stripped", async () => {
-    const { hooks, saved } = createHarness();
+    const { hooks, saved } = await createHarness();
     const ctx = {
       sessionKey: "agent-main-discord-channel-123",
       messageProvider: "discord",
@@ -115,7 +117,7 @@ describe("capture sender attribution", () => {
   });
 
   it("does not guess attribution when no structured key matches", async () => {
-    const { hooks, saved } = createHarness();
+    const { hooks, saved } = await createHarness();
     const ctx = {
       sessionKey: "agent-main-discord-channel-456",
       messageProvider: "discord",
@@ -145,7 +147,7 @@ describe("capture sender attribution", () => {
   });
 
   it("keeps textual Conversation info sender_id authoritative when present", async () => {
-    const { hooks, saved } = createHarness();
+    const { hooks, saved } = await createHarness();
     const ctx = {
       sessionKey: "agent-main-discord-channel-789",
       messageProvider: "discord",

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -4,6 +4,8 @@ import type { PluginState } from "../state.js";
 type HookMap = Map<string, (event: any, ctx: any) => Promise<void> | void>;
 type SavedMessage = { peerId: string; content: string; opts?: unknown };
 
+const DISCORD_SENDER_ID = "425084004937760780";
+
 function createPeer(id: string, saved: SavedMessage[]) {
   return {
     id,
@@ -85,105 +87,149 @@ async function createHarness() {
   return { hooks, saved };
 }
 
+function ctx(sessionKey: string) {
+  return {
+    sessionKey,
+    messageProvider: "discord",
+    agentId: "main",
+  };
+}
+
+function conversationInfo(data: Record<string, unknown>, body = "") {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify(data),
+    "```",
+    body ? "" : undefined,
+    body || undefined,
+  ].filter((line): line is string => typeof line === "string").join("\n");
+}
+
+async function receive(
+  hooks: HookMap,
+  context: ReturnType<typeof ctx>,
+  event: Record<string, unknown> = {},
+) {
+  await hooks.get("message_received")?.({
+    senderId: DISCORD_SENDER_ID,
+    sessionKey: context.sessionKey,
+    messageId: "discord-message-1",
+    metadata: { provider: "discord" },
+    ...event,
+  }, context);
+}
+
+async function endTurn(hooks: HookMap, context: ReturnType<typeof ctx>, messages: unknown[]) {
+  await hooks.get("agent_end")?.({ success: true, messages }, context);
+}
+
+function expectSaved(saved: SavedMessage[], peerId: string, content: string) {
+  expect(saved).toEqual([
+    expect.objectContaining({ peerId, content }),
+  ]);
+}
+
 describe("capture sender attribution", () => {
   it("uses structured message_received senderId when text metadata was stripped", async () => {
     const { hooks, saved } = await createHarness();
-    const ctx = {
-      sessionKey: "agent-main-discord-channel-123",
-      messageProvider: "discord",
-      agentId: "main",
-    };
+    const context = ctx("agent-main-discord-channel-123");
 
-    await hooks.get("message_received")?.({
-      senderId: "425084004937760780",
-      sessionKey: ctx.sessionKey,
-      messageId: "discord-message-1",
-      metadata: { provider: "discord" },
-    }, ctx);
-
-    await hooks.get("agent_end")?.({
-      success: true,
-      messages: [
-        { role: "user", content: "stripped hello", messageId: "discord-message-1" },
-      ],
-    }, ctx);
-
-    expect(saved).toEqual([
-      expect.objectContaining({
-        peerId: "425084004937760780",
-        content: "stripped hello",
-      }),
+    await receive(hooks, context);
+    await endTurn(hooks, context, [
+      { role: "user", content: "stripped hello", messageId: "discord-message-1" },
     ]);
+
+    expectSaved(saved, DISCORD_SENDER_ID, "stripped hello");
   });
 
   it("does not guess attribution when no structured key matches", async () => {
     const { hooks, saved } = await createHarness();
-    const ctx = {
-      sessionKey: "agent-main-discord-channel-456",
-      messageProvider: "discord",
-      agentId: "main",
-    };
+    const context = ctx("agent-main-discord-channel-456");
 
-    await hooks.get("message_received")?.({
-      senderId: "425084004937760780",
-      sessionKey: ctx.sessionKey,
-      messageId: "discord-message-1",
-      metadata: { provider: "discord" },
-    }, ctx);
-
-    await hooks.get("agent_end")?.({
-      success: true,
-      messages: [
-        { role: "user", content: "no matching key", messageId: "different-message" },
-      ],
-    }, ctx);
-
-    expect(saved).toEqual([
-      expect.objectContaining({
-        peerId: "owner",
-        content: "no matching key",
-      }),
+    await receive(hooks, context);
+    await endTurn(hooks, context, [
+      { role: "user", content: "no matching key", messageId: "different-message" },
     ]);
+
+    expectSaved(saved, "owner", "no matching key");
+  });
+
+  it("uses structured senderId by exact content when transcript has no message id", async () => {
+    const { hooks, saved } = await createHarness();
+    const context = ctx("agent-main-discord-channel-content");
+
+    await receive(hooks, context, {
+      content: "live discord text",
+    });
+    await endTurn(hooks, context, [
+      { role: "user", content: "live discord text" },
+    ]);
+
+    expectSaved(saved, DISCORD_SENDER_ID, "live discord text");
+  });
+
+  it("uses adjacent OpenClaw runtime-context sender_id when user message has no metadata", async () => {
+    const { hooks, saved } = await createHarness();
+    const context = ctx("agent-main-discord-channel-runtime-context");
+
+    await endTurn(hooks, context, [
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello from discord" }],
+        timestamp: 1778182777904,
+      },
+      {
+        role: "custom",
+        customType: "openclaw.runtime-context",
+        content: conversationInfo({
+          sender_id: DISCORD_SENDER_ID,
+          sender: "rendrag",
+          message_id: "1502032066576122047",
+        }),
+        timestamp: 1778182777919,
+      },
+    ]);
+
+    expectSaved(saved, DISCORD_SENDER_ID, "hello from discord");
+  });
+
+  it("does not use content attribution when duplicate text has conflicting senders", async () => {
+    const { hooks, saved } = await createHarness();
+    const context = ctx("agent-main-discord-channel-duplicate-content");
+
+    await receive(hooks, context, {
+      senderId: "sender-one",
+      messageId: "discord-message-1",
+      content: "same text",
+    });
+    await receive(hooks, context, {
+      senderId: "sender-two",
+      messageId: "discord-message-2",
+      content: "same text",
+    });
+    await endTurn(hooks, context, [
+      { role: "user", content: "same text" },
+    ]);
+
+    expectSaved(saved, "owner", "same text");
   });
 
   it("keeps textual Conversation info sender_id authoritative when present", async () => {
     const { hooks, saved } = await createHarness();
-    const ctx = {
-      sessionKey: "agent-main-discord-channel-789",
-      messageProvider: "discord",
-      agentId: "main",
-    };
+    const context = ctx("agent-main-discord-channel-789");
 
-    await hooks.get("message_received")?.({
+    await receive(hooks, context, {
       senderId: "wrong-sender",
-      sessionKey: ctx.sessionKey,
-      messageId: "discord-message-1",
-      metadata: { provider: "discord" },
-    }, ctx);
-
-    await hooks.get("agent_end")?.({
-      success: true,
-      messages: [
-        {
-          role: "user",
-          messageId: "discord-message-1",
-          content: [
-            "Conversation info (untrusted metadata):",
-            "```json",
-            JSON.stringify({ sender_id: "right-sender" }),
-            "```",
-            "",
-            "metadata hello",
-          ].join("\n"),
-        },
-      ],
-    }, ctx);
-
-    expect(saved).toEqual([
-      expect.objectContaining({
-        peerId: "right-sender",
-        content: "metadata hello",
-      }),
+    });
+    await endTurn(hooks, context, [
+      {
+        role: "user",
+        messageId: "discord-message-1",
+        content: conversationInfo({ sender_id: "right-sender" }, "metadata hello"),
+      },
     ]);
+
+    expectSaved(saved, "right-sender", "metadata hello");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #91.

This updates capture attribution so live OpenClaw messages that have already had their textual `Conversation info` metadata stripped can still be attributed to the correct participant when OpenClaw exposed structured sender data earlier on `message_received`.

## What changed

- Records structured `message_received.senderId` by exact session/message keys.
- Matches stripped captured user messages by `sessionKey + messageId`, with exact timestamp as a secondary key when present.
- Leaves unmatched stripped messages on the existing fallback path instead of guessing attribution.
- Keeps textual `Conversation info.sender_id` authoritative when it is still present.
- Adds focused capture tests for matched, unmatched, and textual-metadata cases.

## Why

`extractMessages()` can only assign per-sender peers when `extractSenderId(rawContent)` finds a textual metadata block. OpenClaw can strip that block before `agent_end`, `before_compaction`, or `before_reset` capture sees the message, even though structured sender information was available earlier on `message_received`.

Without a keyed handoff, stripped Discord/group-chat messages can fall back to the `owner` peer and pollute the owner representation.

## Validation

- `pnpm install --ignore-scripts`
- `pnpm vitest run test/capture.test.ts`
- `pnpm vitest run`
- `pnpm build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of sender identification in conversations through enhanced context tracking and fallback mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->