### PR TITLE
feat: declare contracts.tools in plugin manifest

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,7 +24,9 @@
       },
       "noisePatterns": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Additional substring patterns to skip messages. Built-in defaults (HEARTBEAT_OK, cron reminders, etc.) always apply."
       },
       "ownerObserveOthers": {
@@ -35,7 +37,7 @@
       "disableDefaultNoisePatterns": {
         "type": "boolean",
         "default": false,
-        "description": "When true, built-in noise patterns are not applied — only noisePatterns entries are used."
+        "description": "When true, built-in noise patterns are not applied \u2014 only noisePatterns entries are used."
       },
       "crossSessionSearch": {
         "type": "boolean",
@@ -80,12 +82,23 @@
     "disableDefaultNoisePatterns": {
       "label": "Disable Default Noise Patterns",
       "advanced": true,
-      "help": "When enabled, only custom noisePatterns entries are used — built-in defaults are skipped."
+      "help": "When enabled, only custom noisePatterns entries are used \u2014 built-in defaults are skipped."
     },
     "crossSessionSearch": {
       "label": "Cross-Session Search",
       "advanced": true,
       "help": "When enabled (default), memory tools can return results from any session in the workspace. Disable to scope results to the active session only."
     }
+  },
+  "contracts": {
+    "tools": [
+      "honcho_ask",
+      "honcho_context",
+      "honcho_search_conclusions",
+      "honcho_search_messages",
+      "honcho_session",
+      "memory_search",
+      "memory_get"
+    ]
   }
 }


### PR DESCRIPTION
## Problem

OpenClaw v2026.5.x requires plugins to declare `contracts.tools` in their manifest before registering agent tools. Without this, OpenClaw logs warnings at startup for every tool registration call:

```
[gateway] [plugins] plugin must declare contracts.tools before registering agent tools (plugin=openclaw-honcho)
[gateway] [plugins] plugin must declare contracts.tools for: memory_search (plugin=openclaw-honcho)
[gateway] [plugins] plugin must declare contracts.tools for: memory_get (plugin=openclaw-honcho)
```

## Fix

Add `contracts.tools` to `openclaw.plugin.json` listing all tools this plugin registers.

## Tools declared

- `honcho_ask`
- `honcho_context`
- `honcho_search_conclusions`
- `honcho_search_messages`
- `honcho_session`
- `memory_search`
- `memory_get`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration schema structure for improved clarity in noise pattern definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->