### PR TITLE
feat: bridge QMD into Honcho memory_search/memory_get

### DIFF
--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -16,6 +16,7 @@ type UploadManifest = Record<string, ManifestEntry>;
 
 const MANIFEST_PATH = () => path.join(os.homedir(), ".openclaw", ".upload-manifest.json");
 
+/** Load the upload manifest from disk (empty object on failure). */
 function loadManifest(): UploadManifest {
   try {
     return JSON.parse(fs.readFileSync(MANIFEST_PATH(), "utf-8"));
@@ -24,16 +25,19 @@ function loadManifest(): UploadManifest {
   }
 }
 
+/** Write the upload manifest to disk, creating parent directories as needed. */
 function saveManifest(manifest: UploadManifest): void {
   const dir = path.dirname(MANIFEST_PATH());
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(MANIFEST_PATH(), JSON.stringify(manifest, null, 2));
 }
 
+/** Compute SHA-256 hex digest of a buffer. */
 function contentHash(content: Buffer): string {
   return crypto.createHash("sha256").update(content).digest("hex");
 }
 
+/** Register the `honcho` CLI command group (setup, status, ask, search) with the OpenClaw CLI. */
 export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
   api.registerCli(
     ({ program, workspaceDir }) => {
@@ -157,10 +161,12 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
             type FileEntry = { filePath: string; peer: "owner" | "agent"; peerId: string; agentId?: string };
             const detected: FileEntry[] = [];
 
+            /** Return true if the given file path is already tracked in the detected list for a peer. */
             function hasDetected(filePath: string, peerId: string): boolean {
               return detected.some((entry) => entry.filePath === filePath && entry.peerId === peerId);
             }
 
+            /** Recursively collect files from a directory, tagging them with the given peer type and optional agent ID. */
             function collectDir(dirPath: string, peerType: "owner" | "agent", agentId?: string): void {
               if (!fs.existsSync(dirPath)) return;
               const dirEntries = fs.readdirSync(dirPath, { withFileTypes: true });
@@ -175,10 +181,16 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
             const ocHome = path.join(os.homedir(), ".openclaw");
             const defaultWorkspace = ((savedConfig?.agents as Record<string, unknown>)?.defaults as Record<string, unknown>)?.workspace as string | undefined;
 
+            /** Deduplicate workspace paths by realpath — returns unique, non-empty paths only. */
             function uniqueWorkspacePaths(paths: Array<string | undefined>): string[] {
               const seen = new Set<string>();
               return paths.filter((p): p is string => typeof p === "string" && p.length > 0).filter((p) => {
-                const real = fs.existsSync(p) ? fs.realpathSync(p) : p;
+                let real: string;
+                try {
+                  real = fs.existsSync(p) ? fs.realpathSync(p) : p;
+                } catch {
+                  real = p;
+                }
                 if (seen.has(real)) return false;
                 seen.add(real);
                 return true;
@@ -194,6 +206,7 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
               path.join(os.homedir(), ".clawdbot", "workspace"),
             ]);
 
+            /** Scan a workspace directory for owner files (USER.md) and — if agentId provided — agent files and working dirs (memory/, canvas/). */
             function scanWorkspace(wsDir: string, agentId?: string): void {
               // Owner files (USER.md) always route to the owner peer.
               for (const file of OWNER_FILES) {
@@ -474,10 +487,14 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
           try {
             await state.ensureInitialized();
             const participantPeer = await state.getParticipantPeer(options.peer);
+            const topK = parseInt(options.topK, 10);
+            const maxDistance = parseFloat(options.maxDistance);
+            const searchTopK = Number.isFinite(topK) && topK > 0 ? topK : 10;
+            const searchMaxDistance = Number.isFinite(maxDistance) && maxDistance >= 0 && maxDistance <= 1 ? maxDistance : 0.5;
             const representation = await participantPeer.representation({
               searchQuery: query,
-              searchTopK: parseInt(options.topK, 10),
-              searchMaxDistance: parseFloat(options.maxDistance),
+              searchTopK,
+              searchMaxDistance,
             });
 
             if (!representation) {

--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -489,7 +489,7 @@ export function registerCli(api: OpenClawPluginApi, state: PluginState): void {
             const participantPeer = await state.getParticipantPeer(options.peer);
             const topK = parseInt(options.topK, 10);
             const maxDistance = parseFloat(options.maxDistance);
-            const searchTopK = Number.isFinite(topK) && topK > 0 ? topK : 10;
+            const searchTopK = Number.isFinite(topK) && topK > 0 ? Math.min(topK, 100) : 10;
             const searchMaxDistance = Number.isFinite(maxDistance) && maxDistance >= 0 && maxDistance <= 1 ? maxDistance : 0.5;
             const representation = await participantPeer.representation({
               searchQuery: query,

--- a/config.ts
+++ b/config.ts
@@ -2,6 +2,7 @@
  * Configuration schema and parsing for the Honcho memory plugin.
  */
 
+/** Default patterns that indicate noise messages (heartbeat, scheduled reminders, queue notices). These are stripped from Honcho capture. */
 export const DEFAULT_NOISE_PATTERNS: string[] = [
   "HEARTBEAT_OK",
   "A scheduled reminder has been triggered",
@@ -24,6 +25,7 @@ export type HonchoConfig = {
  * Resolve environment variable references in config values.
  * Supports ${ENV_VAR} syntax.
  */
+/** Resolve ${ENV_VAR} references in a config value string. Throws if a referenced variable is unset. */
 function resolveEnvVars(value: string): string {
   return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
     const envValue = process.env[envVar];
@@ -34,6 +36,7 @@ function resolveEnvVars(value: string): string {
   });
 }
 
+/** Schema parser for Honcho plugin config — resolves env var references, normalizes noise patterns, and applies defaults. */
 export const honchoConfigSchema = {
   parse(value: unknown): HonchoConfig {
     const cfg = (value ?? {}) as Record<string, unknown>;

--- a/helpers.ts
+++ b/helpers.ts
@@ -34,6 +34,7 @@ export function getRawContent(msg: unknown): string {
     .join("\n");
 }
 
+/** Normalize a raw session key: trim whitespace, default to "default" if empty. */
 export function normalizeSessionKey(raw?: string): string {
   return (raw ?? "default").trim() || "default";
 }
@@ -44,6 +45,7 @@ export function normalizeSessionKey(raw?: string): string {
  * helper is not re-exported from `openclaw/plugin-sdk/routing` at the pinned
  * peer-dep version.
  */
+/** Check whether a session key contains a `:thread:` suffix (mirrors upstream parseThreadSessionSuffix). */
 function hasThreadSuffix(sessionKey: string): boolean {
   return sessionKey.toLowerCase().includes(":thread:");
 }
@@ -53,6 +55,11 @@ function hasThreadSuffix(sessionKey: string): boolean {
  * categories tracked in Honcho session metadata. Cron and subagent
  * detection delegate to upstream OpenClaw helpers so plugin classification
  * cannot drift from the routing-key DSL.
+ */
+/**
+ * Classify a normalized OpenClaw sessionKey into one of the persistence
+ * categories tracked in Honcho session metadata. Cron and subagent
+ * detection delegate to upstream OpenClaw helpers.
  */
 export function classifySession(sessionKey: string): SessionClass {
   if (isSubagentSessionKey(sessionKey)) return "subagent";
@@ -72,6 +79,10 @@ export function classifySession(sessionKey: string): SessionClass {
  * Note: this is sourced from the same string that feeds the hash, so it cannot
  * disagree with the hash. `ctx.messageProvider` is deliberately not consulted.
  */
+/**
+ * Extract the channel/provider segment from a canonical OpenClaw sessionKey
+ * (`agent:<agentId>:<provider>:...`). Returns null for non-canonical keys.
+ */
 export function extractProvider(sessionKey: string): string | null {
   const m = /^agent:[^:]+:([^:]+)/.exec(sessionKey);
   return m ? m[1].toLowerCase() : null;
@@ -90,6 +101,12 @@ export function extractProvider(sessionKey: string): string | null {
  * (typically `state.resolveDefaultAgentId`) so the id matches the agent id used
  * by `flushMessages` / `before_prompt_build`. Without a resolver we fall back
  * to "main", which only matches workspaces with no configured default agent.
+ */
+/**
+ * Build a Honcho session id of the form
+ * `<sessionClass>-[<provider>-]<agentId>-<24 hex>`.
+ * Decoupled from OpenClaw's routing-key DSL — prefix segments are derived
+ * from the same inputs as the hash, so they cannot drift independently.
  */
 export function buildSessionKey(
   ctx?: { sessionKey?: string; agentId?: string },
@@ -116,6 +133,7 @@ export function buildSessionKey(
   return parts.join("-");
 }
 
+/** Convenience wrapper: returns true when the session context indicates a subagent session. */
 export function isSubagentSession(ctx?: { sessionKey?: string }): boolean {
   return isSubagentSessionKey(ctx?.sessionKey);
 }
@@ -156,17 +174,24 @@ const SENTINEL_FAST_RE = new RegExp(
     .join("|")
 );
 
+/** Return true when the given line matches one of the inbound metadata sentinel strings (Conversation info, Sender, Thread starter, etc.). */
 function isInboundMetaSentinelLine(line: string): boolean {
   const trimmed = line.trim();
   return INBOUND_META_SENTINELS.some((sentinel) => sentinel === trimmed);
 }
 
+/** Return true when a line starts the untrusted-context JSON fence block that should be stripped from memory storage. */
 function shouldStripTrailingUntrustedContext(lines: string[], index: number): boolean {
   if (lines[index]?.trim() !== UNTRUSTED_CONTEXT_HEADER) return false;
   const probe = lines.slice(index + 1, Math.min(lines.length, index + 8)).join("\n");
   return /<<<EXTERNAL_UNTRUSTED_CONTENT|UNTRUSTED channel metadata \(|Source:\s+/.test(probe);
 }
 
+/**
+ * Strip OpenClaw's inbound metadata blocks (Conversation info, Sender, Thread starter, etc.)
+ * from raw message text. These are AI-facing only and must not be stored in Honcho.
+ * Also strips leading timestamps injected by OpenClaw's injectTimestamp.
+ */
 function stripInboundMetadata(text: string): string {
   if (!text) return text;
 
@@ -227,6 +252,11 @@ function stripInboundMetadata(text: string): string {
  * Also strips leading OpenClaw reply directive tags (e.g. [[reply_to_current]])
  * so control tokens are never persisted or re-surfaced as user-visible text.
  */
+/**
+ * Strip Honcho's own injected context and OpenClaw's inbound metadata from
+ * message content to prevent feedback loops and persistence of AI-facing
+ * control tokens.
+ */
 export function cleanMessageContent(content: string): string {
   let cleaned = content;
   // Strip Honcho memory context tags (prevent re-injection loops).
@@ -251,6 +281,11 @@ const CONVERSATION_INFO_SENTINEL = "Conversation info (untrusted metadata):";
  *
  * Only considers the FIRST occurrence of the sentinel to prevent user-pasted or quoted
  * metadata blocks from poisoning sender attribution.
+ */
+/**
+ * Extract sender_id from a raw message's untrusted metadata block.
+ * Must be called BEFORE cleanMessageContent() which strips these blocks.
+ * Returns undefined for DMs or on parse failure.
  */
 export function extractSenderId(content: string): string | undefined {
   if (!content || !content.includes(CONVERSATION_INFO_SENTINEL)) return undefined;
@@ -308,6 +343,11 @@ export function shouldSkipMessage(content: string, noisePatterns: string[]): boo
   });
 }
 
+/**
+ * Convert raw inbound messages (with role, content, metadata) into Honcho
+ * MessageInput objects — stripping noise, resolving senders to Honcho peers,
+ * and cleaning metadata. Filters out skipped/empty messages.
+ */
 export function extractMessages(
   rawMessages: unknown[],
   defaultParticipantPeer: Peer,
@@ -322,13 +362,13 @@ export function extractMessages(
     const m = msg as Record<string, unknown>;
     const role = m.role as string | undefined;
 
-    if (role !== "user" && role !== "assistant") continue;
+    if (role !== "user" && role !== "assistant" && role !== "custom_message") continue;
 
     const rawContent = getRawContent(msg);
 
-    // For user messages, extract sender ID before cleaning strips metadata
+    // For user and custom messages, extract sender ID before cleaning strips metadata
     let peer: Peer;
-    if (role === "user") {
+    if (role === "user" || role === "custom_message") {
       const senderId = extractSenderId(rawContent);
       peer = (senderId && resolvePeer?.(senderId)) || defaultParticipantPeer;
     } else {
@@ -341,7 +381,10 @@ export function extractMessages(
     if (!content) continue;
     if (shouldSkipMessage(content, noisePatterns)) continue;
 
-    const ts = typeof m.timestamp === "number" ? new Date(m.timestamp) : undefined;
+    const ts =
+      typeof m.timestamp === "number" && Number.isFinite(m.timestamp) && m.timestamp > 0
+        ? new Date(m.timestamp)
+        : undefined;
     result.push(peer.message(content, ts ? { createdAt: ts } : undefined));
   }
 

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -157,6 +157,7 @@ export async function flushMessages(
   return extracted.length;
 }
 
+/** Register capture hooks — saves conversation messages to Honcho via agent_end, before_compaction, and before_reset events. */
 export function registerCaptureHook(api: OpenClawPluginApi, state: PluginState): void {
   /**
    * agent_end — primary capture hook. Saves conversation messages after each turn.

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -3,6 +3,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey, extractSenderId, isSubagentSession } from "../helpers.js";
 
+/** Register before_prompt_build hook — injects Honcho user context (profile, history summary) into the prompt before each agent turn. */
 export function registerContextHook(api: OpenClawPluginApi, state: PluginState): void {
   api.on("before_prompt_build", async (event, ctx) => {
     if (!event.prompt || event.prompt.length < 5) return;

--- a/hooks/gateway.ts
+++ b/hooks/gateway.ts
@@ -2,6 +2,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 
+/** Register gateway_start hook — initializes Honcho connection on gateway startup and logs peer map status. */
 export function registerGatewayHook(api: OpenClawPluginApi, state: PluginState): void {
   api.on("gateway_start", async (_event, _ctx) => {
     api.logger.info("Initializing Honcho memory...");

--- a/index.ts
+++ b/index.ts
@@ -89,6 +89,7 @@ export default definePluginEntry({
   kind: "memory",
   configSchema: honchoConfigSchema,
 
+  /** Plugin entry point — registers Honcho memory hooks, tools, CLI commands, and the memory runtime adapter. */
   register(api) {
     const state = createPluginState(api);
 

--- a/peers.ts
+++ b/peers.ts
@@ -28,12 +28,17 @@ export type PeersFile = {
   peers: Record<string, string>;
 };
 
+/** Resolve path to the peers file — env override OPENCLAW_HONCHO_PEERS_FILE or ~/.honcho/openclaw-peers.json. */
 export function resolvePeersFilePath(): string {
   const envPath = process.env.OPENCLAW_HONCHO_PEERS_FILE;
   if (envPath && envPath.trim().length > 0) return envPath.trim();
   return path.join(os.homedir(), ".honcho", "openclaw-peers.json");
 }
 
+/**
+ * Parse a raw JSON string into a PeersFile structure.
+ * Falls back to legacy owner policy with empty map on parse failure.
+ */
 function parsePeersJson(raw: string, filePath: string): PeersFile {
   try {
     const parsed = JSON.parse(raw);
@@ -62,6 +67,7 @@ function parsePeersJson(raw: string, filePath: string): PeersFile {
 }
 
 /** Read the peers file. Missing → per-sender (fresh install); anything else → owner (legacy). */
+/** Read peers file from disk. Missing file → per-sender (fresh install); anything else → owner (legacy). */
 export async function loadPeersFile(filePath: string): Promise<PeersFile> {
   try {
     return parsePeersJson(await fs.readFile(filePath, "utf8"), filePath);
@@ -72,6 +78,7 @@ export async function loadPeersFile(filePath: string): Promise<PeersFile> {
   }
 }
 
+/** Synchronous version of loadPeersFile — used during boot before async context is available. */
 export function loadPeersFileSync(filePath: string): PeersFile {
   try {
     return parsePeersJson(readFileSync(filePath, "utf8"), filePath);
@@ -82,6 +89,7 @@ export function loadPeersFileSync(filePath: string): PeersFile {
   }
 }
 
+/** Filter a record to keep only string values with nonzero length. */
 function coerceStringMap(value: Record<string, unknown>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(value)) {
@@ -106,7 +114,11 @@ export function resolveParticipantPeerId(
   if (mapped !== undefined) return mapped;
   const seedPeerId =
     persister.defaultUnknownPolicy === "per-sender"
-      ? senderId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, HONCHO_PEER_ID_MAX_LEN)
+      ? (() => {
+          const sanitized = senderId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, HONCHO_PEER_ID_MAX_LEN);
+          // Guard against empty sanitized IDs (e.g. senderId is all non-alphanumeric)
+          return sanitized.length > 0 ? sanitized : `sender_${Buffer.from(senderId).toString("base64url").slice(0, 32)}`;
+        })()
       : ownerPeerId;
   persister.enqueue(senderId, seedPeerId);
   return seedPeerId;
@@ -197,6 +209,7 @@ export class PeersPersister {
 }
 
 /** Sync `target` to equal `source` (same keys and values). */
+/** Sync `target` to equal `source` (same keys and values) in-place. */
 function replaceRecordInPlace(target: Record<string, string>, source: Record<string, string>): void {
   for (const k of Object.keys(target)) {
     if (!(k in source)) delete target[k];
@@ -208,6 +221,11 @@ function replaceRecordInPlace(target: Record<string, string>, source: Record<str
  * Same as reading the peers file for parsing, except a missing file uses
  * `memoryPolicy` instead of the fresh-install default (`per-sender`), so the
  * first write does not clobber the policy loaded at boot from an in-memory-only state.
+ */
+/**
+ * Load peers file for merge, using `memoryPolicy` as the default when the file is missing
+ * (instead of the fresh-install "per-sender" default), so the first write does not clobber
+ * the boot-loaded policy.
  */
 async function loadPeersFileForMerge(filePath: string, memoryPolicy: DefaultUnknownPolicy): Promise<PeersFile> {
   try {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { buildSessionKey } from "./helpers.js";
 import { isLocalHonchoBaseUrl, type PluginState } from "./state.js";
 
@@ -143,7 +143,7 @@ export async function getHonchoMemorySearchManager(
   /** Run qmd via CLI and parse results into memory-search shape. */
   function qmdSearch(query: string, limit: number): Array<Record<string, unknown>> | null {
     try {
-      const stdout = execSync(`${qmdCommand()} ${qmdSearchMode()} ${JSON.stringify(query)} --json -n ${limit}`, {
+      const stdout = execFileSync(qmdCommand(), [qmdSearchMode(), JSON.stringify(query), "--json", "-n", String(limit)], {
         encoding: "utf-8",
         timeout: 30000,
         stdio: ["pipe", "pipe", "ignore"],
@@ -167,7 +167,7 @@ export async function getHonchoMemorySearchManager(
   /** Run qmd get via CLI and return raw file content. */
   function qmdGet(path: string): string | null {
     try {
-      const stdout = execSync(`${qmdCommand()} get ${JSON.stringify(path)}`, {
+      const stdout = execFileSync(qmdCommand(), ["get", path], {
         encoding: "utf-8",
         timeout: 30000,
         stdio: ["pipe", "pipe", "ignore"],
@@ -181,12 +181,6 @@ export async function getHonchoMemorySearchManager(
   return {
     manager: {
       async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
-        await state.ensureInitialized();
-        let requestedSessionKey =
-          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
-            ? opts.sessionKey
-            : activeSessionKey ?? null;
-
         // Always try QMD in parallel when configured
         const qmdPromise = isQmdConfigured()
           ? Promise.resolve().then(() => {
@@ -205,7 +199,7 @@ export async function getHonchoMemorySearchManager(
           ? Number(opts.maxResults)
           : DEFAULT_SEARCH_RESULTS;
         const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
-        requestedSessionKey =          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
+        const requestedSessionKey =          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
             ? opts.sessionKey
             : activeSessionKey ?? null;
         const scopeEnabled = !state.cfg.crossSessionSearch;

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
 import { buildSessionKey } from "./helpers.js";
 import { isLocalHonchoBaseUrl, type PluginState } from "./state.js";
 
@@ -140,14 +140,39 @@ export async function getHonchoMemorySearchManager(
     return state.api?.config?.memory?.qmd?.command || "qmd";
   }
 
-  /** Run qmd via CLI and parse results into memory-search shape. */
-  function qmdSearch(query: string, limit: number): Array<Record<string, unknown>> | null {
+  /** Run qmd via CLI with timeout and return stdout, or null on failure. */
+  async function runQmdCli(args: string[]): Promise<string | null> {
     try {
-      const stdout = execFileSync(qmdCommand(), [qmdSearchMode(), query, "--json", "-n", String(limit)], {
-        encoding: "utf-8",
-        timeout: 30000,
-        stdio: ["pipe", "pipe", "ignore"],
+      const stdout = await new Promise<string>((resolve, reject) => {
+        execFile(
+          qmdCommand(),
+          args,
+          {
+            encoding: "utf-8",
+            signal: AbortSignal.timeout(30000),
+          },
+          (err, out) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            resolve(out);
+          }
+        );
       });
+      return stdout;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Run qmd via CLI and parse results into memory-search shape. */
+  async function qmdSearch(query: string, limit: number): Promise<Array<Record<string, unknown>> | null> {
+    const stdout = await runQmdCli([qmdSearchMode(), query, "--json", "-n", String(limit)]);
+    if (stdout === null) {
+      return null;
+    }
+    try {
       const raw = JSON.parse(stdout.trim());
       if (!Array.isArray(raw)) return null;
       return raw.map((r: Record<string, unknown>) => ({
@@ -165,17 +190,8 @@ export async function getHonchoMemorySearchManager(
   }
 
   /** Run qmd get via CLI and return raw file content. */
-  function qmdGet(path: string): string | null {
-    try {
-      const stdout = execFileSync(qmdCommand(), ["get", path], {
-        encoding: "utf-8",
-        timeout: 30000,
-        stdio: ["pipe", "pipe", "ignore"],
-      });
-      return stdout;
-    } catch {
-      return null;
-    }
+  async function qmdGet(path: string): Promise<string | null> {
+    return runQmdCli(["get", path]);
   }
 
   return {
@@ -184,13 +200,17 @@ export async function getHonchoMemorySearchManager(
       async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
         // Always try QMD in parallel when configured
         const qmdPromise = isQmdConfigured()
-          ? Promise.resolve().then(() => {
-              const r = Number.isFinite(opts.maxResults)
-                ? Number(opts.maxResults)
-                : DEFAULT_SEARCH_RESULTS;
-              const l = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(r)));
-              return qmdSearch(query, l);
-            }).catch(() => null)
+          ? (async () => {
+              try {
+                const r = Number.isFinite(opts.maxResults)
+                  ? Number(opts.maxResults)
+                  : DEFAULT_SEARCH_RESULTS;
+                const l = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(r)));
+                return await qmdSearch(query, l);
+              } catch {
+                return null;
+              }
+            })()
           : Promise.resolve(null);
         await state.ensureInitialized();
         const participantPeer = activeSessionKey
@@ -277,7 +297,7 @@ export async function getHonchoMemorySearchManager(
         const relPath = params.relPath;
         // Handle qmd:// paths by delegating to qmd get
         if (typeof relPath === "string" && relPath.startsWith("qmd://")) {
-          const qmdText = qmdGet(relPath);
+          const qmdText = await qmdGet(relPath);
           if (qmdText !== null) {
             return {
               path: relPath,

--- a/runtime.ts
+++ b/runtime.ts
@@ -143,7 +143,7 @@ export async function getHonchoMemorySearchManager(
   /** Run qmd via CLI and parse results into memory-search shape. */
   function qmdSearch(query: string, limit: number): Array<Record<string, unknown>> | null {
     try {
-      const stdout = execFileSync(qmdCommand(), [qmdSearchMode(), JSON.stringify(query), "--json", "-n", String(limit)], {
+      const stdout = execFileSync(qmdCommand(), [qmdSearchMode(), query, "--json", "-n", String(limit)], {
         encoding: "utf-8",
         timeout: 30000,
         stdio: ["pipe", "pipe", "ignore"],

--- a/runtime.ts
+++ b/runtime.ts
@@ -321,7 +321,7 @@ export async function getHonchoMemorySearchManager(
               source: "qmd",
             };
           }
-          throw new Error(`Unsupported Honcho memory path: ${relPath}`);
+          throw new Error(`Failed to retrieve qmd:// path: ${relPath} - qmd CLI returned no content`);
         }
         const sessionId = parseSessionPath(relPath);
         if (!sessionId) {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import { buildSessionKey } from "./helpers.js";
 import { isLocalHonchoBaseUrl, type PluginState } from "./state.js";
 
@@ -123,9 +124,79 @@ export async function getHonchoMemorySearchManager(
 
   await state.ensureInitialized();
 
+  /** Check if QMD backend is configured in OpenClaw config. */
+  function isQmdConfigured(): boolean {
+    const mem = state.api?.config?.memory;
+    return !!(mem?.backend === "qmd" && mem?.qmd);
+  }
+
+  /** Read the QMD search mode from config (search | vsearch | query), defaulting to query. */
+  function qmdSearchMode(): string {
+    return state.api?.config?.memory?.qmd?.searchMode || "query";
+  }
+
+  /** Read the QMD binary path from config, or fall back to PATH. */
+  function qmdCommand(): string {
+    return state.api?.config?.memory?.qmd?.command || "qmd";
+  }
+
+  /** Run qmd via CLI and parse results into memory-search shape. */
+  function qmdSearch(query: string, limit: number): Array<Record<string, unknown>> | null {
+    try {
+      const stdout = execSync(`${qmdCommand()} ${qmdSearchMode()} ${JSON.stringify(query)} --json -n ${limit}`, {
+        encoding: "utf-8",
+        timeout: 30000,
+        stdio: ["pipe", "pipe", "ignore"],
+      });
+      const raw = JSON.parse(stdout.trim());
+      if (!Array.isArray(raw)) return null;
+      return raw.map((r: Record<string, unknown>) => ({
+        path: r.file ?? r.path ?? "",
+        startLine: r.line ?? r.startLine ?? 1,
+        endLine: r.line ?? r.endLine ?? 1,
+        score: r.score ?? 0,
+        snippet: r.snippet ?? "",
+        title: r.title ?? "",
+        source: "qmd",
+      }));
+    } catch {
+      return null;
+    }
+  }
+
+  /** Run qmd get via CLI and return raw file content. */
+  function qmdGet(path: string): string | null {
+    try {
+      const stdout = execSync(`${qmdCommand()} get ${JSON.stringify(path)}`, {
+        encoding: "utf-8",
+        timeout: 30000,
+        stdio: ["pipe", "pipe", "ignore"],
+      });
+      return stdout;
+    } catch {
+      return null;
+    }
+  }
+
   return {
     manager: {
       async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
+        await state.ensureInitialized();
+        let requestedSessionKey =
+          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
+            ? opts.sessionKey
+            : activeSessionKey ?? null;
+
+        // Always try QMD in parallel when configured
+        const qmdPromise = isQmdConfigured()
+          ? Promise.resolve().then(() => {
+              const r = Number.isFinite(opts.maxResults)
+                ? Number(opts.maxResults)
+                : DEFAULT_SEARCH_RESULTS;
+              const l = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(r)));
+              return qmdSearch(query, l);
+            }).catch(() => null)
+          : Promise.resolve(null);
         await state.ensureInitialized();
         const participantPeer = activeSessionKey
           ? await state.resolveSessionParticipantPeer(activeSessionKey)
@@ -134,8 +205,7 @@ export async function getHonchoMemorySearchManager(
           ? Number(opts.maxResults)
           : DEFAULT_SEARCH_RESULTS;
         const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
-        const requestedSessionKey =
-          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
+        const requestedSessionKey =          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
             ? opts.sessionKey
             : activeSessionKey ?? null;
         const scopeEnabled = !state.cfg.crossSessionSearch;
@@ -177,7 +247,9 @@ export async function getHonchoMemorySearchManager(
           collect(await participantPeer.search(query, { limit }));
         }
 
-        return Promise.all(
+        // Merge QMD results (with real scores) above Honcho session results (clamped)
+        const [qmdResults] = await Promise.all([qmdPromise]);
+        const honchoResults = await Promise.all(
           filtered.map(async (msg: any) => {
             const snippet = typeof msg.content === "string" ? msg.content : "";
             let transcriptPromise = transcriptCache.get(msg.sessionId);
@@ -197,34 +269,59 @@ export async function getHonchoMemorySearchManager(
             };
           })
         );
+        const clampedSessions = honchoResults.map((r) => ({ ...r, score: Math.min(r.score, 0.5) }));
+        const merged =
+          qmdResults && qmdResults.length > 0
+            ? [...qmdResults, ...clampedSessions].slice(0, limit)
+            : clampedSessions;
+        return merged;
       },
 
       async readFile(params: { relPath: string; from?: number; lines?: number }) {
-        const sessionId = parseSessionPath(params.relPath);
+        const relPath = params.relPath;
+        // Handle qmd:// paths by delegating to qmd get
+        if (typeof relPath === "string" && relPath.startsWith("qmd://")) {
+          const qmdText = qmdGet(relPath);
+          if (qmdText !== null) {
+            return {
+              path: relPath,
+              text: sliceLines(qmdText, params.from, params.lines),
+              source: "qmd",
+            };
+          }
+          throw new Error(`Unsupported Honcho memory path: ${relPath}`);
+        }
+        const sessionId = parseSessionPath(relPath);
         if (!sessionId) {
-          throw new Error(`Unsupported Honcho memory path: ${params.relPath}`);
+          throw new Error(`Unsupported Honcho memory path: ${relPath}`);
         }
         if (!state.cfg.crossSessionSearch && activeSessionKey && !matchesSessionScope(sessionId, activeSessionKey)) {
-          throw new Error(`Requested Honcho memory path is outside the active session: ${params.relPath}`);
+          throw new Error(`Requested Honcho memory path is outside the active session: ${relPath}`);
         }
 
         const transcript = await buildSessionTranscript(state, agentId, sessionId);
         return {
-          path: params.relPath,
+          path: relPath,
           text: sliceLines(transcript, params.from, params.lines),
         };
       },
 
       status() {
+        const qmdAvailable = isQmdConfigured();
         return {
           backend: "qmd",
-          provider: isLocalHonchoBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
+          provider: qmdAvailable
+            ? "honcho+qmd"
+            : isLocalHonchoBaseUrl(state.cfg.baseUrl)
+              ? "honcho-selfhosted"
+              : "honcho",
           model: "n/a",
-          sources: ["sessions"],
+          sources: qmdAvailable ? ["sessions", "qmd"] : ["sessions"],
           custom: {
             searchMode: "semantic",
             workspaceId: state.cfg.workspaceId,
             baseUrl: state.cfg.baseUrl,
+            ...(qmdAvailable ? { qmd: true } : {}),
           },
         };
       },

--- a/runtime.ts
+++ b/runtime.ts
@@ -126,8 +126,7 @@ export async function getHonchoMemorySearchManager(
 
   /** Check if QMD backend is configured in OpenClaw config. */
   function isQmdConfigured(): boolean {
-    const mem = state.api?.config?.memory;
-    return !!(mem?.backend === "qmd" && mem?.qmd);
+    return state.api?.config?.memory?.backend === "qmd";
   }
 
   /** Read the QMD search mode from config (search | vsearch | query), defaulting to query. */

--- a/runtime.ts
+++ b/runtime.ts
@@ -140,6 +140,15 @@ export async function getHonchoMemorySearchManager(
     return state.api?.config?.memory?.qmd?.command || "qmd";
   }
 
+  /** Optional QMD path allowlist (qmd:// prefixes). Null means allow all paths. */
+  function qmdAllowedPrefixes(): string[] | null {
+    const prefixes = state.api?.config?.memory?.qmd?.allowedPrefixes;
+    if (!Array.isArray(prefixes)) {
+      return null;
+    }
+    return prefixes.filter((prefix): prefix is string => typeof prefix === "string");
+  }
+
   /** Run qmd via CLI with timeout and return stdout, or null on failure. */
   async function runQmdCli(args: string[]): Promise<string | null> {
     try {
@@ -297,6 +306,13 @@ export async function getHonchoMemorySearchManager(
         const relPath = params.relPath;
         // Handle qmd:// paths by delegating to qmd get
         if (typeof relPath === "string" && relPath.startsWith("qmd://")) {
+          const allowedPrefixes = qmdAllowedPrefixes();
+          if (
+            allowedPrefixes &&
+            !allowedPrefixes.some((prefix) => relPath.startsWith(prefix))
+          ) {
+            throw new Error(`QMD memory path is not allowed by configured prefixes: ${relPath}`);
+          }
           const qmdText = await qmdGet(relPath);
           if (qmdText !== null) {
             return {

--- a/runtime.ts
+++ b/runtime.ts
@@ -180,6 +180,7 @@ export async function getHonchoMemorySearchManager(
 
   return {
     manager: {
+      /** Search across QMD-indexed files and Honcho session transcripts, merging results. */
       async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
         // Always try QMD in parallel when configured
         const qmdPromise = isQmdConfigured()
@@ -271,6 +272,7 @@ export async function getHonchoMemorySearchManager(
         return merged;
       },
 
+      /** Read a file from QMD (qmd:// paths) or a Honcho session transcript. */
       async readFile(params: { relPath: string; from?: number; lines?: number }) {
         const relPath = params.relPath;
         // Handle qmd:// paths by delegating to qmd get
@@ -300,6 +302,7 @@ export async function getHonchoMemorySearchManager(
         };
       },
 
+      /** Return status descriptor including QMD availability and provider info. */
       status() {
         const qmdAvailable = isQmdConfigured();
         return {

--- a/runtime.ts
+++ b/runtime.ts
@@ -142,7 +142,8 @@ export async function getHonchoMemorySearchManager(
 
   /** Optional QMD path allowlist (qmd:// prefixes). Null means allow all paths. */
   function qmdAllowedPrefixes(): string[] | null {
-    const prefixes = state.api?.config?.memory?.qmd?.allowedPrefixes;
+    const cfg = state.api?.config?.memory?.qmd as Record<string, unknown> | undefined;
+    const prefixes = cfg?.allowedPrefixes;
     if (!Array.isArray(prefixes)) {
       return null;
     }
@@ -267,7 +268,7 @@ export async function getHonchoMemorySearchManager(
             metadata: { agentId },
           });
           collect(await exactSession.search(query, { limit }));
-        } else {
+        } else if (filtered.length < limit) {
           collect(await participantPeer.search(query, { limit }));
         }
 

--- a/runtime.ts
+++ b/runtime.ts
@@ -205,7 +205,7 @@ export async function getHonchoMemorySearchManager(
           ? Number(opts.maxResults)
           : DEFAULT_SEARCH_RESULTS;
         const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
-        const requestedSessionKey =          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
+        requestedSessionKey =          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
             ? opts.sessionKey
             : activeSessionKey ?? null;
         const scopeEnabled = !state.cfg.crossSessionSearch;

--- a/state.ts
+++ b/state.ts
@@ -163,6 +163,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     if (peer) return peer;
     peer = await honcho.peer(OWNER_ID, { metadata: {} });
     state.participantPeers.set(OWNER_ID, peer);
+    participantPeerIdCache = null;
     return peer;
   }
 
@@ -180,7 +181,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     let resolvedPeerId = resolveParticipantPeerId(channelPeerId, peersPersister, OWNER_ID);
     // Guard against empty sanitized peer IDs (e.g. sender_id is all non-alphanumeric)
     if (!resolvedPeerId || resolvedPeerId.length === 0) {
-      resolvedPeerId = `sender-${createHash("sha256").update(channelPeerId).digest("hex").slice(0, 16)}`;
+      resolvedPeerId = `sender_${createHash("sha256").update(channelPeerId).digest("base64url").slice(0, 32)}`;
     }
     const autoSeeded = !wasInFile && resolvedPeerId !== OWNER_ID;
 
@@ -192,6 +193,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
       peer = await honcho.peer(resolvedPeerId, { metadata });
     }
     state.participantPeers.set(channelPeerId, peer);
+    participantPeerIdCache = null;
     return peer;
   }
 

--- a/state.ts
+++ b/state.ts
@@ -4,6 +4,7 @@
  * PluginState object that gets passed to every module.
  */
 
+import { createHash } from "node:crypto";
 import { Honcho, type Peer } from "@honcho-ai/sdk";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
@@ -18,6 +19,7 @@ import {
 export const OWNER_ID = "owner";
 export const LEGACY_PEER_ID = "openclaw";
 
+/** Return true when the Honcho base URL points to localhost / 127.0.0.1 / ::1 (self-hosted mode). */
 export function isLocalHonchoBaseUrl(baseUrl?: string): boolean {
   const base = String(baseUrl ?? "").trim();
   if (!base) return false;
@@ -63,6 +65,7 @@ export type PluginState = {
   resolveDefaultAgentId: () => string;
 };
 
+/** Build the shared PluginState object — wires Honcho SDK, peer management, and init gating. Follows DI pattern: every module receives the same state ref. */
 export function createPluginState(api: OpenClawPluginApi): PluginState {
   const cfg = honchoConfigSchema.parse(api.pluginConfig);
 
@@ -110,6 +113,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     resolveDefaultAgentId,
   };
 
+/** Resolve the default agent ID from the OpenClaw config (first default agent, or "main"). */
   function resolveDefaultAgentId(): string {
     const agents = api.config?.agents?.list;
     if (!Array.isArray(agents) || agents.length === 0) return "main";
@@ -117,6 +121,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     return (defaultAgent?.id ?? "main").toLowerCase().trim() || "main";
   }
 
+/** Ensure the Honcho workspace and peers are initialized. Guards against concurrent init races. */
   async function ensureInitialized(): Promise<void> {
     if (state.initialized) return;
     if (initPromise) return initPromise;
@@ -130,6 +135,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     }
   }
 
+/** Core initialization: load workspace metadata, agent peer map, and create the default owner peer. */
   async function doInit(): Promise<void> {
 
     const wsMeta = await honcho.getMetadata();
@@ -151,6 +157,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     state.initialized = true;
   }
 
+/** Get or create the default "owner" participant peer. */
   async function ensureOwnerPeer(): Promise<Peer> {
     let peer = state.participantPeers.get(OWNER_ID);
     if (peer) return peer;
@@ -159,6 +166,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     return peer;
   }
 
+  /** Resolve or mint a participant Honcho peer for a given channel sender ID. Unknown IDs auto-seed per peers file policy. */
   async function getParticipantPeer(channelPeerId?: string): Promise<Peer> {
     if (!channelPeerId) return ensureOwnerPeer();
 
@@ -169,7 +177,11 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     if (peer) return peer;
 
     const wasInFile = channelPeerId in peersPersister.peers;
-    const resolvedPeerId = resolveParticipantPeerId(channelPeerId, peersPersister, OWNER_ID);
+    let resolvedPeerId = resolveParticipantPeerId(channelPeerId, peersPersister, OWNER_ID);
+    // Guard against empty sanitized peer IDs (e.g. sender_id is all non-alphanumeric)
+    if (!resolvedPeerId || resolvedPeerId.length === 0) {
+      resolvedPeerId = `sender-${createHash("sha256").update(channelPeerId).digest("hex").slice(0, 16)}`;
+    }
     const autoSeeded = !wasInFile && resolvedPeerId !== OWNER_ID;
 
     if (resolvedPeerId === OWNER_ID) {
@@ -183,6 +195,7 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     return peer;
   }
 
+  /** Read participantSenderId from session metadata and resolve the corresponding Honcho peer. Falls back to default owner. */
   async function resolveSessionParticipantPeer(sessionKey: string): Promise<Peer> {
     const session = await honcho.session(sessionKey);
     const meta = await session.getMetadata();
@@ -195,15 +208,23 @@ export function createPluginState(api: OpenClawPluginApi): PluginState {
     return await getParticipantPeer();
   }
 
-  function isParticipantPeerId(peerId: string): boolean {
-    if (peerId === OWNER_ID) return true;
-    // Check if this peer ID is a known participant peer
+  // Cache of participant peer IDs for O(1) lookup in transcript building.
+  let participantPeerIdCache: Set<string> | null = null;
+
+  function rebuildParticipantPeerIdCache(): void {
+    participantPeerIdCache = new Set<string>([OWNER_ID]);
     for (const [, peer] of state.participantPeers) {
-      if (peer.id === peerId) return true;
+      participantPeerIdCache.add(peer.id);
     }
-    return false;
   }
 
+  /** Return true if the given Honcho peer ID belongs to any known participant (owner or per-sender). */
+  function isParticipantPeerId(peerId: string): boolean {
+    if (!participantPeerIdCache) rebuildParticipantPeerIdCache();
+    return participantPeerIdCache!.has(peerId);
+  }
+
+  /** Get or create the agent Honcho peer for a given agent ID, persisting the agentPeerMap on first discovery. */
   async function getAgentPeer(agentId?: string): Promise<Peer> {
     const id = (agentId || resolveDefaultAgentId()).toLowerCase().trim() || "main";
 

--- a/test/qmd-bridge.test.ts
+++ b/test/qmd-bridge.test.ts
@@ -153,10 +153,6 @@ describe("QMD bridge — config detection", () => {
   });
 
   it("returns honcho+qmd when qmd block exists (even empty)", async () => {
-    const state = createState({ memory: createMemoryConfig({ command: undefined, searchMode: undefined }) });
-    // Empty qmd block — isQmdConfigured checks mem?.qmd truthiness
-    // But qmd is { includeDefaultMemory: true } which is truthy
-    // So for this test, set qmd to {}
     const memState = createState({ memory: { backend: "qmd", qmd: {} } });
     const { manager } = await getHonchoMemorySearchManager(memState, { agentId: "main" });
     const s = manager.status();

--- a/test/qmd-bridge.test.ts
+++ b/test/qmd-bridge.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { getHonchoMemorySearchManager } from "../runtime.js";
 import type { PluginState } from "../state.js";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
-// Mock child_process.execSync
+// Mock child_process.execFileSync
 vi.mock("child_process", () => ({
+  execFileSync: vi.fn(),
   execSync: vi.fn(),
 }));
 
@@ -152,15 +153,16 @@ describe("QMD bridge — search", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("maps qmd JSON fields to memory-search shape", async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig() });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
 
     const results = await manager.search("basc3", { maxResults: 5 });
 
-    expect(execSync).toHaveBeenCalledWith(
-      expect.stringContaining("qmd query"),
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("qmd"),
+      expect.arrayContaining(["query"]),
       expect.objectContaining({ timeout: 30000 }),
     );
 
@@ -174,49 +176,52 @@ describe("QMD bridge — search", () => {
   });
 
   it("uses configured searchMode for the subprocess command", async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig({ searchMode: "vsearch" }) });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
 
     await manager.search("basc3", { maxResults: 1 });
 
-    expect(execSync).toHaveBeenCalledWith(
-      expect.stringContaining("vsearch"),
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("qmd"),
+      expect.arrayContaining(["vsearch"]),
       expect.any(Object),
     );
   });
 
   it("uses qmd binary path from config", async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig({ command: "/custom/qmd" }) });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
 
     await manager.search("basc3", { maxResults: 1 });
 
-    expect(execSync).toHaveBeenCalledWith(
+    expect(execFileSync).toHaveBeenCalledWith(
       expect.stringContaining("/custom/qmd"),
+      expect.any(Array),
       expect.any(Object),
     );
   });
 
   it("defaults to qmd on PATH when command is not configured", async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig({ command: undefined }) });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
 
     await manager.search("basc3", { maxResults: 1 });
 
-    expect(execSync).toHaveBeenCalledWith(
-      expect.stringContaining("qmd query"),
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("qmd"),
+      expect.any(Array),
       expect.any(Object),
     );
   });
 
   it("falls through when qmd search throws", async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
       throw new Error("QMD not found");
     });
 
@@ -240,7 +245,7 @@ describe("QMD bridge — readFile", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("reads qmd:// paths via qmd get", async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockReturnValue("# BASC-3 Report\nContent\n");
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue("# BASC-3 Report\nContent\n");
 
     const state = createState({ memory: createMemoryConfig() });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
@@ -249,8 +254,9 @@ describe("QMD bridge — readFile", () => {
       relPath: "qmd://wiki-memory/assessments/basc3.md",
     });
 
-    expect(execSync).toHaveBeenCalledWith(
-      expect.stringContaining("qmd get"),
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("qmd"),
+      expect.arrayContaining(["get"]),
       expect.any(Object),
     );
     expect(file.path).toBe("qmd://wiki-memory/assessments/basc3.md");
@@ -259,7 +265,7 @@ describe("QMD bridge — readFile", () => {
   });
 
   it("throws on qmd:// path when qmd get fails", async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
       throw new Error("qmd get failed");
     });
 
@@ -279,7 +285,7 @@ describe("QMD bridge — score clamping", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("clamps session scores to 0.5 in merged results", async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig() });
     const { manager } = await getHonchoMemorySearchManager(state, {

--- a/test/qmd-bridge.test.ts
+++ b/test/qmd-bridge.test.ts
@@ -293,7 +293,7 @@ describe("QMD bridge — readFile", () => {
 
     await expect(
       manager.readFile({ relPath: "qmd://wiki-memory/missing.md" }),
-    ).rejects.toThrow(/Unsupported Honcho memory path/);
+    ).rejects.toThrow(/Failed to retrieve qmd:\/\/ path/);
   });
 
   it("rejects disallowed qmd:// paths when allowedPrefixes are configured", async () => {

--- a/test/qmd-bridge.test.ts
+++ b/test/qmd-bridge.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getHonchoMemorySearchManager } from "../runtime.js";
+import type { PluginState } from "../state.js";
+import { execSync } from "child_process";
+
+// Mock child_process.execSync
+vi.mock("child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+type TestState = PluginState & {
+  participantPeer: {
+    id: string;
+    search: ReturnType<typeof vi.fn>;
+    sessions: ReturnType<typeof vi.fn>;
+  } | null;
+};
+
+function createMemoryConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    backend: "qmd",
+    qmd: {
+      searchMode: "query",
+      command: "/usr/local/bin/qmd",
+      includeDefaultMemory: true,
+      ...overrides,
+    },
+  };
+}
+
+function createSession(sessionId: string) {
+  return {
+    id: sessionId,
+    context: vi.fn(async () => ({
+      summary: { content: `Summary for ${sessionId}` },
+      messages: [
+        { peerId: "owner", content: `Message from ${sessionId}` },
+      ],
+    })),
+    search: vi.fn(async () => [
+      { id: `msg-${sessionId}`, sessionId, content: `Hit from ${sessionId}` },
+    ]),
+  };
+}
+
+function createState(config: { memory?: Record<string, unknown> } = {}): TestState {
+  const participantPeer = {
+    id: "owner",
+    search: vi.fn(async () => [
+      { sessionId: "session-1", content: "Need to remember this" },
+    ]),
+    sessions: vi.fn(async () => ({
+      async *[Symbol.asyncIterator]() {},
+    })),
+  };
+
+  const state = {
+    cfg: {
+      workspaceId: "openclaw",
+      baseUrl: "http://10.0.0.4:8077",
+      noisePatterns: [],
+      disableDefaultNoisePatterns: false,
+      ownerObserveOthers: false,
+      crossSessionSearch: true,
+    },
+    honcho: {
+      session: vi.fn(async (sessionId: string) => createSession(sessionId)),
+    } as never,
+    participantPeer,
+    participantPeers: new Map(),
+    agentPeers: new Map(),
+    agentPeerMap: {},
+    turnStartIndex: new Map(),
+    initialized: true,
+    api: {
+      config: config.memory ? { memory: config.memory } : {},
+    } as never,
+    ensureInitialized: vi.fn(async () => {}),
+    getAgentPeer: vi.fn(async (agentId = "main") => ({ id: `agent-${agentId}` })),
+    getParticipantPeer: vi.fn(async () => {
+      if (!state.participantPeer) throw new Error("Honcho owner peer not initialized");
+      return state.participantPeer;
+    }),
+    resolveSessionParticipantPeer: vi.fn(async () => {
+      if (!state.participantPeer) throw new Error("Honcho owner peer not initialized");
+      return state.participantPeer;
+    }),
+    isParticipantPeerId: vi.fn((peerId: string) => peerId === "owner"),
+    resolveDefaultAgentId: vi.fn(() => "main"),
+  } as unknown as TestState;
+  return state;
+}
+
+const QMD_RESPONSE = JSON.stringify([
+  {
+    docid: "#abc1",
+    score: 0.78,
+    file: "qmd://wiki-memory/assessments/basc3-report.md",
+    line: 3,
+    title: "BASC-3 Report",
+    context: "School psych assessments",
+    snippet: "BASC-3 assessment criteria",
+  },
+]);
+
+// ---------------------------------------------------------------------------
+// isQmdConfigured / status()
+// ---------------------------------------------------------------------------
+describe("QMD bridge — config detection", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns honcho+qmd when fully configured", async () => {
+    const state = createState({ memory: createMemoryConfig() });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+    const s = manager.status();
+    expect(s.provider).toBe("honcho+qmd");
+    expect(s.sources).toContain("qmd");
+    expect((s.custom as Record<string, unknown>).qmd).toBe(true);
+  });
+
+  it("returns honcho when no memory config", async () => {
+    const state = createState();
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+    const s = manager.status();
+    expect(s.provider).toBe("honcho");
+    expect(s.sources).toEqual(["sessions"]);
+  });
+
+  it("returns honcho when backend is not qmd", async () => {
+    const state = createState({ memory: { backend: "builtin" } });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+    const s = manager.status();
+    expect(s.provider).toBe("honcho");
+  });
+
+  it("returns honcho+qmd when qmd block exists (even empty)", async () => {
+    const state = createState({ memory: createMemoryConfig({ command: undefined, searchMode: undefined }) });
+    // Empty qmd block — isQmdConfigured checks mem?.qmd truthiness
+    // But qmd is { includeDefaultMemory: true } which is truthy
+    // So for this test, set qmd to {}
+    const memState = createState({ memory: { backend: "qmd", qmd: {} } });
+    const { manager } = await getHonchoMemorySearchManager(memState, { agentId: "main" });
+    const s = manager.status();
+    expect(s.provider).toBe("honcho+qmd");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// qmdSearch field mapping and command construction
+// ---------------------------------------------------------------------------
+describe("QMD bridge — search", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("maps qmd JSON fields to memory-search shape", async () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+
+    const state = createState({ memory: createMemoryConfig() });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+
+    const results = await manager.search("basc3", { maxResults: 5 });
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining("qmd query"),
+      expect.objectContaining({ timeout: 30000 }),
+    );
+
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].path).toBe("qmd://wiki-memory/assessments/basc3-report.md");
+    expect(results[0].startLine).toBe(3);
+    expect(results[0].endLine).toBe(3);
+    expect(results[0].score).toBe(0.78);
+    expect(results[0].source).toBe("qmd");
+    expect(results[0].snippet).toContain("BASC-3");
+  });
+
+  it("uses configured searchMode for the subprocess command", async () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+
+    const state = createState({ memory: createMemoryConfig({ searchMode: "vsearch" }) });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+
+    await manager.search("basc3", { maxResults: 1 });
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining("vsearch"),
+      expect.any(Object),
+    );
+  });
+
+  it("uses qmd binary path from config", async () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+
+    const state = createState({ memory: createMemoryConfig({ command: "/custom/qmd" }) });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+
+    await manager.search("basc3", { maxResults: 1 });
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining("/custom/qmd"),
+      expect.any(Object),
+    );
+  });
+
+  it("defaults to qmd on PATH when command is not configured", async () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+
+    const state = createState({ memory: createMemoryConfig({ command: undefined }) });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+
+    await manager.search("basc3", { maxResults: 1 });
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining("qmd query"),
+      expect.any(Object),
+    );
+  });
+
+  it("falls through when qmd search throws", async () => {
+    (execSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("QMD not found");
+    });
+
+    const state = createState({ memory: createMemoryConfig() });
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+
+    const results = await manager.search("basc3", { maxResults: 5 });
+    // Should return Honcho session results when QMD fails
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r: Record<string, unknown>) => r.source === "sessions")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readFile with qmd:// URIs
+// ---------------------------------------------------------------------------
+describe("QMD bridge — readFile", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reads qmd:// paths via qmd get", async () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue("# BASC-3 Report\nContent\n");
+
+    const state = createState({ memory: createMemoryConfig() });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+
+    const file = await manager.readFile({
+      relPath: "qmd://wiki-memory/assessments/basc3.md",
+    });
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining("qmd get"),
+      expect.any(Object),
+    );
+    expect(file.path).toBe("qmd://wiki-memory/assessments/basc3.md");
+    expect(file.text).toContain("BASC-3 Report");
+    expect((file as Record<string, unknown>).source).toBe("qmd");
+  });
+
+  it("throws on qmd:// path when qmd get fails", async () => {
+    (execSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("qmd get failed");
+    });
+
+    const state = createState({ memory: createMemoryConfig() });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+
+    await expect(
+      manager.readFile({ relPath: "qmd://wiki-memory/missing.md" }),
+    ).rejects.toThrow(/Unsupported Honcho memory path/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Score clamping
+// ---------------------------------------------------------------------------
+describe("QMD bridge — score clamping", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clamps session scores to 0.5 in merged results", async () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+
+    const state = createState({ memory: createMemoryConfig() });
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+
+    const results = await manager.search("basc3", { maxResults: 10 });
+
+    // QMD results keep real scores
+    const qmd = results.filter((r: Record<string, unknown>) => r.source === "qmd");
+    expect(qmd.length).toBeGreaterThan(0);
+    for (const r of qmd) {
+      expect(r.score).toBeGreaterThan(0.5);
+    }
+
+    // Session results clamped
+    const ses = results.filter((r: Record<string, unknown>) => r.source === "sessions");
+    for (const r of ses) {
+      expect(r.score).toBeLessThanOrEqual(0.5);
+    }
+  });
+
+  it("returns only session results when QMD is not configured", async () => {
+    const state = createState(); // no memory config
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+
+    const results = await manager.search("anything", { maxResults: 10 });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r: Record<string, unknown>) => r.source === "sessions")).toBe(true);
+  });
+});

--- a/test/qmd-bridge.test.ts
+++ b/test/qmd-bridge.test.ts
@@ -295,6 +295,34 @@ describe("QMD bridge — readFile", () => {
       manager.readFile({ relPath: "qmd://wiki-memory/missing.md" }),
     ).rejects.toThrow(/Unsupported Honcho memory path/);
   });
+
+  it("rejects disallowed qmd:// paths when allowedPrefixes are configured", async () => {
+    mockExecFileSuccess("# Should not be read\n");
+
+    const state = createState({
+      memory: createMemoryConfig({ allowedPrefixes: ["qmd://wiki-memory/allowed/"] }),
+    });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+
+    await expect(
+      manager.readFile({ relPath: "qmd://wiki-memory/assessments/basc3.md" }),
+    ).rejects.toThrow(/not allowed by configured prefixes/);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("allows qmd:// paths when allowedPrefixes are not configured", async () => {
+    mockExecFileSuccess("# BASC-3 Report\nContent\n");
+
+    const state = createState({ memory: createMemoryConfig({ allowedPrefixes: undefined }) });
+    const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
+
+    await expect(
+      manager.readFile({ relPath: "qmd://wiki-memory/assessments/basc3.md" }),
+    ).resolves.toMatchObject({
+      path: "qmd://wiki-memory/assessments/basc3.md",
+      source: "qmd",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/qmd-bridge.test.ts
+++ b/test/qmd-bridge.test.ts
@@ -1,13 +1,31 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { getHonchoMemorySearchManager } from "../runtime.js";
 import type { PluginState } from "../state.js";
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
 
-// Mock child_process.execFileSync
+// Mock child_process.execFile
 vi.mock("child_process", () => ({
-  execFileSync: vi.fn(),
+  execFile: vi.fn(),
   execSync: vi.fn(),
 }));
+
+function mockExecFileSuccess(stdout: string) {
+  (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, out: string) => void) => {
+      cb(null, stdout);
+      return undefined as never;
+    }
+  );
+}
+
+function mockExecFileError(err = new Error("qmd command failed")) {
+  (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, out: string) => void) => {
+      cb(err, "");
+      return undefined as never;
+    }
+  );
+}
 
 type TestState = PluginState & {
   participantPeer: {
@@ -153,17 +171,18 @@ describe("QMD bridge — search", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("maps qmd JSON fields to memory-search shape", async () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    mockExecFileSuccess(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig() });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
 
     const results = await manager.search("basc3", { maxResults: 5 });
 
-    expect(execFileSync).toHaveBeenCalledWith(
+    expect(execFile).toHaveBeenCalledWith(
       expect.stringContaining("qmd"),
       expect.arrayContaining(["query"]),
-      expect.objectContaining({ timeout: 30000 }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      expect.any(Function),
     );
 
     expect(results.length).toBeGreaterThanOrEqual(1);
@@ -176,54 +195,55 @@ describe("QMD bridge — search", () => {
   });
 
   it("uses configured searchMode for the subprocess command", async () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    mockExecFileSuccess(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig({ searchMode: "vsearch" }) });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
 
     await manager.search("basc3", { maxResults: 1 });
 
-    expect(execFileSync).toHaveBeenCalledWith(
+    expect(execFile).toHaveBeenCalledWith(
       expect.stringContaining("qmd"),
       expect.arrayContaining(["vsearch"]),
       expect.any(Object),
+      expect.any(Function),
     );
   });
 
   it("uses qmd binary path from config", async () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    mockExecFileSuccess(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig({ command: "/custom/qmd" }) });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
 
     await manager.search("basc3", { maxResults: 1 });
 
-    expect(execFileSync).toHaveBeenCalledWith(
+    expect(execFile).toHaveBeenCalledWith(
       expect.stringContaining("/custom/qmd"),
       expect.any(Array),
       expect.any(Object),
+      expect.any(Function),
     );
   });
 
   it("defaults to qmd on PATH when command is not configured", async () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    mockExecFileSuccess(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig({ command: undefined }) });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
 
     await manager.search("basc3", { maxResults: 1 });
 
-    expect(execFileSync).toHaveBeenCalledWith(
+    expect(execFile).toHaveBeenCalledWith(
       expect.stringContaining("qmd"),
       expect.any(Array),
       expect.any(Object),
+      expect.any(Function),
     );
   });
 
   it("falls through when qmd search throws", async () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
-      throw new Error("QMD not found");
-    });
+    mockExecFileError(new Error("QMD not found"));
 
     const state = createState({ memory: createMemoryConfig() });
     const { manager } = await getHonchoMemorySearchManager(state, {
@@ -245,7 +265,7 @@ describe("QMD bridge — readFile", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("reads qmd:// paths via qmd get", async () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue("# BASC-3 Report\nContent\n");
+    mockExecFileSuccess("# BASC-3 Report\nContent\n");
 
     const state = createState({ memory: createMemoryConfig() });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
@@ -254,10 +274,11 @@ describe("QMD bridge — readFile", () => {
       relPath: "qmd://wiki-memory/assessments/basc3.md",
     });
 
-    expect(execFileSync).toHaveBeenCalledWith(
+    expect(execFile).toHaveBeenCalledWith(
       expect.stringContaining("qmd"),
       expect.arrayContaining(["get"]),
       expect.any(Object),
+      expect.any(Function),
     );
     expect(file.path).toBe("qmd://wiki-memory/assessments/basc3.md");
     expect(file.text).toContain("BASC-3 Report");
@@ -265,9 +286,7 @@ describe("QMD bridge — readFile", () => {
   });
 
   it("throws on qmd:// path when qmd get fails", async () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
-      throw new Error("qmd get failed");
-    });
+    mockExecFileError(new Error("qmd get failed"));
 
     const state = createState({ memory: createMemoryConfig() });
     const { manager } = await getHonchoMemorySearchManager(state, { agentId: "main" });
@@ -285,7 +304,7 @@ describe("QMD bridge — score clamping", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("clamps session scores to 0.5 in merged results", async () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(QMD_RESPONSE);
+    mockExecFileSuccess(QMD_RESPONSE);
 
     const state = createState({ memory: createMemoryConfig() });
     const { manager } = await getHonchoMemorySearchManager(state, {

--- a/tools/ask.ts
+++ b/tools/ask.ts
@@ -4,6 +4,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 
+/** Register the honcho_ask tool — asks Honcho a direct question about a participant and returns a synthesized answer. */
 export function registerAskTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
     (toolCtx) => ({
@@ -54,7 +55,7 @@ export function registerAskTool(api: OpenClawPluginApi, state: PluginState): voi
         });
 
         return {
-          content: [{ type: "text", text: answer! }],
+          content: [{ type: "text", text: answer ?? "No answer available." }],
           details: { query, depth },
         };
       },

--- a/tools/context.ts
+++ b/tools/context.ts
@@ -4,6 +4,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 
+/** Register the honcho_context tool — retrieves stored user profile (card) or full Honcho representation across sessions. */
 export function registerContextTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
     (toolCtx) => ({
@@ -43,8 +44,8 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
           const card = await participantPeer.card().catch((err) => {
             // Only treat NotFoundError as empty; re-throw others or log
             if (err?.name === "NotFoundError") return null;
-            // Optionally log unexpected errors for debugging
-            console.warn("honcho_context card() error:", err);
+            // Log unexpected errors for debugging
+            api.logger.warn?.(`honcho_context card() error: ${err}`);
             return null;
           });
 

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -8,7 +8,6 @@ import { getHonchoMemorySearchManager } from "../runtime.js";
 const MemorySearchSchema = Type.Object({
   query: Type.String(),
   maxResults: Type.Optional(Type.Number()),
-  minScore: Type.Optional(Type.Number()),
 }, { additionalProperties: false });
 
 const MemoryGetSchema = Type.Object({
@@ -97,7 +96,6 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const p = params as Record<string, unknown>;
         const query = readStringParam(p, "query", { required: true });
         const maxResults = readNumberParam(p, "maxResults");
-        readNumberParam(p, "minScore");
         const honchoSessionKey = buildSessionKey({
           sessionKey: ctx.sessionKey,
           agentId: ctx.agentId,

--- a/tools/message-search.ts
+++ b/tools/message-search.ts
@@ -5,6 +5,7 @@ import type { Message } from "@honcho-ai/sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 
+/** Register the honcho_search_messages tool — hybrid semantic + full-text search over Honcho messages across sessions. */
 export function registerMessageSearchTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
     (toolCtx) => ({

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -4,6 +4,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 
+/** Register the honcho_search_conclusions tool — semantic vector search over Honcho conclusions about a participant. */
 export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
     (toolCtx) => ({

--- a/tools/session.ts
+++ b/tools/session.ts
@@ -4,6 +4,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey, cleanMessageContent } from "../helpers.js";
 
+/** Register the honcho_session tool — retrieves conversation history and summary for the current Honcho session. */
 export function registerSessionTool(api: OpenClawPluginApi, state: PluginState): void {
   api.registerTool(
     (toolCtx) => ({


### PR DESCRIPTION
When memory.backend: 'qmd' is configured, the Honcho plugin's memory_search/memory_get tools only return Honcho session transcripts. This patch adds parallel QMD query execution so indexed local files (such as wiki docs) appear in results alongside session data.

Changes:
- import execSync from child_process
- isQmdConfigured(), qmdSearchMode(), qmdCommand() helpers reading from state.api.config.memory (openclaw.json)
- qmdSearch shells out to qmd <mode> <query> --json -n <limit> with 30s timeout, maps qmd's file/line fields to Honcho's path/startLine format
- qmdGet shells out to qmd get <path> for qmd:// URIs
- search() runs QMD in parallel with Honcho, merges results, clamps session scores to 0.5 so file results sort above them
- readFile() handles qmd:// paths before falling back to Honcho
- status() reports provider: 'honcho+qmd' when QMD is active

This was developed with AI assistance and tested on live infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional QMD-backed memory search alongside existing search; qmd:// content retrieval with optional allowlist; status now reflects combined provider/QMD availability.

* **Bug Fixes**
  * CLI flag validation and safer workspace path resolution; more robust sender/peer ID generation and stricter timestamp handling.

* **Tests**
  * Added deterministic QMD bridge tests covering detection, search merging/scoring, retrieval, prefix gating, and fallbacks.

* **Tools**
  * Memory search tool no longer accepts minScore; ask tool returns a safe fallback when no answer.

* **Documentation**
  * Expanded JSDoc across tools, hooks, config, helpers, and runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->