### PR TITLE
chore: release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to `@honcho-ai/openclaw-honcho` will be documented in this f
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-07-17
+
 ### Fixed
-- **`crossSessionSearch` flag now actually toggles search strategy**: `memory_search` was always session-scoped regardless of the flag, so cross-session queries returned `[]`. Config default (`true`) now spans the participant peer's sessions; `false` scopes to the active session. Adds optional `crossSessionSearch` parameter on `memory_search` for per-call override.
+- **`crossSessionSearch` flag now actually toggles search strategy (#113)**: `memory_search` was always session-scoped regardless of the flag, so cross-session queries returned `[]`. Config default (`true`) now spans the participant peer's sessions; `false` scopes to the active session. Adds optional `crossSessionSearch` parameter on `memory_search` for per-call override.
 - **`flushMessages` reliability (#108)**: chunk `addMessages` under Honcho's 100/request limit and stop clobbering `lastSavedIndex`, preventing lost or duplicated messages on large or repeated flushes.
+- **No spurious API-key warning for self-hosted deployments (#109)**: only `api.honcho.dev` is treated as the managed cloud, so self-hosted instances on a custom domain no longer log a missing-API-key warning on startup and now correctly report `provider: "honcho-selfhosted"`.
 
 ## [1.5.1] - 2026-05-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/openclaw-honcho",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "description": "Honcho AI-native memory integration for OpenClaw",
   "main": "dist/index.js",


### PR DESCRIPTION
Preps the 1.5.2 release. Bumps `package.json` to 1.5.2 and stamps the CHANGELOG.

### Included since 1.5.1
- **#113** — `crossSessionSearch` flag now toggles search strategy (was always session-scoped, returned `[]` for cross-session)
- **#108** — chunk `addMessages` under Honcho's 100/request limit; stop clobbering `lastSavedIndex`
- **#109** — no spurious API-key warning for self-hosted deployments on custom domains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed incorrect API-key warnings for self-hosted deployments using custom domains.
  - Improved cross-session search behavior.
  - Increased reliability when flushing messages.

- **Release**
  - Updated the package to version 1.5.2, including the fixes above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->