### PR TITLE
fix: capture channel delta messages

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -7,6 +7,8 @@ export const DEFAULT_NOISE_PATTERNS: string[] = [
   "A scheduled reminder has been triggered",
   "Execute your Session Startup sequence now",
   "Queued messages from",
+  "已回复。",
+  "已回复",
 ];
 
 export type HonchoConfig = {

--- a/helpers.ts
+++ b/helpers.ts
@@ -10,28 +10,71 @@ import {
   isSubagentSessionKey,
 } from "openclaw/plugin-sdk/routing";
 
-type ContentBlock = { type?: string; text?: unknown };
-type RawMessage = { role?: string; content?: string | ContentBlock[]; timestamp?: number };
+type ContentBlock = { type?: string; text?: unknown; name?: unknown; arguments?: unknown };
+type RawMessage = {
+  role?: string;
+  content?: string | ContentBlock[];
+  timestamp?: number;
+  message?: unknown;
+};
 
 export type SessionClass = "chat" | "cron" | "subagent" | "thread" | "unknown";
 
 const SESSION_ID_DIGEST_LEN = 24;
 
+function unwrapMessage(msg: unknown): unknown {
+  if (!msg || typeof msg !== "object") return msg;
+  const wrapped = msg as RawMessage;
+  if (wrapped.message && typeof wrapped.message === "object") {
+    return wrapped.message;
+  }
+  return msg;
+}
+
+export function getMessageRole(msg: unknown): string | undefined {
+  const unwrapped = unwrapMessage(msg);
+  if (!unwrapped || typeof unwrapped !== "object") return undefined;
+  return (unwrapped as RawMessage).role;
+}
+
+export function getMessageTimestamp(msg: unknown): number | undefined {
+  const unwrapped = unwrapMessage(msg);
+  if (!unwrapped || typeof unwrapped !== "object") return undefined;
+  return (unwrapped as RawMessage).timestamp;
+}
+
+function extractMessageToolText(blocks: ContentBlock[]): string {
+  const texts: string[] = [];
+  for (const block of blocks) {
+    if (!block || block.type !== "toolCall" || block.name !== "message") continue;
+    const args = block.arguments;
+    if (!args || typeof args !== "object") continue;
+    const message = (args as Record<string, unknown>).message;
+    if (typeof message === "string" && message.trim()) {
+      texts.push(message);
+    }
+  }
+  return texts.join("\n");
+}
+
 /**
  * Extract plain text from a message's `content` (string or array of content blocks).
- * Returns "" for non-message inputs or messages with no text blocks.
+ * Returns "" for non-message inputs or messages with no text/tool-call blocks.
  */
 export function getRawContent(msg: unknown): string {
-  if (!msg || typeof msg !== "object") return "";
-  const { content } = msg as RawMessage;
+  const unwrapped = unwrapMessage(msg);
+  if (!unwrapped || typeof unwrapped !== "object") return "";
+  const { content } = unwrapped as RawMessage;
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
-  return content
+  const textContent = content
     .filter((b): b is ContentBlock & { text: string } =>
       !!b && b.type === "text" && typeof b.text === "string",
     )
     .map((b) => b.text)
     .join("\n");
+  if (textContent) return textContent;
+  return extractMessageToolText(content);
 }
 
 export function normalizeSessionKey(raw?: string): string {
@@ -318,9 +361,7 @@ export function extractMessages(
   const result: MessageInput[] = [];
 
   for (const msg of rawMessages) {
-    if (!msg || typeof msg !== "object") continue;
-    const m = msg as Record<string, unknown>;
-    const role = m.role as string | undefined;
+    const role = getMessageRole(msg);
 
     if (role !== "user" && role !== "assistant") continue;
 
@@ -341,7 +382,8 @@ export function extractMessages(
     if (!content) continue;
     if (shouldSkipMessage(content, noisePatterns)) continue;
 
-    const ts = typeof m.timestamp === "number" ? new Date(m.timestamp) : undefined;
+    const timestamp = getMessageTimestamp(msg);
+    const ts = typeof timestamp === "number" ? new Date(timestamp) : undefined;
     result.push(peer.message(content, ts ? { createdAt: ts } : undefined));
   }
 

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -9,6 +9,7 @@ import {
   normalizeSessionKey,
   extractMessages,
   extractSenderId,
+  getMessageRole,
   getRawContent,
 } from "../helpers.js";
 import { subagentParentMap } from "./subagent.js";
@@ -56,18 +57,26 @@ export async function flushMessages(
     } : {}),
   };
 
-  const session = await state.honcho.session(sessionKey, { metadata: sessionMeta });
+  const session = await state.honcho.session(sessionKey);
   const meta = await session.getMetadata();
   const existingMeta: Record<string, unknown> =
     meta && typeof meta === "object" ? (meta as Record<string, unknown>) : {};
 
-  const turnStartIndex = Math.min(
-    Math.max(state.turnStartIndex.get(sessionKey) ?? 0, 0),
-    messages.length,
-  );
+  const rawTurnStartIndex = state.turnStartIndex.get(sessionKey);
+  // Some OpenClaw runtimes pass the full transcript to before_prompt_build,
+  // then pass only the current turn's delta messages to agent_end. In that
+  // shape, a transcript index from before_prompt_build is larger than the
+  // agent_end batch length; treat the agent_end batch as already sliced.
+  const isDeltaBatch =
+    typeof rawTurnStartIndex === "number" && rawTurnStartIndex > messages.length;
+  const turnStartIndex = isDeltaBatch
+    ? 0
+    : Math.min(Math.max(rawTurnStartIndex ?? 0, 0), messages.length);
   const rawLastSavedIndex =
     typeof existingMeta.lastSavedIndex === "number" ? existingMeta.lastSavedIndex : 0;
-  const lastSavedIndex = Math.min(Math.max(rawLastSavedIndex, 0), messages.length);
+  const lastSavedIndex = isDeltaBatch
+    ? 0
+    : Math.min(Math.max(rawLastSavedIndex, 0), messages.length);
   const startIndex = Math.max(turnStartIndex, lastSavedIndex);
 
   if (messages.length <= startIndex) {
@@ -81,9 +90,7 @@ export async function flushMessages(
   let lastSenderId: string | undefined;
   let userMsgCount = 0;
   for (const msg of newRawMessages) {
-    if (!msg || typeof msg !== "object") continue;
-    const m = msg as Record<string, unknown>;
-    if (m.role !== "user") continue;
+    if (getMessageRole(msg) !== "user") continue;
     userMsgCount++;
     const rawContent = getRawContent(msg);
     const senderId = extractSenderId(rawContent);
@@ -141,7 +148,10 @@ export async function flushMessages(
   const updatedMeta: Record<string, unknown> = {
     ...existingMeta,
     ...sessionMeta,
-    lastSavedIndex: messages.length,
+    lastSavedIndex:
+      isDeltaBatch && typeof rawTurnStartIndex === "number"
+        ? rawTurnStartIndex + messages.length
+        : messages.length,
   };
   if (lastSenderId) {
     updatedMeta.participantSenderId = lastSenderId;

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -3,6 +3,21 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey, extractSenderId, isSubagentSession } from "../helpers.js";
 
+function resolveTurnStartIndex(messages: unknown[]): number {
+  if (!Array.isArray(messages) || messages.length === 0) return 0;
+  const lastIndex = messages.length - 1;
+  const rawLast = messages[lastIndex];
+  const last =
+    rawLast && typeof rawLast === "object" &&
+    "message" in rawLast && typeof (rawLast as { message?: unknown }).message === "object"
+      ? (rawLast as { message: unknown }).message
+      : rawLast;
+  if (last && typeof last === "object" && (last as { role?: unknown }).role === "user") {
+    return lastIndex;
+  }
+  return messages.length;
+}
+
 export function registerContextHook(api: OpenClawPluginApi, state: PluginState): void {
   api.on("before_prompt_build", async (event, ctx) => {
     if (!event.prompt || event.prompt.length < 5) return;
@@ -11,7 +26,7 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
     const sessionKey = buildSessionKey({ sessionKey: ctx.sessionKey, agentId });
     const isSubagent = isSubagentSession(ctx);
 
-    state.turnStartIndex.set(sessionKey, event.messages.length);
+    state.turnStartIndex.set(sessionKey, resolveTurnStartIndex(event.messages));
 
     try {
       await state.ensureInitialized();
@@ -44,7 +59,7 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
           throw e;
         }
       } else {
-        const session = await state.honcho.session(sessionKey, { metadata: { agentId } });
+        const session = await state.honcho.session(sessionKey);
 
         let context;
         try {

--- a/runtime.ts
+++ b/runtime.ts
@@ -40,7 +40,7 @@ async function buildSessionTranscript(
 
   const participantPeer = await state.resolveSessionParticipantPeer(sessionId);
   const agentPeer = await state.getAgentPeer(agentId);
-  const session = await state.honcho.session(sessionId, { metadata: { agentId } });
+  const session = await state.honcho.session(sessionId);
   const context = await session.context({
     summary: true,
     tokens: 20000,

--- a/state.ts
+++ b/state.ts
@@ -26,7 +26,22 @@ export function isLocalHonchoBaseUrl(baseUrl?: string): boolean {
     const { hostname, protocol } = new URL(base);
     if (protocol !== "http:" && protocol !== "https:") return false;
     const normalizedHost = hostname.replace(/^\[(.*)\]$/, "$1");
-    return normalizedHost === "localhost" || normalizedHost === "127.0.0.1" || normalizedHost === "::1";
+    if (normalizedHost === "localhost" || normalizedHost === "127.0.0.1" || normalizedHost === "::1") {
+      return true;
+    }
+
+    const octets = normalizedHost.split(".").map((part) => Number(part));
+    if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+      return false;
+    }
+
+    const [a, b] = octets;
+    return (
+      a === 10 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 100 && b >= 64 && b <= 127)
+    );
   } catch {
     return false;
   }

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { flushMessages } from "../hooks/capture.js";
+import { buildSessionKey } from "../helpers.js";
 import type { PluginState } from "../state.js";
 
 const SENTINEL = "Conversation info (untrusted metadata):";
@@ -160,5 +161,65 @@ describe("flushMessages metadata", () => {
 
     expect(session.metadata).not.toHaveProperty("messageProvider");
     expect(session.metadata).not.toHaveProperty("lastSessionId");
+  });
+
+  it("treats agent_end delta batches as already sliced when turnStartIndex exceeds batch length", async () => {
+    const { state, session } = createMockState();
+    const api = { logger: loggerStub() } as never;
+    const ctx = {
+      sessionKey: "agent:main:openclaw-weixin:direct:user-1",
+      agentId: "main",
+    };
+    const honchoSessionKey = buildSessionKey(ctx);
+    state.turnStartIndex.set(honchoSessionKey, 80);
+
+    const saved = await flushMessages(
+      api,
+      state,
+      [
+        { role: "user", content: "current turn", timestamp: 1 },
+        { role: "assistant", content: "current reply", timestamp: 2 },
+      ],
+      ctx,
+    );
+
+    expect(saved).toBe(2);
+    expect(session.addMessages).toHaveBeenCalledOnce();
+    expect(session.metadata.lastSavedIndex).toBe(82);
+  });
+
+  it("extracts wrapped OpenClaw messages during sender resolution and capture", async () => {
+    const { state, session } = createMockState();
+    const api = { logger: loggerStub() } as never;
+
+    await flushMessages(
+      api,
+      state,
+      [
+        {
+          type: "message",
+          message: {
+            role: "user",
+            content: `${metadataBlock({ sender_id: "U-wrapped" })}\n\nwrapped hello`,
+            timestamp: 1,
+          },
+        },
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "wrapped reply",
+            timestamp: 2,
+          },
+        },
+      ],
+      {
+        sessionKey: "agent:main:discord:group:c-1",
+        agentId: "main",
+      },
+    );
+
+    expect(session.metadata.participantSenderId).toBe("U-wrapped");
+    expect(session.addMessages).toHaveBeenCalledOnce();
   });
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -4,6 +4,8 @@ import {
   classifySession,
   extractSenderId,
   extractProvider,
+  extractMessages,
+  getRawContent,
   normalizeSessionKey,
 } from "../helpers.js";
 
@@ -268,5 +270,53 @@ describe("extractSenderId", () => {
   it("returns undefined when the content has no metadata block", () => {
     expect(extractSenderId("just a normal DM")).toBeUndefined();
     expect(extractSenderId("")).toBeUndefined();
+  });
+});
+
+describe("message content extraction", () => {
+  const ownerPeer = { id: "owner", message: (content: string) => ({ peer: "owner", content }) };
+  const agentPeer = { id: "agent-main", message: (content: string) => ({ peer: "agent", content }) };
+
+  it("unwraps OpenClaw message wrapper objects", () => {
+    expect(getRawContent({ type: "message", message: { role: "user", content: "hello" } })).toBe("hello");
+  });
+
+  it("extracts visible outbound text from message tool calls", () => {
+    const content = getRawContent({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          name: "message",
+          arguments: { message: "visible channel reply" },
+        },
+      ],
+    });
+
+    expect(content).toBe("visible channel reply");
+  });
+
+  it("drops default channel delivery placeholders via noise patterns", () => {
+    const extracted = extractMessages(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              name: "message",
+              arguments: { message: "visible channel reply" },
+            },
+          ],
+        },
+        { role: "assistant", content: "已回复。" },
+      ],
+      ownerPeer as never,
+      agentPeer as never,
+      ["已回复。", "已回复"],
+    );
+
+    expect(extracted).toHaveLength(1);
+    expect(extracted[0]).toEqual({ peer: "agent", content: "visible channel reply" });
   });
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isLocalHonchoBaseUrl } from "../state.js";
+
+describe("isLocalHonchoBaseUrl", () => {
+  it("treats localhost, private LAN, and tailnet addresses as self-hosted", () => {
+    expect(isLocalHonchoBaseUrl("http://localhost:8000")).toBe(true);
+    expect(isLocalHonchoBaseUrl("http://127.0.0.1:8000")).toBe(true);
+    expect(isLocalHonchoBaseUrl("http://10.0.0.2:8000")).toBe(true);
+    expect(isLocalHonchoBaseUrl("http://172.16.0.2:8000")).toBe(true);
+    expect(isLocalHonchoBaseUrl("http://192.168.1.2:8000")).toBe(true);
+    expect(isLocalHonchoBaseUrl("http://100.64.0.2:8000")).toBe(true);
+  });
+
+  it("does not classify public Honcho URLs as self-hosted", () => {
+    expect(isLocalHonchoBaseUrl("https://api.honcho.dev")).toBe(false);
+    expect(isLocalHonchoBaseUrl("https://8.8.8.8")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- handle wrapped OpenClaw message records when extracting roles, timestamps, sender metadata, and content
- treat `agent_end` batches as already sliced when `before_prompt_build` recorded a full-transcript cursor
- persist visible outbound channel replies from `message` tool calls while filtering channel delivery placeholders
- classify private LAN and `100.64.0.0/10` self-host URLs as local Honcho deployments

## Testing
- `./node_modules/.bin/vitest --run`
- `./node_modules/.bin/tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message content extraction and metadata handling
  * Enhanced detection of self-hosted Honcho instances with broader private network support
  * Fixed delta batch message persistence handling

* **Chores**
  * Added comprehensive test coverage for message extraction, batch handling, and self-hosted detection
  * Added support for additional Chinese noise pattern defaults

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/openclaw-honcho/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->