### PR TITLE
feat: cap injected Honcho context conclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,31 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `apiKey`               | `string`   | —                          | Honcho API key (required for managed; omit for self-hosted). |
 | `workspaceId`          | `string`   | `"openclaw"`               | Honcho workspace ID for memory isolation. |
 | `baseUrl`              | `string`   | `"https://api.honcho.dev"` | API endpoint (for self-hosted instances). |
+| `contextMaxConclusions` | `number` | —                          | Optional cap (1-100) for conclusions included in automatically injected Honcho context. |
 | `noisePatterns`        | `string[]` | built-in defaults          | Patterns to skip messages. User-provided patterns are merged with built-in defaults (unless `disableDefaultNoisePatterns` is set). |
 | `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
 | `crossSessionSearch`   | `boolean`  | `true`                     | Allow `memory_search` and `memory_get` to access any session. Set to `false` to restrict to the active session and its children. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
+
+### Context Injection
+
+On each turn, the plugin appends Honcho context to the system prompt during OpenClaw's `before_prompt_build` phase. By default, this includes key facts, the peer representation, and any available conversation summary.
+
+For workspaces with large peer representations, cap the automatic injection:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw-honcho": {
+        "config": {
+          "contextMaxConclusions": 25
+        }
+      }
+    }
+  }
+}
+```
 
 ### Self-Hosted / Local Honcho
 

--- a/config.ts
+++ b/config.ts
@@ -14,6 +14,7 @@ export type HonchoConfig = {
   workspaceId: string;
   baseUrl: string;
   timeoutMs?: number;
+  contextMaxConclusions?: number;
   noisePatterns: string[];
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
@@ -74,6 +75,17 @@ export const honchoConfigSchema = {
         if (process.env.HONCHO_TIMEOUT_MS !== undefined) {
           const parsed = Number(process.env.HONCHO_TIMEOUT_MS);
           if (Number.isFinite(parsed) && parsed > 0) return parsed;
+        }
+        return undefined;
+      })(),
+      contextMaxConclusions: (() => {
+        if (
+          typeof cfg.contextMaxConclusions === "number" &&
+          Number.isInteger(cfg.contextMaxConclusions) &&
+          cfg.contextMaxConclusions >= 1 &&
+          cfg.contextMaxConclusions <= 100
+        ) {
+          return cfg.contextMaxConclusions;
         }
         return undefined;
       })(),

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -26,10 +26,14 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
         : await state.resolveSessionParticipantPeer(sessionKey);
 
       const sections: string[] = [];
+      const maxConclusions = state.cfg.contextMaxConclusions;
 
       if (isSubagent) {
         try {
-          const peerCtx = await agentPeer.context({ target: participantPeer });
+          const peerCtx = await agentPeer.context({
+            target: participantPeer,
+            ...(maxConclusions !== undefined ? { maxConclusions } : {}),
+          });
           if (peerCtx.peerCard?.length) {
             sections.push(`Key facts:\n${peerCtx.peerCard.map((f: string) => `• ${f}`).join("\n")}`);
           }
@@ -53,6 +57,9 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
             tokens: 2000,
             peerTarget: participantPeer,
             peerPerspective: agentPeer,
+            ...(maxConclusions !== undefined
+              ? { representationOptions: { maxConclusions } }
+              : {}),
           });
         } catch (e: unknown) {
           const isNotFound =

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -42,6 +42,12 @@
         "minimum": 1,
         "description": "HTTP timeout in milliseconds for Honcho SDK requests. Useful for slower self-hosted local models."
       },
+      "contextMaxConclusions": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100,
+        "description": "Optional maximum number of conclusions to include in automatically injected Honcho context. Limits large peer representations in the system prompt."
+      },
       "noisePatterns": {
         "type": "array",
         "items": { "type": "string" },
@@ -86,6 +92,12 @@
       "advanced": true,
       "placeholder": "60000",
       "help": "Increase this for self-hosted Honcho deployments backed by slower local models."
+    },
+    "contextMaxConclusions": {
+      "label": "Context Max Conclusions",
+      "advanced": true,
+      "placeholder": "25",
+      "help": "Caps the number of conclusions included in automatically injected Honcho context."
     },
     "noisePatterns": {
       "label": "Noise Patterns",

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -38,7 +38,7 @@ function createMockState({
     resolveDefaultAgentId: vi.fn(() => "main"),
   } as unknown as PluginState;
 
-  return { state, session };
+  return { state, session, agentPeer };
 }
 
 function registerHandler(state: PluginState) {
@@ -74,5 +74,31 @@ describe("Honcho context injection", () => {
     }));
     expect(result.appendSystemContext).toContain("User context:");
     expect(result.appendSystemContext).toContain("large representation");
+  });
+
+  it("passes contextMaxConclusions directly to agentPeer.context for subagent sessions", async () => {
+    const { state, agentPeer } = createMockState({ contextMaxConclusions: 25 });
+    agentPeer.context.mockResolvedValue({
+      peerCard: ["IDENTITY: Name: Renaud"],
+      representation: "Subagent user context data",
+    });
+    const handler = registerHandler(state);
+
+    const result = await handler(
+      {
+        prompt: "hello from user",
+        messages: [{ role: "user", content: "hello" }],
+      },
+      { sessionKey: "agent:main:subagent:research-1", agentId: "main" },
+    ) as { appendSystemContext: string };
+
+    expect(agentPeer.context).toHaveBeenCalledWith(expect.objectContaining({
+      maxConclusions: 25,
+    }));
+    expect(agentPeer.context).not.toHaveBeenCalledWith(expect.objectContaining({
+      representationOptions: expect.anything(),
+    }));
+    expect(result.appendSystemContext).toContain("User context:");
+    expect(result.appendSystemContext).toContain("Subagent user context data");
   });
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerContextHook } from "../hooks/context.js";
+import type { PluginState } from "../state.js";
+
+function createMockState({
+  contextMaxConclusions,
+}: {
+  contextMaxConclusions?: number;
+} = {}) {
+  const participantPeer = { id: "user-1" };
+  const agentPeer = { id: "agent-main", context: vi.fn() };
+  const session = {
+    context: vi.fn(async () => ({
+      peerCard: ["IDENTITY: Name: Renaud"],
+      peerRepresentation: "## Explicit Observations\n\nlarge representation",
+      summary: { content: "Earlier summary" },
+    })),
+  };
+
+  const state = {
+    cfg: {
+      workspaceId: "openclaw",
+      baseUrl: "https://api.honcho.dev",
+      noisePatterns: [],
+      disableDefaultNoisePatterns: false,
+      ownerObserveOthers: false,
+      crossSessionSearch: true,
+      contextMaxConclusions,
+    },
+    honcho: {
+      session: vi.fn(async () => session),
+    },
+    turnStartIndex: new Map<string, number>(),
+    ensureInitialized: vi.fn(async () => undefined),
+    getAgentPeer: vi.fn(async () => agentPeer),
+    getParticipantPeer: vi.fn(async () => participantPeer),
+    resolveSessionParticipantPeer: vi.fn(async () => participantPeer),
+    resolveDefaultAgentId: vi.fn(() => "main"),
+  } as unknown as PluginState;
+
+  return { state, session };
+}
+
+function registerHandler(state: PluginState) {
+  const handlers: Array<(event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<unknown>> = [];
+  const api = {
+    on: vi.fn((name: string, handler: (event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<unknown>) => {
+      expect(name).toBe("before_prompt_build");
+      handlers.push(handler);
+    }),
+    logger: { warn: vi.fn() },
+  };
+
+  registerContextHook(api as never, state);
+  expect(handlers).toHaveLength(1);
+  return handlers[0]!;
+}
+
+describe("Honcho context injection", () => {
+  it("passes contextMaxConclusions to session.context representation options", async () => {
+    const { state, session } = createMockState({ contextMaxConclusions: 25 });
+    const handler = registerHandler(state);
+
+    const result = await handler(
+      {
+        prompt: "hello from user",
+        messages: [{ role: "user", content: "hello" }],
+      },
+      { sessionKey: "agent:main:telegram:user-1", agentId: "main" },
+    ) as { appendSystemContext: string };
+
+    expect(session.context).toHaveBeenCalledWith(expect.objectContaining({
+      representationOptions: { maxConclusions: 25 },
+    }));
+    expect(result.appendSystemContext).toContain("User context:");
+    expect(result.appendSystemContext).toContain("large representation");
+  });
+});


### PR DESCRIPTION
## Summary

- add a `contextMaxConclusions` config option for automatic Honcho context injection
- pass the cap through to `session.context(... representationOptions.maxConclusions ...)` and subagent `agentPeer.context(...)` calls
- document the option and cover the prompt-injection path with a focused test

This is intentionally narrower than #81: it does not add new injection-mode toggles, and only exposes Honcho's existing `maxConclusions` control for the automatically injected peer representation.

## Why

`tokens: 2000` does not cap `peerRepresentation`; large explicit-observation blocks can still be appended to the system prompt. Honcho already supports `maxConclusions`, so this lets users keep automatic context enabled while bounding prompt size.

In a local self-hosted check against an existing large peer representation, the default context was about 17k characters, while `maxConclusions: 25` reduced it to about 3k characters.

## Validation

- `corepack pnpm@9 build`
- `corepack pnpm@9 test -- --run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `contextMaxConclusions` configuration setting to control the number of conclusions in automatically injected context (1–100).

* **Documentation**
  * Updated configuration documentation with new setting explanation and configuration example.

* **Tests**
  * Added test coverage for context injection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->