### PR TITLE
fix: add Honcho Memory plugin display name

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "openclaw-honcho",
+  "name": "Honcho Memory",
   "kind": "memory",
   "setup": {
     "providers": [


### PR DESCRIPTION
## Summary
- Add the optional `name` field to `openclaw.plugin.json` so the plugin displays as `Honcho Memory`.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('openclaw.plugin.json','utf8')); console.log('openclaw.plugin.json parses')"`
- `pnpm build`
- `pnpm exec vitest run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the display name of the Honcho memory plugin to "Honcho Memory" for improved clarity and consistency in the plugin interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->