### PR TITLE
chore: release 1.5.1 for ClawHub display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@honcho-ai/openclaw-honcho` will be documented in this file.
 
+## [1.5.1] - 2026-05-21
+
+### Fixed
+- **ClawHub display name (#101)**: Re-publish to ClawHub so the package picks up the `name: "Honcho Memory"` field added to `openclaw.plugin.json`. Previous 1.5.0 ClawHub artifact was built from a commit that predated the display-name addition and showed no display name in `clawhub package inspect`.
+
 ## [1.5.0] - 2026-05-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/openclaw-honcho",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "description": "Honcho AI-native memory integration for OpenClaw",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps to 1.5.1 so ClawHub picks up the `name: "Honcho Memory"` field added in #101. The 1.5.0 ClawHub artifact was built from a pre-#101 commit and shows no display name in `clawhub package inspect`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the display name to "Honcho Memory".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->