### PR TITLE
feat: add explicit Honcho remember tool

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ import { registerContextTool } from "./tools/context.js";
 import { registerAskTool } from "./tools/ask.js";
 import { registerMemoryPassthrough } from "./tools/memory-passthrough.js";
 import { registerMessageSearchTool } from "./tools/message-search.js";
+import { registerRememberTool } from "./tools/remember.js";
 import { registerCli } from "./commands/cli.js";
 import { registerHonchoMemoryRuntime } from "./runtime.js";
 
@@ -37,8 +38,9 @@ export const buildPromptSection: MemoryPromptSectionBuilder = ({
   const hasSearch = availableTools.has("honcho_search_conclusions");
   const hasAsk = availableTools.has("honcho_ask");
   const hasMessageSearch = availableTools.has("honcho_search_messages");
+  const hasRemember = availableTools.has("honcho_remember");
 
-  const anyTool = hasSession || hasContext || hasSearch || hasAsk || hasMessageSearch;
+  const anyTool = hasSession || hasContext || hasSearch || hasAsk || hasMessageSearch || hasRemember;
   if (!anyTool) return [];
 
   const lines: string[] = ["## Honcho Memory"];
@@ -63,6 +65,11 @@ export const buildPromptSection: MemoryPromptSectionBuilder = ({
   if (hasMessageSearch) {
     lines.push(
       "- honcho_search_messages: Find specific messages across all sessions. Filter by sender (user/agent/all), date, metadata."
+    );
+  }
+  if (hasRemember) {
+    lines.push(
+      "- honcho_remember: Explicitly save a durable fact, preference, decision, or project state when the user asks you to remember something."
     );
   }
   if (hasSession) {
@@ -105,12 +112,13 @@ export default definePluginEntry({
     registerContextHook(api, state);
     registerCaptureHook(api, state);
 
-    // Tools (5 core + 2 passthrough)
+    // Tools (6 core + 2 passthrough)
     registerSessionTool(api, state);
     registerContextTool(api, state);
     registerSearchTool(api, state);
     registerAskTool(api, state);
     registerMessageSearchTool(api, state);
+    registerRememberTool(api, state);
     registerMemoryPassthrough(api, state);
 
     // CLI

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,18 @@
 {
   "id": "openclaw-honcho",
   "kind": "memory",
+  "contracts": {
+    "tools": [
+      "honcho_context",
+      "honcho_search_conclusions",
+      "honcho_search_messages",
+      "honcho_session",
+      "honcho_ask",
+      "honcho_remember",
+      "memory_search",
+      "memory_get"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/test/remember.test.ts
+++ b/test/remember.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerRememberTool } from "../tools/remember.js";
+import type { PluginState } from "../state.js";
+
+function createHarness(createResult: Array<{ id: string }> = [{ id: "conclusion-1" }]) {
+  const create = vi.fn(async () => createResult);
+  const observedPeer = { id: "owner" };
+  const agentPeer = {
+    id: "agent-main",
+    conclusions: { create },
+    conclusionsOf: vi.fn(() => ({ create })),
+  };
+  const state = {
+    cfg: { workspaceId: "workspace-1" },
+    honcho: {
+      session: vi.fn(async () => ({})),
+    },
+    ensureInitialized: vi.fn(async () => {}),
+    getAgentPeer: vi.fn(async () => agentPeer),
+    getParticipantPeer: vi.fn(async () => observedPeer),
+    resolveSessionParticipantPeer: vi.fn(async () => observedPeer),
+    resolveDefaultAgentId: vi.fn(() => "main"),
+  } as unknown as PluginState;
+  const registrations: Array<{ factory: (ctx: Record<string, unknown>) => Record<string, unknown> }> = [];
+  const api = {
+    registerTool: (factory: (ctx: Record<string, unknown>) => Record<string, unknown>) => {
+      registrations.push({ factory });
+    },
+  };
+
+  registerRememberTool(api as never, state);
+  const tool = registrations[0]!.factory({
+    agentId: "main",
+    messageProvider: "test",
+    sessionKey: "session-1",
+  }) as {
+    execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+  };
+
+  return { agentPeer, create, state, tool };
+}
+
+describe("honcho_remember", () => {
+  it("reports the created conclusion id on success", async () => {
+    const { create, tool } = createHarness([{ id: "conclusion-1" }]);
+
+    const result = await tool.execute("call-1", { content: "Remember this" });
+
+    expect(create).toHaveBeenCalledWith({
+      content: "Remember this",
+      sessionId: "session-1-test",
+    });
+    expect(result.content[0]?.text).toBe("Saved to Honcho (owner): conclusion-1");
+  });
+
+  it("fails instead of reporting success when Honcho returns no records", async () => {
+    const { tool } = createHarness([]);
+
+    await expect(tool.execute("call-1", { content: "Remember this" })).rejects.toThrow(
+      /returned no created conclusions/
+    );
+  });
+});

--- a/tools/remember.ts
+++ b/tools/remember.ts
@@ -1,0 +1,99 @@
+import { Type } from "@sinclair/typebox";
+// @ts-ignore - resolved by openclaw runtime
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { PluginState } from "../state.js";
+import { buildSessionKey } from "../helpers.js";
+
+export function registerRememberTool(api: OpenClawPluginApi, state: PluginState): void {
+  api.registerTool(
+    (toolCtx) => ({
+      name: "honcho_remember",
+      label: "Remember in Honcho",
+      description:
+        "Explicitly save a durable conclusion to Honcho. Use when the user asks to remember something or when important project state must be persisted now.",
+      parameters: Type.Object(
+        {
+          content: Type.String({
+            description:
+              "The durable fact, preference, decision, or project state to save. Write it as a concise standalone memory.",
+            minLength: 1,
+          }),
+          about: Type.Optional(
+            Type.String({
+              description:
+                "Sender ID of the participant the memory is about. Defaults to the current session participant.",
+            })
+          ),
+          observed: Type.Optional(
+            Type.Unsafe<"participant" | "agent">({
+              type: "string",
+              enum: ["participant", "agent"],
+              description:
+                "Who the memory is about. Default: participant. Use agent for assistant/self operating lessons.",
+            })
+          ),
+          attachToCurrentSession: Type.Optional(
+            Type.Boolean({
+              description: "Attach the conclusion to the current Honcho session. Default: true.",
+            })
+          ),
+        },
+        { additionalProperties: false }
+      ),
+      async execute(_toolCallId, params) {
+        const {
+          content: rawContent,
+          about,
+          observed = "participant",
+          attachToCurrentSession = true,
+        } = params as {
+          content: string;
+          about?: string;
+          observed?: "participant" | "agent";
+          attachToCurrentSession?: boolean;
+        };
+        const content = rawContent.trim();
+        if (!content) throw new Error("content required");
+
+        const sessionKey = buildSessionKey(toolCtx);
+        const agentId = toolCtx.agentId ?? state.resolveDefaultAgentId();
+
+        await state.ensureInitialized();
+        const agentPeer = await state.getAgentPeer(agentId);
+        const observedPeer =
+          observed === "agent"
+            ? agentPeer
+            : about
+              ? await state.getParticipantPeer(about)
+              : await state.resolveSessionParticipantPeer(sessionKey);
+        const scope = observed === "agent" ? agentPeer.conclusions : agentPeer.conclusionsOf(observedPeer);
+
+        const sessionId = attachToCurrentSession ? sessionKey : undefined;
+        if (sessionId) {
+          await state.honcho.session(sessionId, { metadata: { agentId } });
+        }
+
+        const created = await scope.create({ content, ...(sessionId ? { sessionId } : {}) });
+        const first = created[0];
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Saved to Honcho (${observedPeer.id})${first?.id ? `: ${first.id}` : ""}`,
+            },
+          ],
+          details: {
+            id: first?.id,
+            content,
+            observer: agentPeer.id,
+            observed: observedPeer.id,
+            sessionId: sessionId ?? null,
+            workspaceId: state.cfg.workspaceId,
+          },
+        };
+      },
+    }),
+    { name: "honcho_remember" }
+  );
+}

--- a/tools/remember.ts
+++ b/tools/remember.ts
@@ -21,7 +21,7 @@ export function registerRememberTool(api: OpenClawPluginApi, state: PluginState)
           about: Type.Optional(
             Type.String({
               description:
-                "Sender ID of the participant the memory is about. Defaults to the current session participant.",
+                "Sender ID of the participant the memory is about. Defaults to the current session participant. Ignored when observed is 'agent'.",
             })
           ),
           observed: Type.Optional(
@@ -29,7 +29,7 @@ export function registerRememberTool(api: OpenClawPluginApi, state: PluginState)
               type: "string",
               enum: ["participant", "agent"],
               description:
-                "Who the memory is about. Default: participant. Use agent for assistant/self operating lessons.",
+                "Who the memory is about. Default: participant. Use agent for assistant/self operating lessons; agent memories always use the agent peer and ignore about.",
             })
           ),
           attachToCurrentSession: Type.Optional(
@@ -75,6 +75,9 @@ export function registerRememberTool(api: OpenClawPluginApi, state: PluginState)
 
         const created = await scope.create({ content, ...(sessionId ? { sessionId } : {}) });
         const first = created[0];
+        if (!first) {
+          throw new Error("honcho_remember: Honcho returned no created conclusions; memory was not saved");
+        }
 
         return {
           content: [


### PR DESCRIPTION
## Summary
- add `honcho_remember` for explicit durable memory writes into Honcho conclusions
- wire the tool into the Honcho memory prompt guidance and plugin registration
- declare Honcho-provided tools in `contracts.tools` so OpenClaw plugin diagnostics know about them

## Why
OpenClaw can use Honcho as the active memory backend for capture/recall, but agents currently lack a clean first-class tool for explicit “remember this” writes. This makes durable project state writes fall back to local Markdown or ad-hoc CLI usage.

## Test plan
- `pnpm build`
- `pnpm exec vitest run`

All tests pass locally: 35/35.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Remember" tool to explicitly save durable user/procedural memory, with options for content, observer context, and optional session attachment.
  * Expanded memory capabilities with new tools/contracts for sessions, searching conclusions and messages, and memory retrieval.
* **Tests**
  * Added tests validating successful memory creation and error handling when creation fails.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/95)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->