### PR TITLE
docs: add TweetClaw research memory workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,16 @@ Honcho stores durable memory for OpenClaw sessions. If the same agent needs publ
 openclaw plugins install @xquik/tweetclaw
 ```
 
-TweetClaw is also published on [npm](https://www.npmjs.com/package/@xquik/tweetclaw) and [ClawHub](https://clawhub.openclaw.ai/packages/@xquik/tweetclaw). Use it for tweet search, reply search, follower export, user lookup, media upload and download, direct messages, tweet monitors, webhooks, giveaway draws, and approval-gated post tweets or post tweet replies.
+TweetClaw is also published on [npm](https://www.npmjs.com/package/@xquik/tweetclaw) and listed on [ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw). Use it when Honcho-backed research needs:
+
+- Search and lookup: tweet search, reply search, and user lookup
+- Export and media: follower export plus media upload and download
+- Monitoring: tweet monitors, webhooks, and giveaway draws
+- Approval-gated actions: post tweets, post tweet replies, and direct messages
 
 For research workflows, have the agent summarize the useful TweetClaw findings in the session with source tweet URLs, author handles, query terms, and decisions. Honcho will capture that turn like any other OpenClaw conversation, making the X/Twitter evidence available through `honcho_context`, `honcho_search_conclusions`, `honcho_search_messages`, and `honcho_ask`.
 
-Keep Honcho credentials separate from TweetClaw and Xquik credentials. Require OpenClaw approval before posting, replying, direct messaging, following, or unfollowing on X/Twitter.
+Keep Honcho credentials separate from TweetClaw and Xquik credentials. TweetClaw marks write-like calls for OpenClaw approval when approval hooks are available; still show the exact account, endpoint, and payload before posting, replying, direct messaging, following, or unfollowing on X/Twitter.
 
 ## Multi-Agent Support
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ Once installed, the plugin works automatically:
 
 Honcho handles all reasoning and synthesis in the cloud.
 
+## X/Twitter Research Memory
+
+Honcho stores durable memory for OpenClaw sessions. If the same agent needs public X/Twitter inputs before memory synthesis, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) beside Honcho:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+TweetClaw is also published on [npm](https://www.npmjs.com/package/@xquik/tweetclaw) and [ClawHub](https://clawhub.openclaw.ai/packages/@xquik/tweetclaw). Use it for tweet search, reply search, follower export, user lookup, media upload and download, direct messages, tweet monitors, webhooks, giveaway draws, and approval-gated post tweets or post tweet replies.
+
+For research workflows, have the agent summarize the useful TweetClaw findings in the session with source tweet URLs, author handles, query terms, and decisions. Honcho will capture that turn like any other OpenClaw conversation, making the X/Twitter evidence available through `honcho_context`, `honcho_search_conclusions`, `honcho_search_messages`, and `honcho_ask`.
+
+Keep Honcho credentials separate from TweetClaw and Xquik credentials. Require OpenClaw approval before posting, replying, direct messaging, following, or unfollowing on X/Twitter.
+
 ## Multi-Agent Support
 
 OpenClaw uses a multi-agent architecture where a primary agent can spawn **subagents** to handle specialized tasks. The Honcho plugin is fully aware of this hierarchy:


### PR DESCRIPTION
## Summary
- Add TweetClaw as an optional X/Twitter research source for Honcho-backed OpenClaw memory workflows.
- Link the OpenClaw plugin install command plus npm and ClawHub pages.
- Keep Honcho scoped to memory capture and retrieval while documenting credential separation and approval-gated X/Twitter actions.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm build`
- `pnpm exec vitest run`
- `pnpm pack --dry-run`
- `git diff --check`
- changed-diff credential scan

No NHS badge change: this README uses a banner image rather than a badge row, so I kept the badge surface untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new X/Twitter Research Memory documentation section covering integration with TweetClaw for research workflows, including usage recommendations and security requirements for credential separation and approval workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/97)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->