### PR TITLE
fix: make legacy memory tool aliases opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
 | `crossSessionSearch`   | `boolean`  | `true`                     | Default scope for `memory_search`. `true` = results span every session the participant peer has written to; `false` = scope to the active session. `memory_search` accepts an optional `crossSessionSearch` boolean parameter to override this per-call. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
+| `enableMemoryCompatibilityTools` | `boolean` | `false`            | Register legacy `memory_search` and `memory_get` aliases for older OpenClaw hosts. Leave disabled on modern OpenClaw, which owns these canonical tool names. |
 
 ### Self-Hosted / Local Honcho
 
@@ -202,7 +203,14 @@ openclaw honcho search <query> [-k N] [-d D]    # Semantic search over memory (t
 
 ## Local File Search (QMD Integration)
 
-This plugin automatically exposes OpenClaw's `memory_search` and `memory_get` tools when a memory backend is configured. This allows you to use both Honcho's cloud-based memory AND local file search together.
+Modern OpenClaw exposes its canonical `memory_search` and `memory_get` tools
+when a memory backend is configured. Honcho therefore leaves its legacy aliases
+disabled by default, avoiding duplicate tool-name warnings while still allowing
+Honcho's named tools and local file search to be used together.
+
+Only older OpenClaw hosts that do not provide canonical memory tools should set
+`enableMemoryCompatibilityTools: true`. Do not enable it on a host that already
+offers `memory_search` and `memory_get`.
 
 ### Setup
 

--- a/config.ts
+++ b/config.ts
@@ -18,6 +18,7 @@ export type HonchoConfig = {
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
   crossSessionSearch: boolean;
+  enableMemoryCompatibilityTools: boolean;
 };
 
 /**
@@ -81,6 +82,7 @@ export const honchoConfigSchema = {
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
       crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,
+      enableMemoryCompatibilityTools: cfg.enableMemoryCompatibilityTools === true,
     };
   },
 };

--- a/index.ts
+++ b/index.ts
@@ -10,10 +10,11 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 // @ts-ignore - resolved by openclaw runtime
 import type {
   MemoryPluginCapability,
+  OpenClawPluginApi,
   OpenClawPluginDefinition,
 } from "openclaw/plugin-sdk/core";
 import { honchoConfigSchema } from "./config.js";
-import { createPluginState } from "./state.js";
+import { createPluginState, type PluginState } from "./state.js";
 import { registerGatewayHook } from "./hooks/gateway.js";
 import { registerContextHook } from "./hooks/context.js";
 import { registerCaptureHook } from "./hooks/capture.js";
@@ -85,6 +86,26 @@ export const buildPromptSection: NonNullable<MemoryPluginCapability["promptBuild
 
 let _loggedLoaded = false;
 
+/**
+ * Register Honcho's named tools and, only when explicitly requested, the
+ * legacy memory_search/memory_get compatibility aliases.
+ *
+ * Modern OpenClaw provides the canonical memory tools itself. Registering the
+ * aliases there creates name-conflict warnings and the host rejects them, so
+ * they are opt-in for older hosts that still need the compatibility surface.
+ */
+export function registerHonchoTools(api: OpenClawPluginApi, state: PluginState): void {
+  registerSessionTool(api, state);
+  registerContextTool(api, state);
+  registerSearchTool(api, state);
+  registerAskTool(api, state);
+  registerMessageSearchTool(api, state);
+
+  if (state.cfg.enableMemoryCompatibilityTools) {
+    registerMemoryPassthrough(api, state);
+  }
+}
+
 const honchoPlugin: OpenClawPluginDefinition = definePluginEntry({
   id: "openclaw-honcho",
   name: "Memory (Honcho)",
@@ -106,13 +127,8 @@ const honchoPlugin: OpenClawPluginDefinition = definePluginEntry({
     registerContextHook(api, state);
     registerCaptureHook(api, state);
 
-    // Tools (5 core + 2 passthrough)
-    registerSessionTool(api, state);
-    registerContextTool(api, state);
-    registerSearchTool(api, state);
-    registerAskTool(api, state);
-    registerMessageSearchTool(api, state);
-    registerMemoryPassthrough(api, state);
+    // Five Honcho tools; legacy memory aliases are explicit opt-in.
+    registerHonchoTools(api, state);
 
     // CLI
     registerCli(api, state);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -61,6 +61,11 @@
         "type": "boolean",
         "default": true,
         "description": "Default scope for memory_search. When true (default), results span every session the participant peer has written to. When false, results are scoped to the active session. Per-call override available via the memory_search `crossSession` parameter."
+      },
+      "enableMemoryCompatibilityTools": {
+        "type": "boolean",
+        "default": false,
+        "description": "Register legacy memory_search and memory_get aliases for older OpenClaw hosts. Keep disabled on modern OpenClaw, which provides canonical tools with these names."
       }
     }
   },
@@ -106,6 +111,11 @@
       "label": "Cross-Session Search",
       "advanced": true,
       "help": "When enabled (default), memory tools can return results from any session in the workspace. Disable to scope results to the active session only."
+    },
+    "enableMemoryCompatibilityTools": {
+      "label": "Legacy Memory Tool Aliases",
+      "advanced": true,
+      "help": "Register Honcho's legacy memory_search and memory_get aliases. Leave disabled on modern OpenClaw to avoid duplicate tool-name warnings."
     }
   }
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { honchoConfigSchema } from "../config.js";
+
+describe("Honcho configuration", () => {
+  it("keeps legacy memory tool aliases disabled by default", () => {
+    const cfg = honchoConfigSchema.parse({ baseUrl: "http://127.0.0.1:8000" });
+
+    expect(cfg.enableMemoryCompatibilityTools).toBe(false);
+  });
+
+  it("allows legacy memory tool aliases to be explicitly enabled", () => {
+    const cfg = honchoConfigSchema.parse({
+      baseUrl: "http://127.0.0.1:8000",
+      enableMemoryCompatibilityTools: true,
+    });
+
+    expect(cfg.enableMemoryCompatibilityTools).toBe(true);
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerHonchoTools } from "../index.js";
+import type { PluginState } from "../state.js";
+
+function registeredNames(enableMemoryCompatibilityTools: boolean): string[] {
+  const registrations: string[] = [];
+  const api = {
+    registerTool: vi.fn((_factory: unknown, options?: { name?: string }) => {
+      if (options?.name) registrations.push(options.name);
+    }),
+  };
+  const state = {
+    cfg: { enableMemoryCompatibilityTools },
+  } as unknown as PluginState;
+
+  registerHonchoTools(api as never, state);
+  return registrations;
+}
+
+describe("Honcho tool registration", () => {
+  it("registers only the five named Honcho tools by default", () => {
+    expect(registeredNames(false)).toEqual([
+      "honcho_session",
+      "honcho_context",
+      "honcho_search_conclusions",
+      "honcho_ask",
+      "honcho_search_messages",
+    ]);
+  });
+
+  it("registers legacy memory aliases only when explicitly enabled", () => {
+    expect(registeredNames(true)).toEqual([
+      "honcho_session",
+      "honcho_context",
+      "honcho_search_conclusions",
+      "honcho_ask",
+      "honcho_search_messages",
+      "memory_search",
+      "memory_get",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Always register Honcho's five namespaced tools.
- Make the legacy `memory_search` and `memory_get` compatibility aliases opt-in through `enableMemoryCompatibilityTools` (default: `false`).
- Document the modern-host behavior and cover both configuration paths with tests.

## Why

Current OpenClaw hosts provide the canonical memory tools themselves. Registering Honcho aliases with the same names produces tool-name conflicts and causes the host to reject the duplicate registrations. Older hosts can still explicitly enable the compatibility surface.

The aliases remain declared in `contracts.tools` because OpenClaw requires every tool that the plugin may register to be present in the static contract.

## Scope and related work

This is intentionally narrower than #99. It does not add a QMD bridge or change memory storage/search behavior; it only gates the existing compatibility aliases so modern OpenClaw can load Honcho without conflicts.

## Validation

Refreshed after rebasing onto `origin/main` (`65dbf0b`):

- `CI=1 corepack pnpm@9.15.9 install --ignore-scripts --frozen-lockfile` — passed
- `corepack pnpm@9.15.9 build` — passed
- `corepack pnpm@9.15.9 exec vitest run test/config.test.ts test/index.test.ts` — 4 tests passed
- `corepack pnpm@9.15.9 exec vitest run` — 70 tests passed
- `git diff --check origin/main...HEAD` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `enableMemoryCompatibilityTools` setting for older OpenClaw hosts.
  - Canonical Honcho memory tools remain available by default.
  - Enable the setting to add the legacy `memory_search` and `memory_get` aliases.

- **Bug Fixes**
  - Prevented duplicate tool-name warnings on modern OpenClaw hosts by disabling legacy compatibility aliases by default.

- **Documentation**
  - Updated configuration guidance to explain when compatibility tools should be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->