### PR TITLE
feat: add opt-in Honcho session exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `workspaceId`          | `string`   | `"openclaw"`               | Honcho workspace ID for memory isolation. |
 | `baseUrl`              | `string`   | `"https://api.honcho.dev"` | API endpoint (for self-hosted instances). |
 | `noisePatterns`        | `string[]` | built-in defaults          | Patterns to skip messages. User-provided patterns are merged with built-in defaults (unless `disableDefaultNoisePatterns` is set). |
+| `ignoreSessionPatterns` | `string[]` | `[]`                      | Glob-style OpenClaw session-key patterns to exclude from Honcho context injection and persistence. `*` stays within one colon-delimited segment; `**` may span segments. |
 | `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
 | `crossSessionSearch`   | `boolean`  | `true`                     | Default scope for `memory_search`. `true` = results span every session the participant peer has written to; `false` = scope to the active session. `memory_search` accepts an optional `crossSessionSearch` boolean parameter to override this per-call. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
@@ -106,6 +107,29 @@ Add custom patterns via `noisePatterns` in your config:
 ```
 
 Custom patterns are merged with the built-in defaults. Each pattern matches if the message **equals** it or **starts with** it. Patterns starting with `/` are treated as anchored regex (e.g., `/^HEARTBEAT/i`).
+
+### Session Filtering
+
+Use `ignoreSessionPatterns` when an entire internal session lane should neither
+receive Honcho context nor be persisted:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw-honcho": {
+        "config": {
+          "ignoreSessionPatterns": ["agent:*:explicit:model-run-*"]
+        }
+      }
+    }
+  }
+}
+```
+
+Patterns are matched case-sensitively against the normalized OpenClaw session
+key. `*` matches within one colon-delimited segment, `**` may span multiple
+segments, and every other character is literal.
 
 ### Owner Peer Observation
 

--- a/config.ts
+++ b/config.ts
@@ -15,6 +15,7 @@ export type HonchoConfig = {
   baseUrl: string;
   timeoutMs?: number;
   noisePatterns: string[];
+  ignoreSessionPatterns: string[];
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
   crossSessionSearch: boolean;
@@ -56,6 +57,16 @@ export const honchoConfigSchema = {
     const noisePatterns = [
       ...new Set([...(disableDefaultNoisePatterns ? [] : DEFAULT_NOISE_PATTERNS), ...userPatterns]),
     ];
+    const ignoreSessionPatterns = Array.isArray(cfg.ignoreSessionPatterns)
+      ? [
+          ...new Set(
+            (cfg.ignoreSessionPatterns as unknown[])
+              .filter((pattern): pattern is string => typeof pattern === "string")
+              .map((pattern) => pattern.trim())
+              .filter((pattern) => pattern.length > 0),
+          ),
+        ]
+      : [];
 
     return {
       apiKey,
@@ -78,6 +89,7 @@ export const honchoConfigSchema = {
         return undefined;
       })(),
       noisePatterns,
+      ignoreSessionPatterns,
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
       crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,

--- a/helpers.ts
+++ b/helpers.ts
@@ -121,6 +121,63 @@ export function isSubagentSession(ctx?: { sessionKey?: string }): boolean {
 }
 
 /**
+ * Match an OpenClaw session key against a glob-style pattern.
+ *
+ * `*` matches within one colon-delimited segment, while `**` may span
+ * segments. All other characters are treated literally.
+ */
+export function matchesSessionPattern(sessionKey: string, pattern: string): boolean {
+  const normalized = normalizeSessionKey(sessionKey);
+  const trimmed = pattern.trim();
+  if (!trimmed) return false;
+
+  type Token = { kind: "literal"; value: string } | { kind: "star" | "globstar" };
+  const tokens: Token[] = [];
+  for (let index = 0; index < trimmed.length; index++) {
+    const char = trimmed[index];
+    if (char === "*") {
+      if (trimmed[index + 1] === "*") {
+        tokens.push({ kind: "globstar" });
+        index++;
+      } else {
+        tokens.push({ kind: "star" });
+      }
+      continue;
+    }
+    tokens.push({ kind: "literal", value: char });
+  }
+
+  // Dynamic programming has predictable O(pattern length × key length) work
+  // and avoids the catastrophic backtracking possible with a generated RegExp.
+  let previous = new Uint8Array(normalized.length + 1);
+  previous[0] = 1;
+
+  for (const token of tokens) {
+    const current = new Uint8Array(normalized.length + 1);
+    if (token.kind === "literal") {
+      for (let keyIndex = 1; keyIndex <= normalized.length; keyIndex++) {
+        current[keyIndex] =
+          previous[keyIndex - 1] === 1 && normalized[keyIndex - 1] === token.value ? 1 : 0;
+      }
+    } else {
+      current[0] = previous[0];
+      for (let keyIndex = 1; keyIndex <= normalized.length; keyIndex++) {
+        const mayConsume = token.kind === "globstar" || normalized[keyIndex - 1] !== ":";
+        current[keyIndex] =
+          previous[keyIndex] === 1 || (mayConsume && current[keyIndex - 1] === 1) ? 1 : 0;
+      }
+    }
+    previous = current;
+  }
+
+  return previous[normalized.length] === 1;
+}
+
+export function shouldSkipSession(sessionKey: string, ignoreSessionPatterns: string[]): boolean {
+  return ignoreSessionPatterns.some((pattern) => matchesSessionPattern(sessionKey, pattern));
+}
+
+/**
  * Port of OpenClaw's strip-inbound-meta.ts core stripping behavior.
  * Keep in sync with openclaw/src/auto-reply/reply/strip-inbound-meta.ts.
  *

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -7,6 +7,7 @@ import {
   classifySession,
   isSubagentSession,
   normalizeSessionKey,
+  shouldSkipSession,
   extractMessages,
   extractSenderId,
   getRawContent,
@@ -27,10 +28,12 @@ export async function flushMessages(
   if (!messages?.length) return 0;
 
   const agentId = ctx.agentId ?? state.resolveDefaultAgentId();
+  const openclawSessionKey = normalizeSessionKey(ctx.sessionKey);
+  if (shouldSkipSession(openclawSessionKey, state.cfg.ignoreSessionPatterns)) return 0;
+
   const sessionKey = buildSessionKey({ sessionKey: ctx.sessionKey, agentId });
   const isSubagent = isSubagentSession(ctx);
   const parentAgentId = isSubagent ? subagentParentMap.get(ctx.sessionKey ?? "") : undefined;
-  const openclawSessionKey = normalizeSessionKey(ctx.sessionKey);
   const sessionClass = classifySession(openclawSessionKey);
 
   await state.ensureInitialized();

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -1,13 +1,22 @@
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
-import { buildSessionKey, extractSenderId, isSubagentSession } from "../helpers.js";
+import {
+  buildSessionKey,
+  extractSenderId,
+  isSubagentSession,
+  normalizeSessionKey,
+  shouldSkipSession,
+} from "../helpers.js";
 
 export function registerContextHook(api: OpenClawPluginApi, state: PluginState): void {
   api.on("before_prompt_build", async (event, ctx) => {
     if (!event.prompt || event.prompt.length < 5) return;
 
     const agentId = ctx.agentId ?? state.resolveDefaultAgentId();
+    const openclawSessionKey = normalizeSessionKey(ctx.sessionKey);
+    if (shouldSkipSession(openclawSessionKey, state.cfg.ignoreSessionPatterns)) return;
+
     const sessionKey = buildSessionKey({ sessionKey: ctx.sessionKey, agentId });
     const isSubagent = isSubagentSession(ctx);
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -47,6 +47,11 @@
         "items": { "type": "string" },
         "description": "Additional substring patterns to skip messages. Built-in defaults (HEARTBEAT_OK, cron reminders, etc.) always apply."
       },
+      "ignoreSessionPatterns": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Glob-style OpenClaw session-key patterns to exclude from Honcho context injection and persistence. '*' stays within one colon-delimited segment; '**' may span segments."
+      },
       "ownerObserveOthers": {
         "type": "boolean",
         "default": false,
@@ -91,6 +96,11 @@
       "label": "Noise Patterns",
       "advanced": true,
       "help": "Additional substring patterns to filter. Messages containing any pattern are dropped before saving to Honcho."
+    },
+    "ignoreSessionPatterns": {
+      "label": "Ignored Session Patterns",
+      "advanced": true,
+      "help": "Exclude matching OpenClaw session keys from Honcho context and persistence. Example: agent:*:explicit:model-run-*"
     },
     "ownerObserveOthers": {
       "label": "Owner Observes Agent",

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -35,6 +35,7 @@ function createMockState(): { state: PluginState; session: SessionStub } {
   const state = {
     cfg: {
       noisePatterns: [],
+      ignoreSessionPatterns: [],
       ownerObserveOthers: false,
       crossSessionSearch: true,
       workspaceId: "openclaw",
@@ -69,6 +70,29 @@ function loggerStub() {
 }
 
 describe("flushMessages metadata", () => {
+  it("does not initialize or create a Honcho session for ignored OpenClaw sessions", async () => {
+    const { state } = createMockState();
+    state.cfg.ignoreSessionPatterns = ["agent:*:explicit:model-run-*"];
+    const api = { logger: loggerStub() } as never;
+
+    const saved = await flushMessages(
+      api,
+      state,
+      [
+        { role: "user", content: "internal prompt", timestamp: 1 },
+        { role: "assistant", content: "internal reply", timestamp: 2 },
+      ],
+      {
+        sessionKey: "agent:main:explicit:model-run-123",
+        agentId: "main",
+      },
+    );
+
+    expect(saved).toBe(0);
+    expect(state.ensureInitialized).not.toHaveBeenCalled();
+    expect(state.honcho.session).not.toHaveBeenCalled();
+  });
+
   it("writes openclawSessionKey, sessionClass, messageProvider, and lastSessionId", async () => {
     const { state, session } = createMockState();
     const api = { logger: loggerStub() } as never;

--- a/test/config-ignore-sessions.test.ts
+++ b/test/config-ignore-sessions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { honchoConfigSchema } from "../config.js";
+
+describe("Honcho ignored session configuration", () => {
+  it("defaults to no ignored sessions", () => {
+    const cfg = honchoConfigSchema.parse({ baseUrl: "http://127.0.0.1:8000" });
+
+    expect(cfg.ignoreSessionPatterns).toEqual([]);
+  });
+
+  it("trims, filters, and deduplicates configured patterns", () => {
+    const cfg = honchoConfigSchema.parse({
+      baseUrl: "http://127.0.0.1:8000",
+      ignoreSessionPatterns: [
+        " agent:*:cron:** ",
+        "agent:*:cron:**",
+        "",
+        42,
+        null,
+      ],
+    });
+
+    expect(cfg.ignoreSessionPatterns).toEqual(["agent:*:cron:**"]);
+  });
+});

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerContextHook } from "../hooks/context.js";
+import type { PluginState } from "../state.js";
+
+describe("Honcho context session filtering", () => {
+  it("does not initialize or inject context for ignored OpenClaw sessions", async () => {
+    let beforePromptBuild:
+      | ((
+          event: { prompt: string; messages: unknown[] },
+          ctx: { sessionKey?: string; agentId?: string },
+        ) => Promise<unknown>)
+      | undefined;
+
+    const api = {
+      on: vi.fn((name: string, handler: typeof beforePromptBuild) => {
+        if (name === "before_prompt_build") beforePromptBuild = handler;
+      }),
+      logger: { warn: vi.fn() },
+    };
+    const state = {
+      cfg: {
+        ignoreSessionPatterns: ["agent:*:explicit:model-run-*"],
+      },
+      turnStartIndex: new Map<string, number>(),
+      resolveDefaultAgentId: vi.fn(() => "main"),
+      ensureInitialized: vi.fn(async () => undefined),
+    } as unknown as PluginState;
+
+    registerContextHook(api as never, state);
+    expect(beforePromptBuild).toBeDefined();
+
+    const result = await beforePromptBuild!(
+      { prompt: "internal model evaluation prompt", messages: [] },
+      { sessionKey: "agent:main:explicit:model-run-123", agentId: "main" },
+    );
+
+    expect(result).toBeUndefined();
+    expect(state.ensureInitialized).not.toHaveBeenCalled();
+    expect(state.turnStartIndex.size).toBe(0);
+  });
+});

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -4,13 +4,58 @@ import {
   classifySession,
   extractSenderId,
   extractProvider,
+  matchesSessionPattern,
   normalizeSessionKey,
+  shouldSkipSession,
 } from "../helpers.js";
 
 const CHAT_ID_RE = /^chat-[a-z0-9]+-[a-z0-9_-]+-[0-9a-f]{24}$/;
 const CRON_OR_SUBAGENT_ID_RE = /^(cron|subagent)-[a-z0-9_-]+-[0-9a-f]{24}$/;
 const THREAD_ID_RE = /^thread-[a-z0-9]+-[a-z0-9_-]+-[0-9a-f]{24}$/;
 const UNKNOWN_ID_RE = /^unknown-[a-z0-9_-]+-[0-9a-f]{24}$/;
+
+describe("session pattern matching", () => {
+  it("matches a single-segment wildcard without crossing colons", () => {
+    expect(
+      matchesSessionPattern(
+        "agent:main:explicit:model-run-123",
+        "agent:*:explicit:model-run-*",
+      ),
+    ).toBe(true);
+    expect(
+      matchesSessionPattern(
+        "agent:main:explicit:nested:model-run-123",
+        "agent:*:explicit:model-run-*",
+      ),
+    ).toBe(false);
+  });
+
+  it("allows a double wildcard to span colon-delimited segments", () => {
+    expect(
+      matchesSessionPattern(
+        "agent:main:internal:nested:model-run-123",
+        "agent:*:**:model-run-*",
+      ),
+    ).toBe(true);
+  });
+
+  it("treats regex metacharacters as literals and ignores blank patterns", () => {
+    expect(matchesSessionPattern("agent:main:explicit:model.run-1", "agent:*:explicit:model.run-*"))
+      .toBe(true);
+    expect(matchesSessionPattern("agent:main:explicit:modelXrun-1", "agent:*:explicit:model.run-*"))
+      .toBe(false);
+    expect(matchesSessionPattern("agent:main:explicit:model?run-1", "agent:*:explicit:model?run-*"))
+      .toBe(true);
+    expect(shouldSkipSession("agent:main:discord:dm:1", ["", "agent:*:cron:**"])).toBe(false);
+  });
+
+  it("handles overlapping double wildcards without backtracking", () => {
+    const pattern = `${"**:".repeat(12)}z`;
+    const sessionKey = Array.from({ length: 36 }, () => "segment").join(":");
+
+    expect(matchesSessionPattern(sessionKey, pattern)).toBe(false);
+  });
+});
 
 describe("buildSessionKey", () => {
   it("stays well under Honcho's 100-char cap even for absurdly long cron keys", () => {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -125,6 +125,7 @@ function createState(baseUrl = "https://api.honcho.dev", { crossSessionSearch = 
       workspaceId: "openclaw",
       baseUrl,
       noisePatterns: [],
+      ignoreSessionPatterns: [],
       disableDefaultNoisePatterns: false,
       ownerObserveOthers: false,
       crossSessionSearch,


### PR DESCRIPTION
## Summary

- Add an opt-in `ignoreSessionPatterns` configuration array (default: `[]`).
- Match normalized OpenClaw session keys with case-sensitive globs: `*` stays within one colon-delimited segment, `**` may cross segments, and all other characters are literal.
- Skip both automatic context injection and message persistence before Honcho initialization or network access.
- Document the behavior and add configuration, matcher, context, and capture regressions.

## Why

Internal lanes such as model evaluation, grading, or maintenance sessions can create irrelevant memory and then inject it into ordinary conversations. Operators need a precise way to exclude an entire OpenClaw session lane without disabling Honcho for normal sessions.

The matcher uses dynamic programming rather than a generated regular expression, so overlapping `**` patterns cannot trigger catastrophic regex backtracking.

## Safety and scope

- Empty by default, so existing behavior is unchanged.
- Matching happens against the original normalized OpenClaw key before it is hashed into a Honcho session ID.
- Exclusions prevent future injection and persistence; they do not delete existing Honcho data.
- This is a focused session-lane control related to #78 and #82. It does not add retention, cleanup, or automatic classification policies.

## Validation

- `pnpm build`
- `pnpm test --run` — 74 tests passed
- Exhaustive matcher comparison across 496,860 short pattern/key combinations — zero semantic mismatches
- Adversarial multi-`**` non-match regression
- `git diff --check`

