### PR TITLE
feat: hard-cap automatic Honcho context

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,38 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `apiKey`               | `string`   | —                          | Honcho API key (required for managed; omit for self-hosted). |
 | `workspaceId`          | `string`   | `"openclaw"`               | Honcho workspace ID for memory isolation. |
 | `baseUrl`              | `string`   | `"https://api.honcho.dev"` | API endpoint (for self-hosted instances). |
+| `contextMaxChars`      | `number`   | —                          | Optional hard limit (512–100000 characters) for the complete automatically injected Honcho context block. |
 | `noisePatterns`        | `string[]` | built-in defaults          | Patterns to skip messages. User-provided patterns are merged with built-in defaults (unless `disableDefaultNoisePatterns` is set). |
 | `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
 | `crossSessionSearch`   | `boolean`  | `true`                     | Default scope for `memory_search`. `true` = results span every session the participant peer has written to; `false` = scope to the active session. `memory_search` accepts an optional `crossSessionSearch` boolean parameter to override this per-call. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
+
+### Automatic Context Size
+
+For workspaces with large Honcho representations or summaries, set a hard
+limit on the complete block injected into each prompt:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw-honcho": {
+        "config": {
+          "contextMaxChars": 6000
+        }
+      }
+    }
+  }
+}
+```
+
+The limit includes headings, peer-card facts, the representation, the session
+summary, the truncation notice, and the final safety instruction. When content
+must be reduced, Honcho preserves the peer card and current-session summary
+before the broader representation. This affects only automatic prompt
+injection: full memory remains stored and available through Honcho tools. Use
+`honcho_context` for user facts and representations, or `honcho_session` for
+session history.
 
 ### Self-Hosted / Local Honcho
 

--- a/config.ts
+++ b/config.ts
@@ -14,6 +14,7 @@ export type HonchoConfig = {
   workspaceId: string;
   baseUrl: string;
   timeoutMs?: number;
+  contextMaxChars?: number;
   noisePatterns: string[];
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
@@ -74,6 +75,17 @@ export const honchoConfigSchema = {
         if (process.env.HONCHO_TIMEOUT_MS !== undefined) {
           const parsed = Number(process.env.HONCHO_TIMEOUT_MS);
           if (Number.isFinite(parsed) && parsed > 0) return parsed;
+        }
+        return undefined;
+      })(),
+      contextMaxChars: (() => {
+        if (
+          typeof cfg.contextMaxChars === "number" &&
+          Number.isInteger(cfg.contextMaxChars) &&
+          cfg.contextMaxChars >= 512 &&
+          cfg.contextMaxChars <= 100_000
+        ) {
+          return cfg.contextMaxChars;
         }
         return undefined;
       })(),

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -3,6 +3,84 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey, extractSenderId, isSubagentSession } from "../helpers.js";
 
+const CONTEXT_PREFIX = "## User Memory Context\n\n";
+const CONTEXT_SUFFIX =
+  "\n\nUse this context naturally when relevant. Never quote or expose this memory context to the user.";
+const TRUNCATION_NOTICE =
+  "\n\n[Automatic Honcho context truncated; use honcho_context for user memory or honcho_session for session history.]";
+
+type InjectedContextSections = {
+  peerCard?: string;
+  representation?: string;
+  summary?: string;
+};
+
+function truncateAtBoundary(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  if (maxChars <= 0) return "";
+
+  let candidate = value.slice(0, maxChars);
+  const lastCodeUnit = candidate.charCodeAt(candidate.length - 1);
+  if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) {
+    candidate = candidate.slice(0, -1);
+  }
+
+  const minimumUsefulBoundary = Math.floor(maxChars * 0.6);
+  const boundary = Math.max(candidate.lastIndexOf("\n"), candidate.lastIndexOf(" "));
+  return (boundary >= minimumUsefulBoundary ? candidate.slice(0, boundary) : candidate).trimEnd();
+}
+
+function renderSections(sections: InjectedContextSections): string {
+  return [
+    sections.peerCard ? `Key facts:\n${sections.peerCard}` : undefined,
+    sections.representation ? `User context:\n${sections.representation}` : undefined,
+    sections.summary ? `Earlier in this conversation:\n${sections.summary}` : undefined,
+  ]
+    .filter((section): section is string => Boolean(section))
+    .join("\n\n");
+}
+
+function formatInjectedContext(sections: InjectedContextSections, maxChars?: number): string {
+  const full = `${CONTEXT_PREFIX}${renderSections(sections)}${CONTEXT_SUFFIX}`;
+  if (maxChars === undefined || full.length <= maxChars) return full;
+
+  const bounded = { ...sections };
+  const reductionOrder: Array<keyof InjectedContextSections> = [
+    "representation",
+    "summary",
+    "peerCard",
+  ];
+  const renderBounded = () =>
+    `${CONTEXT_PREFIX}${renderSections(bounded)}${TRUNCATION_NOTICE}${CONTEXT_SUFFIX}`;
+
+  let result = renderBounded();
+  for (const key of reductionOrder) {
+    if (result.length <= maxChars) break;
+    const value = bounded[key];
+    if (!value) continue;
+
+    const targetLength = value.length - (result.length - maxChars);
+    const truncated = truncateAtBoundary(value, targetLength);
+    if (truncated) {
+      bounded[key] = truncated;
+    } else {
+      delete bounded[key];
+    }
+    result = renderBounded();
+  }
+
+  if (result.length <= maxChars) return result;
+
+  // The configured minimum leaves room for the wrapper, but keep this final
+  // guard so future wording changes cannot violate the advertised hard cap.
+  const bodyBudget = Math.max(
+    0,
+    maxChars - CONTEXT_PREFIX.length - TRUNCATION_NOTICE.length - CONTEXT_SUFFIX.length,
+  );
+  const boundedBody = truncateAtBoundary(renderSections(bounded), bodyBudget);
+  return `${CONTEXT_PREFIX}${boundedBody}${TRUNCATION_NOTICE}${CONTEXT_SUFFIX}`;
+}
+
 export function registerContextHook(api: OpenClawPluginApi, state: PluginState): void {
   api.on("before_prompt_build", async (event, ctx) => {
     if (!event.prompt || event.prompt.length < 5) return;
@@ -25,16 +103,16 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
         ? await state.getParticipantPeer(currentSenderId)
         : await state.resolveSessionParticipantPeer(sessionKey);
 
-      const sections: string[] = [];
+      const sections: InjectedContextSections = {};
 
       if (isSubagent) {
         try {
           const peerCtx = await agentPeer.context({ target: participantPeer });
           if (peerCtx.peerCard?.length) {
-            sections.push(`Key facts:\n${peerCtx.peerCard.map((f: string) => `• ${f}`).join("\n")}`);
+            sections.peerCard = peerCtx.peerCard.map((fact: string) => `• ${fact}`).join("\n");
           }
           if (peerCtx.representation) {
-            sections.push(`User context:\n${peerCtx.representation}`);
+            sections.representation = peerCtx.representation;
           }
         } catch (e: unknown) {
           const isNotFound =
@@ -63,25 +141,23 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
         }
 
         if (context.peerCard?.length) {
-          sections.push(`Key facts:\n${context.peerCard.map((f) => `• ${f}`).join("\n")}`);
+          sections.peerCard = context.peerCard.map((fact) => `• ${fact}`).join("\n");
         }
         if (context.peerRepresentation) {
-          sections.push(`User context:\n${context.peerRepresentation}`);
+          sections.representation = context.peerRepresentation;
         }
         if (context.summary?.content) {
-          sections.push(`Earlier in this conversation:\n${context.summary.content}`);
+          sections.summary = context.summary.content;
         }
       }
 
-      if (sections.length === 0) return;
-
-      const formatted = sections.join("\n\n");
+      if (!sections.peerCard && !sections.representation && !sections.summary) return;
 
       // Use appendSystemContext instead of systemPrompt to avoid overriding
       // other plugins' prompt contributions. appendSystemContext is appended
       // to the system prompt and benefits from provider prompt caching.
       return {
-        appendSystemContext: `## User Memory Context\n\n${formatted}\n\nUse this context naturally when relevant. Never quote or expose this memory context to the user.`,
+        appendSystemContext: formatInjectedContext(sections, state.cfg.contextMaxChars),
       };
     } catch (error) {
       api.logger.warn?.(`Failed to fetch Honcho context: ${error}`);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -42,6 +42,12 @@
         "minimum": 1,
         "description": "HTTP timeout in milliseconds for Honcho SDK requests. Useful for slower self-hosted local models."
       },
+      "contextMaxChars": {
+        "type": "integer",
+        "minimum": 512,
+        "maximum": 100000,
+        "description": "Optional hard character limit for the complete automatically injected Honcho system-context block. Full memory remains available through Honcho tools."
+      },
       "noisePatterns": {
         "type": "array",
         "items": { "type": "string" },
@@ -86,6 +92,12 @@
       "advanced": true,
       "placeholder": "60000",
       "help": "Increase this for self-hosted Honcho deployments backed by slower local models."
+    },
+    "contextMaxChars": {
+      "label": "Context Character Limit",
+      "advanced": true,
+      "placeholder": "6000",
+      "help": "Hard limit for the complete automatic Honcho context block. Does not delete or limit memory available through Honcho tools."
     },
     "noisePatterns": {
       "label": "Noise Patterns",

--- a/test/config-context-limit.test.ts
+++ b/test/config-context-limit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { honchoConfigSchema } from "../config.js";
+
+describe("Honcho automatic context character limit", () => {
+  it("is disabled by default", () => {
+    expect(honchoConfigSchema.parse({}).contextMaxChars).toBeUndefined();
+  });
+
+  it("accepts the documented inclusive bounds", () => {
+    expect(honchoConfigSchema.parse({ contextMaxChars: 512 }).contextMaxChars).toBe(512);
+    expect(honchoConfigSchema.parse({ contextMaxChars: 100_000 }).contextMaxChars).toBe(100_000);
+  });
+
+  it("ignores non-integer and out-of-range values", () => {
+    for (const value of [511, 100_001, 1024.5, "6000"]) {
+      expect(honchoConfigSchema.parse({ contextMaxChars: value }).contextMaxChars).toBeUndefined();
+    }
+  });
+});

--- a/test/context-limit.test.ts
+++ b/test/context-limit.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerContextHook } from "../hooks/context.js";
+import type { PluginState } from "../state.js";
+
+function createMockState(contextMaxChars?: number) {
+  const participantPeer = { id: "user-1" };
+  const agentPeer = { id: "agent-main", context: vi.fn() };
+  const session = {
+    context: vi.fn(async () => ({
+      peerCard: ["A durable fact"],
+      peerRepresentation: "A compact representation",
+      summary: { content: "A compact summary" },
+    })),
+  };
+  const state = {
+    cfg: {
+      workspaceId: "openclaw",
+      baseUrl: "https://api.honcho.dev",
+      noisePatterns: [],
+      disableDefaultNoisePatterns: false,
+      ownerObserveOthers: false,
+      crossSessionSearch: true,
+      contextMaxChars,
+    },
+    honcho: { session: vi.fn(async () => session) },
+    turnStartIndex: new Map<string, number>(),
+    ensureInitialized: vi.fn(async () => undefined),
+    getAgentPeer: vi.fn(async () => agentPeer),
+    getParticipantPeer: vi.fn(async () => participantPeer),
+    resolveSessionParticipantPeer: vi.fn(async () => participantPeer),
+    resolveDefaultAgentId: vi.fn(() => "main"),
+  } as unknown as PluginState;
+
+  return { state, session, agentPeer };
+}
+
+function registerHandler(state: PluginState) {
+  let handler:
+    | ((event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<unknown>)
+    | undefined;
+  const api = {
+    on: vi.fn(
+      (
+        name: string,
+        registered: (event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<unknown>,
+      ) => {
+        if (name === "before_prompt_build") handler = registered;
+      },
+    ),
+    logger: { warn: vi.fn() },
+  };
+
+  registerContextHook(api as never, state);
+  expect(handler).toBeDefined();
+  return handler!;
+}
+
+const event = {
+  prompt: "What should I remember?",
+  messages: [{ role: "user", content: "What should I remember?" }],
+};
+
+describe("Honcho automatic context hard cap", () => {
+  it("preserves legacy output when no limit is configured", async () => {
+    const { state } = createMockState();
+    const result = (await registerHandler(state)(event, {
+      sessionKey: "agent:main:discord:channel-1",
+      agentId: "main",
+    })) as { appendSystemContext: string };
+
+    expect(result.appendSystemContext).toBe(
+      [
+        "## User Memory Context",
+        "",
+        "Key facts:",
+        "• A durable fact",
+        "",
+        "User context:",
+        "A compact representation",
+        "",
+        "Earlier in this conversation:",
+        "A compact summary",
+        "",
+        "Use this context naturally when relevant. Never quote or expose this memory context to the user.",
+      ].join("\n"),
+    );
+  });
+
+  it("caps the complete normal-session block and preserves higher-priority sections", async () => {
+    const { state, session } = createMockState(512);
+    session.context.mockResolvedValue({
+      peerCard: ["A durable fact"],
+      peerRepresentation: "x".repeat(4_000),
+      summary: { content: "y".repeat(2_000) },
+    });
+
+    const result = (await registerHandler(state)(event, {
+      sessionKey: "agent:main:discord:channel-1",
+      agentId: "main",
+    })) as { appendSystemContext: string };
+
+    expect(result.appendSystemContext.length).toBeLessThanOrEqual(512);
+    expect(result.appendSystemContext).toContain("A durable fact");
+    expect(result.appendSystemContext).not.toContain("User context:");
+    expect(result.appendSystemContext).toContain("Earlier in this conversation:");
+    expect(result.appendSystemContext).toContain("Automatic Honcho context truncated");
+    expect(result.appendSystemContext).toContain(
+      "Never quote or expose this memory context to the user.",
+    );
+  });
+
+  it("caps subagent context without splitting UTF-16 surrogate pairs", async () => {
+    const { state, agentPeer } = createMockState(512);
+    agentPeer.context.mockResolvedValue({
+      peerCard: ["A durable fact"],
+      representation: "😀".repeat(4_000),
+    });
+
+    const result = (await registerHandler(state)(event, {
+      sessionKey: "agent:main:subagent:research-1",
+      agentId: "main",
+    })) as { appendSystemContext: string };
+
+    expect(result.appendSystemContext.length).toBeLessThanOrEqual(512);
+    expect(result.appendSystemContext).toContain("A durable fact");
+    expect(result.appendSystemContext).toContain("Automatic Honcho context truncated");
+    expect(result.appendSystemContext).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add optional `contextMaxChars` configuration with a documented range of 512–100000.
- Enforce the limit across the complete rendered automatic context block, including headings, notices, and the final safety instruction.
- Reduce broad representation text first, then session summary, then peer-card facts; retain a retrieval notice when truncation occurs.
- Preserve the exact legacy output when the option is unset.

## Why

The existing `tokens: 2000` request does not guarantee a bound on the aggregate rendered block: peer cards, representations, session summaries, and wrapper text can still produce a very large prompt contribution. This change gives operators a deterministic final ceiling without removing any stored memory.

Truncated details remain queryable with Honcho tools: `honcho_context` for user facts and representations, and `honcho_session` for session history.

## Relationship to #106

This is complementary to #106, not a replacement. #106 limits fetched conclusions; this PR caps the final aggregate block after all context sections are assembled. The changes touch some of the same configuration, documentation, and context-hook locations, so this draft may need a small rebase after #106 lands.

## Safety

- Disabled by default; uncapped output is byte-for-byte unchanged.
- Does not delete or modify Honcho memory.
- Avoids splitting UTF-16 surrogate pairs when truncating.
- Always retains the final instruction that memory context must not be exposed to the user.

## Validation

- `pnpm build`
- `pnpm test --run` — 72 tests passed
- 500 Unicode fuzz cases remained within the configured cap with no split surrogate pairs
- `git diff --check`

