### PR TITLE
fix: bound Honcho session key length

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -2,10 +2,15 @@
  * Pure helper functions — no mutable state dependencies.
  */
 
+import { createHash } from "node:crypto";
+
 import type { Peer, MessageInput } from "@honcho-ai/sdk";
 
 type ContentBlock = { type?: string; text?: unknown };
 type RawMessage = { role?: string; content?: string | ContentBlock[]; timestamp?: number };
+
+const HONCHO_SESSION_ID_MAX_LENGTH = 100;
+const SESSION_KEY_HASH_LENGTH = 16;
 
 /**
  * Extract plain text from a message's `content` (string or array of content blocks).
@@ -28,12 +33,24 @@ export function getRawContent(msg: unknown): string {
  * Build a Honcho session key from OpenClaw context.
  * Combines sessionKey + messageProvider to create unique sessions per platform.
  * Uses hyphens as separators (Honcho requires hyphens, not underscores).
+ * Honcho session IDs are capped at 100 characters, so overlong keys keep a
+ * readable prefix plus a deterministic hash suffix.
  */
 export function buildSessionKey(ctx?: { sessionKey?: string; messageProvider?: string }): string {
   const baseKey = ctx?.sessionKey ?? "default";
   const provider = ctx?.messageProvider ?? "unknown";
   const combined = `${baseKey}-${provider}`;
-  return combined.replace(/[^a-zA-Z0-9-]/g, "-");
+  const legacyKey = combined.replace(/[^a-zA-Z0-9-]/g, "-");
+
+  if (legacyKey.length <= HONCHO_SESSION_ID_MAX_LENGTH) return legacyKey;
+
+  const digest = createHash("sha256")
+    .update(legacyKey, "utf8")
+    .digest("hex")
+    .slice(0, SESSION_KEY_HASH_LENGTH);
+  const suffix = `-${digest}`;
+
+  return legacyKey.slice(0, HONCHO_SESSION_ID_MAX_LENGTH - suffix.length) + suffix;
 }
 
 export function isSubagentSession(ctx?: { sessionKey?: string }): boolean {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractSenderId } from "../helpers.js";
+import { buildSessionKey, extractSenderId } from "../helpers.js";
 
 const SENTINEL = "Conversation info (untrusted metadata):";
 
@@ -11,6 +11,66 @@ function metadataBlock(payload: Record<string, unknown>): string {
     "```",
   ].join("\n");
 }
+
+describe("buildSessionKey", () => {
+  it("preserves existing short session keys byte-for-byte", () => {
+    expect(buildSessionKey({ sessionKey: "agent:main:telegram:direct:8259661815", messageProvider: "telegram" }))
+      .toBe("agent-main-telegram-direct-8259661815-telegram");
+  });
+
+  it("uses existing default values", () => {
+    expect(buildSessionKey()).toBe("default-unknown");
+  });
+
+  it("preserves sanitization behavior for valid-length keys", () => {
+    expect(buildSessionKey({ sessionKey: "agent:main:discord:channel:abc_def", messageProvider: "discord/web" }))
+      .toBe("agent-main-discord-channel-abc-def-discord-web");
+  });
+
+  it("bounds overlong isolated cron run keys to Honcho's session ID limit", () => {
+    const key = buildSessionKey({
+      sessionKey: "agent:main:cron:265fdd54-a132-4076-a87b-bc08b72de2b1:run:2351a6ec-3b5c-4291-bb0a-ac4adfa323cc",
+      messageProvider: "unknown",
+    });
+
+    expect(key.length).toBeLessThanOrEqual(100);
+    expect(key).toMatch(/^agent-main-cron-265fdd54-a132-4076-a87b-bc08b72de2b1-run-/);
+    expect(key).toMatch(/-[0-9a-f]{16}$/);
+  });
+
+  it("shortens long keys deterministically", () => {
+    const ctx = {
+      sessionKey: "agent:main:cron:265fdd54-a132-4076-a87b-bc08b72de2b1:run:2351a6ec-3b5c-4291-bb0a-ac4adfa323cc",
+      messageProvider: "unknown",
+    };
+
+    expect(buildSessionKey(ctx)).toBe(buildSessionKey(ctx));
+  });
+
+  it("keeps long keys distinct via the hash suffix", () => {
+    const first = buildSessionKey({
+      sessionKey: "agent:main:cron:265fdd54-a132-4076-a87b-bc08b72de2b1:run:2351a6ec-3b5c-4291-bb0a-ac4adfa323cc",
+      messageProvider: "unknown",
+    });
+    const second = buildSessionKey({
+      sessionKey: "agent:main:cron:265fdd54-a132-4076-a87b-bc08b72de2b1:run:42f3a913-8a60-4e65-b0aa-985c62ec1583",
+      messageProvider: "unknown",
+    });
+
+    expect(first).not.toBe(second);
+    expect(first.length).toBeLessThanOrEqual(100);
+    expect(second.length).toBeLessThanOrEqual(100);
+    expect(first).toMatch(/-[0-9a-f]{16}$/);
+    expect(second).toMatch(/-[0-9a-f]{16}$/);
+  });
+
+  it("includes the provider in shortened key identity", () => {
+    const sessionKey = "agent:main:cron:265fdd54-a132-4076-a87b-bc08b72de2b1:run:2351a6ec-3b5c-4291-bb0a-ac4adfa323cc";
+
+    expect(buildSessionKey({ sessionKey, messageProvider: "unknown" }))
+      .not.toBe(buildSessionKey({ sessionKey, messageProvider: "cron" }));
+  });
+});
 
 describe("extractSenderId", () => {
   it("reads sender_id from a leading metadata block", () => {


### PR DESCRIPTION
## Summary

Fixes #87. Related to #86.

Fixes Honcho session key generation for long OpenClaw session keys by enforcing Honcho's 100-character session ID limit.

OpenClaw isolated cron runs can produce session keys like:

```text
agent:main:cron:<job-uuid>:run:<run-session-uuid>
```

After the plugin appends the message provider and sanitizes the value, these can exceed Honcho's maximum session ID length. The result is a context fetch failure like:

```text
Session ID can be at most 100 characters
```

This patch preserves the existing byte-for-byte output for all valid-length keys, and only shortens overlong keys using a readable prefix plus deterministic SHA-256 hash suffix.

## Behavior

- Existing session keys `<= 100` chars are unchanged.
- Overlong session keys are bounded to `<= 100` chars.
- Overlong keys remain deterministic.
- Different long keys remain distinct via the hash suffix.
- No config or migration is required for existing valid session IDs.

## Tests

Added coverage for:

- short-key compatibility
- default values
- sanitization compatibility
- isolated cron-shaped overlong keys
- deterministic shortening
- distinct long keys
- provider-specific identity

Quality gates run locally:

```text
./node_modules/.bin/vitest --run
./node_modules/.bin/tsc
```

Both passed.