### PR TITLE
fix(runtime): honor crossSessionSearch flag in memory_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@honcho-ai/openclaw-honcho` will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **`crossSessionSearch` flag now actually toggles search strategy**: `memory_search` was always session-scoped regardless of the flag, so cross-session queries returned `[]`. Config default (`true`) now spans the participant peer's sessions; `false` scopes to the active session. Adds optional `crossSessionSearch` parameter on `memory_search` for per-call override.
+
 ## [1.5.1] - 2026-05-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `baseUrl`              | `string`   | `"https://api.honcho.dev"` | API endpoint (for self-hosted instances). |
 | `noisePatterns`        | `string[]` | built-in defaults          | Patterns to skip messages. User-provided patterns are merged with built-in defaults (unless `disableDefaultNoisePatterns` is set). |
 | `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
-| `crossSessionSearch`   | `boolean`  | `true`                     | Allow `memory_search` and `memory_get` to access any session. Set to `false` to restrict to the active session and its children. |
+| `crossSessionSearch`   | `boolean`  | `true`                     | Default scope for `memory_search`. `true` = results span every session the participant peer has written to; `false` = scope to the active session. `memory_search` accepts an optional `crossSessionSearch` boolean parameter to override this per-call. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
 
 ### Self-Hosted / Local Honcho

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -60,7 +60,7 @@
       "crossSessionSearch": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), memory_search/memory_get can return results from any session in the workspace. When false, results are scoped to the active session and its child sessions only."
+        "description": "Default scope for memory_search. When true (default), results span every session the participant peer has written to. When false, results are scoped to the active session. Per-call override available via the memory_search `crossSession` parameter."
       }
     }
   },

--- a/runtime.ts
+++ b/runtime.ts
@@ -125,7 +125,7 @@ export async function getHonchoMemorySearchManager(
 
   return {
     manager: {
-      async search(query: string, opts: { maxResults?: number; sessionKey?: string } = {}) {
+      async search(query: string, opts: { maxResults?: number; crossSessionSearch?: boolean } = {}) {
         await state.ensureInitialized();
         const participantPeer = activeSessionKey
           ? await state.resolveSessionParticipantPeer(activeSessionKey)
@@ -134,49 +134,27 @@ export async function getHonchoMemorySearchManager(
           ? Number(opts.maxResults)
           : DEFAULT_SEARCH_RESULTS;
         const limit = Math.min(MAX_SEARCH_RESULTS, Math.max(1, Math.trunc(requested)));
-        const requestedSessionKey =
-          typeof opts.sessionKey === "string" && opts.sessionKey.length > 0
-            ? opts.sessionKey
-            : activeSessionKey ?? null;
-        const scopeEnabled = !state.cfg.crossSessionSearch;
-        if (
-          scopeEnabled &&
-          activeSessionKey &&
-          requestedSessionKey &&
-          !matchesSessionScope(requestedSessionKey, activeSessionKey)
-        ) {
-          throw new Error(
-            `Requested Honcho session is outside the active session: ${requestedSessionKey}`
-          );
-        }
-        const transcriptCache = new Map<string, Promise<string>>();
-        const seenSessionIds = new Set<string>();
+
+        const crossSession = opts.crossSessionSearch ?? state.cfg.crossSessionSearch;
+        const rawResults: Array<any> = crossSession || !activeSessionKey
+          ? await participantPeer.search(query, { limit })
+          : await (
+              await state.honcho.session(activeSessionKey, { metadata: { agentId } })
+            ).search(query, { limit });
+
+        const seen = new Set<string>();
         const filtered: Array<any> = [];
-
-        const collect = (messages: Array<any>) => {
-          for (const msg of messages) {
-            if (filtered.length >= limit) break;
-            const sessionId = typeof msg?.sessionId === "string" ? msg.sessionId : "";
-            if (!sessionId || seenSessionIds.has(`${sessionId}:${String(msg?.id ?? msg?.createdAt ?? msg?.content ?? "")}`)) {
-              continue;
-            }
-            if (scopeEnabled && requestedSessionKey && !matchesSessionScope(sessionId, requestedSessionKey)) {
-              continue;
-            }
-            seenSessionIds.add(`${sessionId}:${String(msg?.id ?? msg?.createdAt ?? msg?.content ?? "")}`);
-            filtered.push(msg);
-          }
-        };
-
-        if (requestedSessionKey) {
-          const exactSession = await state.honcho.session(requestedSessionKey, {
-            metadata: { agentId },
-          });
-          collect(await exactSession.search(query, { limit }));
-        } else {
-          collect(await participantPeer.search(query, { limit }));
+        for (const msg of rawResults) {
+          if (filtered.length >= limit) break;
+          const sessionId = typeof msg?.sessionId === "string" ? msg.sessionId : "";
+          if (!sessionId) continue;
+          const dedupeKey = `${sessionId}:${String(msg?.id ?? msg?.createdAt ?? msg?.content ?? "")}`;
+          if (seen.has(dedupeKey)) continue;
+          seen.add(dedupeKey);
+          filtered.push(msg);
         }
 
+        const transcriptCache = new Map<string, Promise<string>>();
         return Promise.all(
           filtered.map(async (msg: any) => {
             const snippet = typeof msg.content === "string" ? msg.content : "";

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -152,40 +152,25 @@ function createState(baseUrl = "https://api.honcho.dev", { crossSessionSearch = 
 }
 
 describe("Honcho memory runtime", () => {
-  it("filters search results by session key and returns session transcript paths", async () => {
+  it("scopes search to the active session when crossSessionSearch is false", async () => {
     const state = createState("https://api.honcho.dev", { crossSessionSearch: false });
 
     const { manager } = await getHonchoMemorySearchManager(state, {
       agentId: "main",
       sessionKey: "session-1",
     });
-    const results = await manager.search("remember", {
-      sessionKey: "session-1",
-      maxResults: 10,
-    });
+    const results = await manager.search("remember", { maxResults: 10 });
 
-    // Scoped search now matches the exact active session id only — new-scheme
-    // ids have a per-session hash suffix, so prefix-based child discovery is
-    // never load-bearing.
     expect(results).toHaveLength(1);
     expect(results[0]?.path).toBe("sessions/session-1.txt");
     expect(results[0]?.snippet).toBe("Need to remember this");
     expect(results[0]?.startLine).toBeGreaterThan(0);
     expect(results[0]?.endLine).toBeGreaterThanOrEqual(results[0]?.startLine ?? 0);
+    // Session-scoped path uses honcho.session(...).search — participant peer is untouched.
     expect(state.participantPeer?.search as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
-
-    const implicitScopeResults = await manager.search("remember", {
-      maxResults: 10,
-    });
-    expect(implicitScopeResults).toHaveLength(1);
-    await expect(
-      manager.search("remember", {
-        sessionKey: "other-session",
-      }),
-    ).rejects.toThrow(/outside the active session/);
   });
 
-  it("allows cross-session search when crossSessionSearch is true", async () => {
+  it("spans the participant peer's sessions when crossSessionSearch is true", async () => {
     const state = createState();
 
     const { manager } = await getHonchoMemorySearchManager(state, {
@@ -193,16 +178,40 @@ describe("Honcho memory runtime", () => {
       sessionKey: "session-1",
     });
 
-    const results = await manager.search("remember", {
-      sessionKey: "other-session",
-    });
-    expect(results.length).toBeGreaterThan(0);
+    const results = await manager.search("anything");
+    expect(state.participantPeer?.search as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    // Mock participant peer returns hits across session-1, session-1-child, other-session.
+    const paths = new Set(results.map((r) => r.path));
+    expect(paths.has("sessions/session-1.txt")).toBe(true);
+    expect(paths.has("sessions/other-session.txt")).toBe(true);
 
     const file = await manager.readFile({
       relPath: "sessions/other-session.txt",
     });
     expect(file.path).toBe("sessions/other-session.txt");
     expect(file.text).toContain("Other summary");
+  });
+
+  it("honors a per-call crossSessionSearch override", async () => {
+    // Config default = false (scope to session); override = true (cross-session).
+    const state = createState("https://api.honcho.dev", { crossSessionSearch: false });
+
+    const { manager } = await getHonchoMemorySearchManager(state, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+
+    await manager.search("q", { crossSessionSearch: true });
+    expect(state.participantPeer?.search as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+
+    // Inverse: config true, per-call override false → session-scoped.
+    const scopedState = createState();
+    const { manager: scopedManager } = await getHonchoMemorySearchManager(scopedState, {
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+    await scopedManager.search("q", { crossSessionSearch: false });
+    expect(scopedState.participantPeer?.search as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 
   it("reads scoped transcript slices and resolves backend metadata", async () => {
@@ -240,16 +249,13 @@ describe("Honcho memory runtime", () => {
   });
 
   it("clamps fallback snippet ranges to the transcript length", async () => {
-    const state = createState();
+    const state = createState("https://api.honcho.dev", { crossSessionSearch: false });
     const { manager } = await getHonchoMemorySearchManager(state, {
       agentId: "main",
       sessionKey: "session-2",
     });
 
-    const [result] = await manager.search("beta", {
-      sessionKey: "session-2",
-      maxResults: 5,
-    });
+    const [result] = await manager.search("beta", { maxResults: 5 });
 
     expect(result?.path).toBe("sessions/session-2.txt");
     expect(result?.startLine).toBe(8);
@@ -265,11 +271,7 @@ describe("Honcho memory runtime", () => {
       sessionKey: "session-1",
     });
 
-    await expect(
-      manager.search("remember", {
-        sessionKey: "session-1",
-      }),
-    ).rejects.toThrow(/owner peer not initialized/);
+    await expect(manager.search("remember")).rejects.toThrow(/owner peer not initialized/);
     await expect(
       manager.readFile({
         relPath: "sessions/session-1.txt",

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -9,6 +9,9 @@ const MemorySearchSchema = Type.Object({
   query: Type.String(),
   maxResults: Type.Optional(Type.Number()),
   minScore: Type.Optional(Type.Number()),
+  crossSessionSearch: Type.Optional(Type.Boolean({
+    description: "Override the plugin's crossSessionSearch config for this call. true = search across all of the participant's sessions; false = scope to the active session.",
+  })),
 }, { additionalProperties: false });
 
 const MemoryGetSchema = Type.Object({
@@ -98,6 +101,7 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
         const query = readStringParam(p, "query", { required: true });
         const maxResults = readNumberParam(p, "maxResults");
         readNumberParam(p, "minScore");
+        const crossSessionSearch = typeof p.crossSessionSearch === "boolean" ? p.crossSessionSearch : undefined;
         const honchoSessionKey = buildSessionKey({
           sessionKey: ctx.sessionKey,
           agentId: ctx.agentId,
@@ -110,7 +114,7 @@ export function registerMemoryPassthrough(api: OpenClawPluginApi, state: PluginS
           });
           const results = await manager.search(query, {
             maxResults: maxResults ?? undefined,
-            sessionKey: honchoSessionKey,
+            crossSessionSearch,
           });
           const status = manager.status();
           return jsonResult({


### PR DESCRIPTION
## Summary

`memory_search` returned zero results whenever the caller had no active session key. Two layers combined to hide every hit:

1. `buildSessionKey()` in `helpers.ts` synthesizes a deterministic session id (`unknown-<agent>-<hex>` under the current signature, `default-<provider>` in the pre-bb546c2 signature) even when `ctx.sessionKey` is empty — no such session exists in Honcho.
2. `getHonchoMemorySearchManager()` in `runtime.ts` routed **every** truthy `requestedSessionKey` into a session-scoped `honcho.session(id).search()` branch, regardless of the `crossSessionSearch` flag. The flag only gated an out-of-scope validation throw and a post-filter predicate — it never switched the search strategy. The `participantPeer.search()` cross-session branch at the bottom of `search()` was dead code.

Every tool call at `tools/memory-passthrough.ts` passes `buildSessionKey(ctx)` as the session key, so the session-scoped branch always fired and returned `[]` from a synthetic id nobody wrote to.

## Fix

Rewrite `search()` around a single strategy toggle:

- `crossSessionSearch: true` (default) → `participantPeer.search(query)` spans every session the participant peer has written to. Also the fallback when no active session key is present.
- `crossSessionSearch: false` → `honcho.session(activeSessionKey).search(query)` stays scoped to one session.

Expose the toggle on `memory_search` itself via an optional `crossSessionSearch` boolean parameter, matching the config name verbatim so callers can override the plugin config per-call. The config value remains the default when the parameter is omitted.

Also drop the redundant `sessionKey` opt on `manager.search` — the manager already knows the active session from its factory params — and simplify the branching. Net **−16 lines** in `runtime.ts`.

## Testing

- Rewrote 3 tests in `test/runtime.test.ts` to reflect the new toggle semantics; added a per-call override test. 55/55 vitest tests pass.
- Verified end-to-end against real Honcho via `simulate/gateway-sim.ts`: same participant captured into two sessions; `crossSessionSearch: true` from session B finds hits in session A, `crossSessionSearch: false` does not.

## Test plan

- [ ] Reviewer confirms `participantPeer.search` is the correct primitive for spanning a peer's sessions under both legacy and per-sender install policies
- [ ] Reviewer sanity-checks that removing `opts.sessionKey` from `manager.search` doesn't break any in-tree caller (audit: only `tools/memory-passthrough.ts` calls it, no other callers pass that opt)

## Prior art

Related to #70, which had the same intent but was built on the pre-bb546c2 signature (using `ownerPeer` — which under per-sender policy holds no messages — instead of `participantPeer`). This PR supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `crossSessionSearch` behavior to `memory_search`, letting searches span all sessions by default or be limited to the active session.
  * Added a per-call `crossSessionSearch` override for `memory_search`.
* **Bug Fixes**
  * Fixed `crossSessionSearch` so it now correctly controls search scope (previously it could return no cross-session results).
* **Documentation**
  * Updated configuration docs to clarify default scope and per-call overrides.
* **Tests**
  * Expanded coverage for session-scoped vs cross-session search behavior and override precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->