### PR TITLE
fix: treat any non-honcho.dev base URL as self-hosted (no spurious API-key warning)

### DIFF
--- a/hooks/gateway.ts
+++ b/hooks/gateway.ts
@@ -14,7 +14,7 @@ export function registerGatewayHook(api: OpenClawPluginApi, state: PluginState):
         })`,
       );
     } catch (error) {
-      api.logger.error(`Failed to initialize Honcho: ${error}`);
+      api.logger.error(`Failed to initialize Honcho at ${state.cfg.baseUrl}: ${error}`);
     }
   });
 }

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,5 +1,5 @@
 import { buildSessionKey } from "./helpers.js";
-import { isLocalHonchoBaseUrl, type PluginState } from "./state.js";
+import { isManagedHonchoCloud, type PluginState } from "./state.js";
 
 const DEFAULT_SEARCH_RESULTS = 10;
 const MAX_SEARCH_RESULTS = 50;
@@ -218,7 +218,7 @@ export async function getHonchoMemorySearchManager(
       status() {
         return {
           backend: "qmd",
-          provider: isLocalHonchoBaseUrl(state.cfg.baseUrl) ? "honcho-selfhosted" : "honcho",
+          provider: isManagedHonchoCloud(state.cfg.baseUrl) ? "honcho" : "honcho-selfhosted",
           model: "n/a",
           sources: ["sessions"],
           custom: {

--- a/state.ts
+++ b/state.ts
@@ -18,28 +18,17 @@ import {
 export const OWNER_ID = "owner";
 export const LEGACY_PEER_ID = "openclaw";
 
-/** Apex domain of the managed Honcho cloud — the only deployment that requires an API key. */
-export const HONCHO_CLOUD_DOMAIN = "honcho.dev";
+export const HONCHO_CLOUD_HOSTNAME = "api.honcho.dev";
 
 /**
- * True when the base URL points at the managed Honcho cloud, i.e. the
- * `honcho.dev` apex or any of its subdomains (e.g. `api.honcho.dev`).
- * The cloud is the only deployment that requires an API key; any other base
- * URL — localhost or a custom self-hosted domain — is treated as self-hosted.
- * An empty/unset base URL is treated as cloud, matching the config default
- * (https://api.honcho.dev).
+ * True when the base URL points at the managed Honcho cloud
+ * (api.honcho.dev). The cloud is the only deployment that requires an API
+ * key; any other base URL — localhost or a custom self-hosted domain — is
+ * treated as self-hosted.
  */
-export function isManagedHonchoCloud(baseUrl?: string): boolean {
-  const base = String(baseUrl ?? "").trim();
-  if (!base) return true;
-
+export function isManagedHonchoCloud(baseUrl: string): boolean {
   try {
-    const { hostname } = new URL(base);
-    const normalizedHost = hostname.replace(/^\[(.*)\]$/, "$1").toLowerCase();
-    return (
-      normalizedHost === HONCHO_CLOUD_DOMAIN ||
-      normalizedHost.endsWith(`.${HONCHO_CLOUD_DOMAIN}`)
-    );
+    return new URL(baseUrl).hostname.toLowerCase() === HONCHO_CLOUD_HOSTNAME;
   } catch {
     return false;
   }

--- a/state.ts
+++ b/state.ts
@@ -18,15 +18,28 @@ import {
 export const OWNER_ID = "owner";
 export const LEGACY_PEER_ID = "openclaw";
 
-export function isLocalHonchoBaseUrl(baseUrl?: string): boolean {
+/** Apex domain of the managed Honcho cloud — the only deployment that requires an API key. */
+export const HONCHO_CLOUD_DOMAIN = "honcho.dev";
+
+/**
+ * True when the base URL points at the managed Honcho cloud, i.e. the
+ * `honcho.dev` apex or any of its subdomains (e.g. `api.honcho.dev`).
+ * The cloud is the only deployment that requires an API key; any other base
+ * URL — localhost or a custom self-hosted domain — is treated as self-hosted.
+ * An empty/unset base URL is treated as cloud, matching the config default
+ * (https://api.honcho.dev).
+ */
+export function isManagedHonchoCloud(baseUrl?: string): boolean {
   const base = String(baseUrl ?? "").trim();
-  if (!base) return false;
+  if (!base) return true;
 
   try {
-    const { hostname, protocol } = new URL(base);
-    if (protocol !== "http:" && protocol !== "https:") return false;
-    const normalizedHost = hostname.replace(/^\[(.*)\]$/, "$1");
-    return normalizedHost === "localhost" || normalizedHost === "127.0.0.1" || normalizedHost === "::1";
+    const { hostname } = new URL(base);
+    const normalizedHost = hostname.replace(/^\[(.*)\]$/, "$1").toLowerCase();
+    return (
+      normalizedHost === HONCHO_CLOUD_DOMAIN ||
+      normalizedHost.endsWith(`.${HONCHO_CLOUD_DOMAIN}`)
+    );
   } catch {
     return false;
   }
@@ -66,7 +79,7 @@ export type PluginState = {
 export function createPluginState(api: OpenClawPluginApi): PluginState {
   const cfg = honchoConfigSchema.parse(api.pluginConfig);
 
-  const selfHosted = isLocalHonchoBaseUrl(cfg.baseUrl);
+  const selfHosted = !isManagedHonchoCloud(cfg.baseUrl);
 
   if (!cfg.apiKey && !selfHosted) {
     api.logger.warn(

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -2,34 +2,19 @@ import { describe, expect, it } from "vitest";
 import { isManagedHonchoCloud } from "../state.js";
 
 describe("isManagedHonchoCloud", () => {
-  it("treats the honcho.dev cloud apex and subdomains as managed cloud", () => {
+  it("recognizes the managed cloud host", () => {
     expect(isManagedHonchoCloud("https://api.honcho.dev")).toBe(true);
-    expect(isManagedHonchoCloud("https://honcho.dev")).toBe(true);
-    expect(isManagedHonchoCloud("https://api.honcho.dev/")).toBe(true);
-    expect(isManagedHonchoCloud("https://eu.api.honcho.dev")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
     expect(isManagedHonchoCloud("https://API.HONCHO.DEV")).toBe(true);
   });
 
-  it("treats an empty/unset base URL as cloud (matches config default)", () => {
-    expect(isManagedHonchoCloud(undefined)).toBe(true);
-    expect(isManagedHonchoCloud("")).toBe(true);
-    expect(isManagedHonchoCloud("   ")).toBe(true);
+  it("treats custom self-hosted domains as not cloud", () => {
+    expect(isManagedHonchoCloud("https://honcho.example.com")).toBe(false);
   });
 
-  it("treats localhost and custom self-hosted domains as self-hosted", () => {
-    expect(isManagedHonchoCloud("http://localhost:8000")).toBe(false);
-    expect(isManagedHonchoCloud("http://127.0.0.1:8000")).toBe(false);
-    expect(isManagedHonchoCloud("http://[::1]:8000")).toBe(false);
-    expect(isManagedHonchoCloud("https://api.honcho.example.com")).toBe(false);
-    expect(isManagedHonchoCloud("https://honcho.mycompany.internal")).toBe(false);
-  });
-
-  it("does not match look-alike domains that merely contain honcho.dev", () => {
+  it("does not match look-alike domains", () => {
     expect(isManagedHonchoCloud("https://honcho.dev.evil.com")).toBe(false);
-    expect(isManagedHonchoCloud("https://nothoncho.dev")).toBe(false);
-  });
-
-  it("returns false for unparseable base URLs", () => {
-    expect(isManagedHonchoCloud("not a url")).toBe(false);
   });
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isManagedHonchoCloud } from "../state.js";
+
+describe("isManagedHonchoCloud", () => {
+  it("treats the honcho.dev cloud apex and subdomains as managed cloud", () => {
+    expect(isManagedHonchoCloud("https://api.honcho.dev")).toBe(true);
+    expect(isManagedHonchoCloud("https://honcho.dev")).toBe(true);
+    expect(isManagedHonchoCloud("https://api.honcho.dev/")).toBe(true);
+    expect(isManagedHonchoCloud("https://eu.api.honcho.dev")).toBe(true);
+    expect(isManagedHonchoCloud("https://API.HONCHO.DEV")).toBe(true);
+  });
+
+  it("treats an empty/unset base URL as cloud (matches config default)", () => {
+    expect(isManagedHonchoCloud(undefined)).toBe(true);
+    expect(isManagedHonchoCloud("")).toBe(true);
+    expect(isManagedHonchoCloud("   ")).toBe(true);
+  });
+
+  it("treats localhost and custom self-hosted domains as self-hosted", () => {
+    expect(isManagedHonchoCloud("http://localhost:8000")).toBe(false);
+    expect(isManagedHonchoCloud("http://127.0.0.1:8000")).toBe(false);
+    expect(isManagedHonchoCloud("http://[::1]:8000")).toBe(false);
+    expect(isManagedHonchoCloud("https://api.honcho.example.com")).toBe(false);
+    expect(isManagedHonchoCloud("https://honcho.mycompany.internal")).toBe(false);
+  });
+
+  it("does not match look-alike domains that merely contain honcho.dev", () => {
+    expect(isManagedHonchoCloud("https://honcho.dev.evil.com")).toBe(false);
+    expect(isManagedHonchoCloud("https://nothoncho.dev")).toBe(false);
+  });
+
+  it("returns false for unparseable base URLs", () => {
+    expect(isManagedHonchoCloud("not a url")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Self-hosted Honcho deployments on a custom domain log a spurious warning on every startup:

```
warn  plugins  openclaw-honcho: No API key configured. Set HONCHO_API_KEY or configure apiKey in plugin config.
```

The warning is gated on `isLocalHonchoBaseUrl()`, which only recognizes `localhost`, `127.0.0.1`, and `::1` as self-hosted. A self-hosted instance reachable at a real hostname (e.g. `honcho.example.com`) is therefore misclassified as the managed cloud, and the plugin warns about an API key it doesn't need. The same misclassification makes the memory backend report `provider: "honcho"` instead of `"honcho-selfhosted"` for those deployments.

## Change

Replace `isLocalHonchoBaseUrl()` with `isManagedHonchoCloud()`. The managed cloud is the only deployment that requires an API key, so that's what we detect — the `honcho.dev` apex and any of its subdomains (matching the SDK's default base URL, `https://api.honcho.dev`). Everything else — localhost **or** a custom self-hosted domain — is treated as self-hosted.

- `state.ts`: API-key warning now fires only when pointed at the cloud (`!isManagedHonchoCloud(baseUrl)`).
- `runtime.ts`: backend `provider` reports `honcho-selfhosted` for any non-cloud base URL.
- Empty/unset base URL is treated as cloud, matching the config default.
- Look-alike hosts (`honcho.dev.evil.com`, `nothoncho.dev`) are correctly classified as **not** cloud.

## Tests

New `test/state.test.ts` covers cloud apex/subdomains, empty URLs, localhost, custom self-hosted domains, look-alike domains, and unparseable input. Existing localhost-based runtime test still passes (still reports `honcho-selfhosted`).

```
Test Files  6 passed (6)
     Tests  59 passed (59)
```

`pnpm build` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages by including the configured Honcho server URL when startup initialization fails.
  * More accurately identifies managed Honcho Cloud versus self-hosted deployments, including custom domains and localhost setups.
  * Corrected provider status reporting and API key warnings based on the detected deployment type.

* **Tests**
  * Added coverage for cloud hostname matching, case variations, custom domains, and look-alike domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->