### PR TITLE
feat(tools): add optional session_id to search, ask, and context tools

### DIFF
--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerAskTool } from "../tools/ask.js";
+import { registerSearchTool } from "../tools/search.js";
+import { registerContextTool } from "../tools/context.js";
+import type { PluginState } from "../state.js";
+
+type ToolDef = {
+  name: string;
+  execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+function captureRegistrations() {
+  const registrations: Array<{
+    factory: (ctx: Record<string, unknown>) => ToolDef;
+    opts?: Record<string, unknown>;
+  }> = [];
+  return {
+    registrations,
+    api: {
+      registerTool: (
+        factory: (ctx: Record<string, unknown>) => ToolDef,
+        opts?: Record<string, unknown>,
+      ) => {
+        registrations.push({ factory, opts });
+      },
+    },
+  };
+}
+
+function makeParticipantPeer() {
+  return {
+    id: "owner",
+    representation: vi.fn(async () => "Full representation text"),
+    card: vi.fn(async () => ["Fact 1", "Fact 2"]),
+  };
+}
+
+function makeAgentPeer() {
+  return {
+    id: "agent-main",
+    chat: vi.fn(async () => "Honcho answer"),
+  };
+}
+
+function createMockState(
+  participantPeer = makeParticipantPeer(),
+  agentPeer = makeAgentPeer(),
+) {
+  return {
+    state: {
+      ensureInitialized: vi.fn(async () => undefined),
+      getAgentPeer: vi.fn(async () => agentPeer),
+      getParticipantPeer: vi.fn(async () => participantPeer),
+      resolveSessionParticipantPeer: vi.fn(async () => participantPeer),
+    } as unknown as PluginState,
+    participantPeer,
+    agentPeer,
+  };
+}
+
+const TOOL_CTX = {
+  sessionKey: "agent:main:dashboard:test",
+  agentId: "main",
+};
+
+describe("honcho_ask session_id", () => {
+  it("passes session to agentPeer.chat when session_id is provided", async () => {
+    const { api, registrations } = captureRegistrations();
+    const { state, agentPeer } = createMockState();
+
+    registerAskTool(api as never, state);
+    const tool = registrations[0]!.factory(TOOL_CTX);
+
+    await tool.execute("call-1", { query: "What's their name?", session_id: "sess-123" });
+
+    const [, opts] = agentPeer.chat.mock.calls[0] as [string, Record<string, unknown>];
+    expect(opts.session).toBe("sess-123");
+  });
+
+  it("passes undefined session when session_id is omitted", async () => {
+    const { api, registrations } = captureRegistrations();
+    const { state, agentPeer } = createMockState();
+
+    registerAskTool(api as never, state);
+    const tool = registrations[0]!.factory(TOOL_CTX);
+
+    await tool.execute("call-1", { query: "What's their name?" });
+
+    const [, opts] = agentPeer.chat.mock.calls[0] as [string, Record<string, unknown>];
+    expect(opts.session).toBeUndefined();
+  });
+});
+
+describe("honcho_search_conclusions session_id", () => {
+  it("passes session to participantPeer.representation when session_id is provided", async () => {
+    const { api, registrations } = captureRegistrations();
+    const { state, participantPeer } = createMockState();
+
+    registerSearchTool(api as never, state);
+    const tool = registrations[0]!.factory(TOOL_CTX);
+
+    await tool.execute("call-1", { query: "preferences", session_id: "sess-456" });
+
+    const [opts] = participantPeer.representation.mock.calls[0] as [Record<string, unknown>];
+    expect(opts.session).toBe("sess-456");
+    expect(opts.searchQuery).toBe("preferences");
+  });
+
+  it("passes undefined session when session_id is omitted", async () => {
+    const { api, registrations } = captureRegistrations();
+    const { state, participantPeer } = createMockState();
+
+    registerSearchTool(api as never, state);
+    const tool = registrations[0]!.factory(TOOL_CTX);
+
+    await tool.execute("call-1", { query: "preferences" });
+
+    const [opts] = participantPeer.representation.mock.calls[0] as [Record<string, unknown>];
+    expect(opts.session).toBeUndefined();
+  });
+});
+
+describe("honcho_context session_id", () => {
+  it("passes session to representation in 'full' mode when session_id is provided", async () => {
+    const { api, registrations } = captureRegistrations();
+    const { state, participantPeer } = createMockState();
+
+    registerContextTool(api as never, state);
+    const tool = registrations[0]!.factory(TOOL_CTX);
+
+    await tool.execute("call-1", { detail: "full", session_id: "sess-789" });
+
+    const [opts] = participantPeer.representation.mock.calls[0] as [Record<string, unknown>];
+    expect(opts.session).toBe("sess-789");
+    expect(opts.includeMostFrequent).toBe(true);
+  });
+
+  it("passes undefined session in 'full' mode when session_id is omitted", async () => {
+    const { api, registrations } = captureRegistrations();
+    const { state, participantPeer } = createMockState();
+
+    registerContextTool(api as never, state);
+    const tool = registrations[0]!.factory(TOOL_CTX);
+
+    await tool.execute("call-1", { detail: "full" });
+
+    const [opts] = participantPeer.representation.mock.calls[0] as [Record<string, unknown>];
+    expect(opts.session).toBeUndefined();
+  });
+
+  it("ignores session_id in 'card' mode — card() receives no session arg", async () => {
+    const { api, registrations } = captureRegistrations();
+    const { state, participantPeer } = createMockState();
+
+    registerContextTool(api as never, state);
+    const tool = registrations[0]!.factory(TOOL_CTX);
+
+    await tool.execute("call-1", { detail: "card", session_id: "sess-789" });
+
+    expect(participantPeer.card).toHaveBeenCalled();
+    expect(participantPeer.representation).not.toHaveBeenCalled();
+  });
+});

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -30,7 +30,12 @@ function captureRegistrations() {
 function makeParticipantPeer() {
   return {
     id: "owner",
-    representation: vi.fn(async () => "Full representation text"),
+    representation: vi.fn(async (opts?: Record<string, unknown>) => {
+      if (opts && !("session" in opts)) {
+        throw new Error("representation() received unexpected options");
+      }
+      return "Full representation text";
+    }),
     card: vi.fn(async () => ["Fact 1", "Fact 2"]),
   };
 }
@@ -38,7 +43,12 @@ function makeParticipantPeer() {
 function makeAgentPeer() {
   return {
     id: "agent-main",
-    chat: vi.fn(async () => "Honcho answer"),
+    chat: vi.fn(async (_query: string, opts?: Record<string, unknown>) => {
+      if (opts && !("session" in opts)) {
+        throw new Error("chat() received unexpected options");
+      }
+      return "Honcho answer";
+    }),
   };
 }
 

--- a/tools/ask.ts
+++ b/tools/ask.ts
@@ -29,14 +29,21 @@ export function registerAskTool(api: OpenClawPluginApi, state: PluginState): voi
                 "Sender ID of the user to ask about. Defaults to the last active sender. Pass a specific sender_id to ask about a different participant.",
             })
           ),
+          session_id: Type.Optional(
+            Type.String({
+              description:
+                "Session ID to scope the question to. Only considers information from this specific session.",
+            })
+          ),
         },
         { additionalProperties: false }
       ),
       async execute(_toolCallId, params) {
-        const { query, depth = "quick", about } = params as {
+        const { query, depth = "quick", about, session_id } = params as {
           query: string;
           depth?: "quick" | "thorough";
           about?: string;
+          session_id?: string;
         };
 
         await state.ensureInitialized();
@@ -51,6 +58,7 @@ export function registerAskTool(api: OpenClawPluginApi, state: PluginState): voi
         const answer = await agentPeer.chat(query, {
           target: participantPeer,
           reasoningLevel,
+          session: session_id,
         });
 
         return {

--- a/tools/context.ts
+++ b/tools/context.ts
@@ -26,11 +26,17 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
                 "Sender ID of the user to query about. Defaults to the last active sender. Pass a specific sender_id to get context about a different participant.",
             })
           ),
+          session_id: Type.Optional(
+            Type.String({
+              description:
+                "Session ID to scope the context to. Only considers information from this specific session.",
+            })
+          ),
         },
         { additionalProperties: false }
       ),
       async execute(_toolCallId, params) {
-        const { detail = "card", about } = params as { detail?: "card" | "full"; about?: string };
+        const { detail = "card", about, session_id } = params as { detail?: "card" | "full"; about?: string; session_id?: string };
 
         await state.ensureInitialized();
         const participantPeer = about
@@ -74,6 +80,7 @@ export function registerContextTool(api: OpenClawPluginApi, state: PluginState):
         // detail === "full"
         const representation = await participantPeer.representation({
           includeMostFrequent: true,
+          session: session_id,
         });
 
         if (!representation) {

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -36,15 +36,22 @@ export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): 
                 "Sender ID of the user to query about. Defaults to the last active sender. Pass a specific sender_id to search conclusions about a different participant.",
             })
           ),
+          session_id: Type.Optional(
+            Type.String({
+              description:
+                "Session ID to scope the search to. Only searches conclusions from this specific session.",
+            })
+          ),
         },
         { additionalProperties: false }
       ),
       async execute(_toolCallId, params) {
-        const { query, topK, maxDistance, about } = params as {
+        const { query, topK, maxDistance, about, session_id } = params as {
           query: string;
           topK?: number;
           maxDistance?: number;
           about?: string;
+          session_id?: string;
         };
 
         await state.ensureInitialized();
@@ -58,6 +65,7 @@ export function registerSearchTool(api: OpenClawPluginApi, state: PluginState): 
           searchQuery: query,
           searchTopK: topK ?? 10,
           searchMaxDistance: maxDistance ?? 0.5,
+          session: session_id,
         });
 
         if (!representation) {


### PR DESCRIPTION
## Summary

Adds an optional `session_id` parameter to three Honcho tools to allow session-scoped queries.

## Changes

- `honcho_search_conclusions` (`tools/search.ts`): filters semantic search to a specific session
- `honcho_ask` (`tools/ask.ts`): limits Q&A to a specific session
- `honcho_context` (`tools/context.ts`): limits context retrieval to a specific session

## Behavior

- `session_id` is **optional** — existing calls without it work unchanged
- When provided, `session_id` is passed to the Honcho SDK as `session: params.session_id`
- Backward compatibility: 100%

## Tests

Added 7 new unit tests in `test/tools.test.ts` covering:
- `honcho_ask` — session_id passed/omitted
- `honcho_search_conclusions` — session_id passed/omitted
- `honcho_context` — session_id in "full" mode (passed/omitted), and "card" mode ignores it

## Verification

- [x] `tsc` compiles without errors
- [x] `vitest run` — 61/61 tests pass
- [x] Tools without `session_id` behave identically to before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional session_id parameter to ask, search, and context tools to enable session-scoped operations and more consistent session-aware results.
  * Tool executions now propagate session identifiers to participant/agent calls for improved session handling.

* **Tests**
  * Added tests verifying session parameter propagation and correct tool behavior across session-scoped scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->