### PR TITLE
feat: add OpenClaw-owned auth broker for self-hosted Honcho

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,97 @@ Run `openclaw honcho setup` to configure interactively, or set values directly i
 | `disableDefaultNoisePatterns` | `boolean` | `false`           | When `true`, built-in noise patterns are not applied — only `noisePatterns` entries are used. |
 | `crossSessionSearch`   | `boolean`  | `true`                     | Default scope for `memory_search`. `true` = results span every session the participant peer has written to; `false` = scope to the active session. `memory_search` accepts an optional `crossSessionSearch` boolean parameter to override this per-call. |
 | `ownerObserveOthers`   | `boolean`  | `false`                    | Whether the owner peer observes agent messages in Honcho's social model. |
+| `authBroker`           | `object`   | disabled                   | Optional OpenClaw-owned auth broker for self-hosted Honcho. See below. |
 
 ### Self-Hosted / Local Honcho
 
 Run `openclaw honcho setup`, enter a blank API key, and set the Base URL to your instance (e.g., `http://localhost:8000`).
 
 For setting up a local Honcho server, see the [Honcho local development guide](https://github.com/plastic-labs/honcho?tab=readme-ov-file#local-development).
+
+### OpenClaw-owned auth broker (self-hosted)
+
+Self-hosted Honcho can use OpenClaw-owned OpenAI credentials without mounting
+`~/.openclaw`, `~/.codex`, or any auth database into a Honcho container. When
+explicitly enabled, this plugin registers two bearer-protected Gateway routes:
+
+- `POST /plugins/openclaw-honcho/auth-broker/v1/embeddings`
+- `POST /plugins/openclaw-honcho/auth-broker/v1/responses`
+
+The embeddings route resolves the same OpenClaw-owned ChatGPT/Codex OAuth
+profile, fixes the upstream to `https://api.openai.com/v1/embeddings`, and
+accepts only `text-embedding-3-small`. **Compatibility warning:** this route is
+opt-in because current OpenClaw documentation says Codex OAuth does not grant
+embeddings access. It has been observed to work for the deployment that
+motivated this feature, but it is not a guaranteed upstream API contract and
+may stop working. Operators who require a supported contract should use an
+OpenAI Platform API key outside this OAuth-only broker.
+
+The Responses route uses OpenClaw's canonical ChatGPT/Codex OAuth manager,
+forwards only to the Codex Responses endpoint, enforces an exact model allowlist,
+and forces `store: false`. The Honcho side receives only the separate broker
+bearer token; it never receives either upstream credential.
+
+Configure a random token of at least 32 characters. A SecretRef is preferred so
+the literal does not live in `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw-honcho": {
+        "config": {
+          "authBroker": {
+            "enabled": true,
+            "authAgentId": "main",
+            "responseModels": ["gpt-5.4-mini", "gpt-5.4"],
+            "bearerToken": {
+              "source": "env",
+              "provider": "default",
+              "id": "HONCHO_AUTH_BROKER_TOKEN"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Stock Honcho calls OpenAI Chat Completions and therefore cannot call the
+Responses route directly. A separate Python OpenAI-compatibility adapter is a
+required deployment prerequisite; this plugin does not ship that adapter. The
+adapter must translate Honcho's Chat Completions calls into Responses payloads.
+Configure that adapter—not stock Honcho itself—to call these two broker routes:
+
+```text
+http://<gateway-host>:<gateway-port>/plugins/openclaw-honcho/auth-broker/v1
+```
+
+The adapter must be able to reach the Gateway listener. OpenClaw defaults to
+`gateway.bind: "loopback"`, which is not reachable from a separate Docker
+bridge container. Keep the route private: either use host networking or a
+private proxy/tunnel, or bind the Gateway with `gateway.bind: "custom"` to the
+specific Docker bridge gateway address. Do not switch to a wildcard or LAN bind
+solely for this broker. A specific custom bind also retains OpenClaw's same-host
+loopback listener.
+
+The adapter sends the broker token as its Bearer credential. It must not read or
+mount Codex/OpenClaw credential files. The Responses call must send a valid,
+allowlisted Responses payload; streaming callers should set `stream: true`.
+Pointing stock Honcho at the broker base URL without the adapter will return
+404 for `/chat/completions` by design.
+
+The broker accepts at most 2,048 embedding inputs per call (matching Honcho's
+stock batch default), 32,000 characters per input, and 1,200,000 characters in
+aggregate, with ten concurrent requests per client. If the adapter is tuned
+above those bounds, lower its batch/concurrency settings to match the broker.
+Keep the Gateway route private to the Honcho network even though it requires a
+strong bearer token, and use HTTPS whenever the token crosses a host boundary.
+This feature requires OpenClaw 2026.7.1 or newer. Set `authAgentId` to bind both
+credential lookups to one agent; otherwise the ambient owner agent is used. If
+multiple OpenAI profiles exist, configure that agent's normal OpenAI auth order;
+the broker deliberately does not implement a second credential selector.
 
 ### Noise Filtering
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ forwards only to the Codex Responses endpoint, enforces an exact model allowlist
 and forces `store: false`. The Honcho side receives only the separate broker
 bearer token; it never receives either upstream credential.
 
-Configure a random token of at least 32 characters. A SecretRef is preferred so
-the literal does not live in `openclaw.json`:
+Configure a random token of at least 32 characters through an explicit env,
+file, or exec SecretRef. Literal tokens and ambient environment fallback are
+rejected. Pin both the owning agent and the exact stored OpenAI OAuth profile:
 
 ```json
 {
@@ -116,6 +117,7 @@ the literal does not live in `openclaw.json`:
           "authBroker": {
             "enabled": true,
             "authAgentId": "main",
+            "authProfileId": "openai:owner@example.com",
             "responseModels": ["gpt-5.4-mini", "gpt-5.4"],
             "bearerToken": {
               "source": "env",
@@ -129,6 +131,13 @@ the literal does not live in `openclaw.json`:
   }
 }
 ```
+
+OpenClaw resolves that SecretRef before validating the plugin's runtime config,
+so the runtime schema also accepts the resulting string. This does not make
+literal configuration valid: for every broker request, the route checks
+OpenClaw's canonical authored-source snapshot and refuses authentication unless
+the raw value is an explicit env, file, or exec SecretRef. It never authenticates
+from the resolved runtime string, a raw literal, or an ambient token fallback.
 
 Stock Honcho calls OpenAI Chat Completions and therefore cannot call the
 Responses route directly. A separate Python OpenAI-compatibility adapter is a
@@ -160,10 +169,13 @@ reads use the shorter of the configured timeout and 30 seconds. Unknown
 top-level fields are rejected on both routes. Route-specific constraints are:
 
 - Embeddings: only `model`, `input`, `encoding_format`, and `dimensions` are
-  accepted. `encoding_format`, when present, must be `float`; `dimensions`,
-  when present, must be `1536`. A call may contain at most 2,048 non-empty
-  string inputs (matching Honcho's stock batch default), 32,000 characters per
-  input, and 1,200,000 input characters in aggregate.
+  accepted. `encoding_format` may be omitted, `float`, or `base64`; the broker
+  always requests `float` upstream and returns OpenAI-compatible number arrays.
+  This accommodates the OpenAI Python SDK's default `base64` wire request while
+  keeping binary decoding out of the broker. `dimensions`, when present, must
+  be `1536`. A call may contain at most 2,048 non-empty string inputs (matching
+  Honcho's stock batch default), 32,000 characters per input, and 1,200,000
+  input characters in aggregate.
 - Responses: array input is limited to 256 items and serialized input to
   512,000 characters. Instructions are limited to 64,000 characters;
   `temperature` to 0 through 2; integer `max_output_tokens` to 1 through
@@ -175,10 +187,11 @@ or timeout settings to match the broker. Oversized request bodies return 413,
 request-body read timeouts return 408, and upstream timeouts return 504.
 Keep the Gateway route private to the Honcho network even though it requires a
 strong bearer token, and use HTTPS whenever the token crosses a host boundary.
-This feature requires OpenClaw 2026.7.1 or newer. Set `authAgentId` to bind both
-credential lookups to one agent; otherwise the ambient owner agent is used. If
-multiple OpenAI profiles exist, configure that agent's normal OpenAI auth order;
-the broker deliberately does not implement a second credential selector.
+This feature requires OpenClaw 2026.7.1 or newer. `authAgentId` and
+`authProfileId` are both required. The broker reads only that agent-scoped,
+stored OAuth profile: it disables external CLI credential discovery, rejects
+API-key/token profile types, and never falls through to another profile. A 401
+may trigger one canonical refresh of the same pinned profile; a 403 never does.
 
 ### Noise Filtering
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,25 @@ allowlisted Responses payload; streaming callers should set `stream: true`.
 Pointing stock Honcho at the broker base URL without the adapter will return
 404 for `/chat/completions` by design.
 
-The broker accepts at most 2,048 embedding inputs per call (matching Honcho's
-stock batch default), 32,000 characters per input, and 1,200,000 characters in
-aggregate, with ten concurrent requests per client. If the adapter is tuned
-above those bounds, lower its batch/concurrency settings to match the broker.
+The broker accepts at most ten concurrent requests per client. Its default
+request-body cap is 2 MiB and its default upstream timeout is 600,000 ms. Body
+reads use the shorter of the configured timeout and 30 seconds. Unknown
+top-level fields are rejected on both routes. Route-specific constraints are:
+
+- Embeddings: only `model`, `input`, `encoding_format`, and `dimensions` are
+  accepted. `encoding_format`, when present, must be `float`; `dimensions`,
+  when present, must be `1536`. A call may contain at most 2,048 non-empty
+  string inputs (matching Honcho's stock batch default), 32,000 characters per
+  input, and 1,200,000 input characters in aggregate.
+- Responses: array input is limited to 256 items and serialized input to
+  512,000 characters. Instructions are limited to 64,000 characters;
+  `temperature` to 0 through 2; integer `max_output_tokens` to 1 through
+  65,536; and `tools` to 64 entries. `include` may contain only
+  `reasoning.encrypted_content`. The broker always sends `store: false`.
+
+If the adapter is tuned above those bounds, lower its body, batch, concurrency,
+or timeout settings to match the broker. Oversized request bodies return 413,
+request-body read timeouts return 408, and upstream timeouts return 504.
 Keep the Gateway route private to the Honcho network even though it requires a
 strong bearer token, and use HTTPS whenever the token crosses a host boundary.
 This feature requires OpenClaw 2026.7.1 or newer. Set `authAgentId` to bind both

--- a/README.md
+++ b/README.md
@@ -189,9 +189,10 @@ Keep the Gateway route private to the Honcho network even though it requires a
 strong bearer token, and use HTTPS whenever the token crosses a host boundary.
 This feature requires OpenClaw 2026.7.1 or newer. `authAgentId` and
 `authProfileId` are both required. The broker reads only that agent-scoped,
-stored OAuth profile: it disables external CLI credential discovery, rejects
-API-key/token profile types, and never falls through to another profile. A 401
-may trigger one canonical refresh of the same pinned profile; a 403 never does.
+stored OAuth profile: it loads an auth store with external CLI profiles removed,
+passes that exact store into credential resolution, rejects API-key/token
+profile types, and never falls through to another profile. A 401 may trigger one
+canonical refresh of the same pinned profile; a 403 never does.
 
 ### Noise Filtering
 

--- a/broker.ts
+++ b/broker.ts
@@ -49,7 +49,6 @@ export const HONCHO_AUTH_BROKER_BASE_PATH = "/plugins/openclaw-honcho/auth-broke
 
 const EMBEDDINGS_UPSTREAM_URL = "https://api.openai.com/v1/embeddings";
 const CODEX_RESPONSES_UPSTREAM_URL = "https://chatgpt.com/backend-api/codex/responses";
-const BROKER_TOKEN_CONFIG_PATH = "plugins.entries.openclaw-honcho.config.authBroker.bearerToken";
 
 export const HONCHO_EMBEDDING_MODEL = "text-embedding-3-small";
 // Match stock Honcho's default 2,048-item embedding batch while retaining an
@@ -80,7 +79,7 @@ export type HonchoAuthBrokerDependencies = {
   resolveCredential: (
     options?: ResolveCodexCredentialOptions,
   ) => Promise<OpenAICodexBrokerCredential>;
-  resolveBearerToken: () => Promise<string | undefined>;
+  resolveBearerToken: (presentedToken?: string) => Promise<string | undefined>;
   logger?: Pick<OpenClawPluginApi["logger"], "warn">;
 };
 
@@ -97,6 +96,11 @@ export type BrokerBearerTokenDependencies = {
   resolveConfiguredSecretInputString: typeof resolveConfiguredSecretInputString;
 };
 
+export type BrokerBearerTokenResolverOptions = {
+  cacheTtlMs?: number;
+  now?: () => number;
+};
+
 const canonicalCodexCredentialDependencies: CanonicalCodexCredentialDependencies = {
   resolveAgentDir,
   loadAuthProfileStoreWithoutExternalProfiles,
@@ -109,6 +113,8 @@ const brokerBearerTokenDependencies: BrokerBearerTokenDependencies = {
   getRuntimeConfigSourceSnapshot,
   resolveConfiguredSecretInputString,
 };
+
+const BROKER_BEARER_TOKEN_CACHE_TTL_MS = 5_000;
 
 class BrokerCredentialUnavailableError extends Error {
   constructor() {
@@ -429,28 +435,28 @@ export async function resolveCanonicalOpenAICodexCredential(
   options: ResolveCodexCredentialOptions = {},
   dependencies: CanonicalCodexCredentialDependencies = canonicalCodexCredentialDependencies,
 ): Promise<OpenAICodexBrokerCredential> {
-  if (!config.authAgentId || !config.authProfileId) {
-    throw new BrokerCredentialUnavailableError();
-  }
-  if (options.profileId && options.profileId !== config.authProfileId) {
-    throw new BrokerCredentialUnavailableError();
-  }
-
-  const cfg = currentConfig(api);
-  const agentDir = dependencies.resolveAgentDir(cfg, config.authAgentId);
-  const store = dependencies.loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
-    allowKeychainPrompt: false,
-  });
-  const profileId = config.authProfileId;
-  const storedProfile = store.profiles[profileId];
-  if (
-    storedProfile?.type !== "oauth" ||
-    !dependencies.listProfilesForProvider(store, "openai").includes(profileId)
-  ) {
-    throw new BrokerCredentialUnavailableError();
-  }
-
   try {
+    if (!config.authAgentId || !config.authProfileId) {
+      throw new BrokerCredentialUnavailableError();
+    }
+    if (options.profileId && options.profileId !== config.authProfileId) {
+      throw new BrokerCredentialUnavailableError();
+    }
+
+    const cfg = currentConfig(api);
+    const agentDir = dependencies.resolveAgentDir(cfg, config.authAgentId);
+    const store = dependencies.loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
+      allowKeychainPrompt: false,
+    });
+    const profileId = config.authProfileId;
+    const storedProfile = store.profiles?.[profileId];
+    if (
+      storedProfile?.type !== "oauth" ||
+      !dependencies.listProfilesForProvider(store, "openai").includes(profileId)
+    ) {
+      throw new BrokerCredentialUnavailableError();
+    }
+
     const auth = await dependencies.resolveApiKeyForProvider({
       provider: "openai",
       cfg,
@@ -475,11 +481,12 @@ export async function resolveCanonicalOpenAICodexCredential(
 }
 
 export async function resolveConfiguredBrokerBearerToken(
+  pluginId: string,
   dependencies: BrokerBearerTokenDependencies = brokerBearerTokenDependencies,
 ): Promise<string | undefined> {
   const cfg = dependencies.getRuntimeConfigSourceSnapshot();
   if (!cfg) return undefined;
-  const pluginEntry = cfg.plugins?.entries?.["openclaw-honcho"];
+  const pluginEntry = cfg.plugins?.entries?.[pluginId];
   const pluginConfig = isRecord(pluginEntry?.config) ? pluginEntry.config : undefined;
   const authBroker = isRecord(pluginConfig?.authBroker) ? pluginConfig.authBroker : undefined;
   const configuredValue = authBroker?.bearerToken;
@@ -501,12 +508,56 @@ export async function resolveConfiguredBrokerBearerToken(
     config: cfg,
     env: process.env,
     value: configuredValue,
-    path: BROKER_TOKEN_CONFIG_PATH,
+    path: `plugins.entries.${pluginId}.config.authBroker.bearerToken`,
     unresolvedReasonStyle: "generic",
   });
   if (resolved.unresolvedRefReason) return undefined;
   const token = resolved.value?.trim();
   return token && token.length >= 32 ? token : undefined;
+}
+
+/** Cache SecretRef material briefly while allowing a newly rotated token through immediately. */
+export function createConfiguredBrokerBearerTokenResolver(
+  pluginId: string,
+  dependencies: BrokerBearerTokenDependencies = brokerBearerTokenDependencies,
+  options: BrokerBearerTokenResolverOptions = {},
+): (presentedToken?: string) => Promise<string | undefined> {
+  const cacheTtlMs = Math.max(1, options.cacheTtlMs ?? BROKER_BEARER_TOKEN_CACHE_TTL_MS);
+  const now = options.now ?? Date.now;
+  let cachedToken: string | undefined;
+  let cacheExpiresAt = 0;
+  let inFlight: Promise<string | undefined> | undefined;
+
+  return async (presentedToken?: string): Promise<string | undefined> => {
+    if (
+      cachedToken &&
+      now() < cacheExpiresAt &&
+      (!presentedToken || safeEqualSecret(cachedToken, presentedToken))
+    ) {
+      return cachedToken;
+    }
+
+    if (!inFlight) {
+      // A cache miss can mean expiry, configuration disablement, or rotation.
+      // Invalidate before resolving so a failed refresh never revives stale
+      // material for another request.
+      cachedToken = undefined;
+      cacheExpiresAt = 0;
+      const pending = resolveConfiguredBrokerBearerToken(pluginId, dependencies);
+      inFlight = pending;
+      const clearInFlight = () => {
+        if (inFlight === pending) inFlight = undefined;
+      };
+      void pending.then(clearInFlight, clearInFlight);
+    }
+
+    const resolved = await inFlight;
+    if (resolved) {
+      cachedToken = resolved;
+      cacheExpiresAt = now() + cacheTtlMs;
+    }
+    return resolved;
+  };
 }
 
 /** Build the prefix-route handler. Exported for focused loopback tests. */
@@ -546,7 +597,7 @@ export function createHonchoAuthBrokerHandler(
 
     let expectedToken: string | undefined;
     try {
-      expectedToken = await dependencies.resolveBearerToken();
+      expectedToken = await dependencies.resolveBearerToken(presentedToken);
     } catch {
       dependencies.logger?.warn("Honcho auth broker could not resolve its bearer token");
       respondJson(
@@ -704,12 +755,13 @@ export function registerHonchoAuthBroker(
   config: HonchoAuthBrokerConfig,
 ): void {
   if (!config.enabled) return;
+  const resolveBearerToken = createConfiguredBrokerBearerTokenResolver(api.id);
   api.registerHttpRoute({
     path: HONCHO_AUTH_BROKER_BASE_PATH,
     auth: "plugin",
     match: "prefix",
     handler: createHonchoAuthBrokerHandler(config, {
-      resolveBearerToken: () => resolveConfiguredBrokerBearerToken(),
+      resolveBearerToken,
       resolveCredential: (options) => resolveCanonicalOpenAICodexCredential(api, config, options),
       logger: api.logger,
     }),

--- a/broker.ts
+++ b/broker.ts
@@ -208,6 +208,9 @@ const FUNCTION_TOOL_FIELDS = new Set([
   "strict",
 ]);
 const FUNCTION_TOOL_CHOICE_FIELDS = new Set(["type", "name"]);
+const RESPONSE_TEXT_FIELDS = new Set(["verbosity"]);
+const RESPONSE_REASONING_FIELDS = new Set(["effort", "summary"]);
+const RESPONSE_REASONING_EFFORTS = new Set(["low", "medium", "high", "xhigh"]);
 const SIMPLE_TOOL_CHOICES = new Set(["auto", "none", "required"]);
 
 function findUnsupportedField(
@@ -319,6 +322,24 @@ function isAllowedToolChoice(value: unknown): boolean {
     value.type === "function" &&
     typeof value.name === "string" &&
     value.name.length > 0
+  );
+}
+
+function isAllowedResponseText(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyFields(value, RESPONSE_TEXT_FIELDS) &&
+    value.verbosity === "low"
+  );
+}
+
+function isAllowedResponseReasoning(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyFields(value, RESPONSE_REASONING_FIELDS) &&
+    typeof value.effort === "string" &&
+    RESPONSE_REASONING_EFFORTS.has(value.effort) &&
+    value.summary === "auto"
   );
 }
 
@@ -472,13 +493,11 @@ function validateResponsePayload(
   ) {
     return { ok: false, message: "Responses include contains an unsupported value" };
   }
-  for (const [field, value] of [
-    ["text", payload.text],
-    ["reasoning", payload.reasoning],
-  ] as const) {
-    if (value !== undefined && !isRecord(value)) {
-      return { ok: false, message: `Responses ${field} must be an object` };
-    }
+  if (payload.text !== undefined && !isAllowedResponseText(payload.text)) {
+    return { ok: false, message: "Responses text contains unsupported options" };
+  }
+  if (payload.reasoning !== undefined && !isAllowedResponseReasoning(payload.reasoning)) {
+    return { ok: false, message: "Responses reasoning contains unsupported options" };
   }
   if (
     payload.parallel_tool_calls !== undefined &&

--- a/broker.ts
+++ b/broker.ts
@@ -1,0 +1,664 @@
+/**
+ * OpenClaw-owned auth broker for self-hosted Honcho.
+ *
+ * Honcho authenticates to these two narrowly scoped HTTP routes with a
+ * plugin-owned bearer token. The plugin then asks OpenClaw's canonical auth
+ * runtime for the required upstream credential. No OpenClaw or Codex
+ * credential store is exposed to the Honcho containers.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// @ts-ignore - resolved by openclaw runtime
+import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+// @ts-ignore - resolved by openclaw runtime
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+// @ts-ignore - resolved by openclaw runtime
+import {
+  listUsableProviderAuthProfileIds,
+  resolveOpenAICodexAuthIdentity,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-auth";
+// @ts-ignore - resolved by openclaw runtime
+import {
+  resolveApiKeyForProvider,
+  resolveProviderAuthProfileMetadata,
+} from "openclaw/plugin-sdk/provider-auth-runtime";
+// @ts-ignore - resolved by openclaw runtime
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+// @ts-ignore - resolved by openclaw runtime
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+// @ts-ignore - resolved by openclaw runtime
+import {
+  createFixedWindowRateLimiter,
+  createWebhookInFlightLimiter,
+  readJsonWebhookBodyOrReject,
+  WEBHOOK_IN_FLIGHT_DEFAULTS,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-ingress";
+import type { HonchoAuthBrokerConfig } from "./config.js";
+
+export const HONCHO_AUTH_BROKER_BASE_PATH = "/plugins/openclaw-honcho/auth-broker/v1";
+
+const EMBEDDINGS_UPSTREAM_URL = "https://api.openai.com/v1/embeddings";
+const CODEX_RESPONSES_UPSTREAM_URL = "https://chatgpt.com/backend-api/codex/responses";
+const BROKER_TOKEN_CONFIG_PATH = "plugins.entries.openclaw-honcho.config.authBroker.bearerToken";
+
+export const HONCHO_EMBEDDING_MODEL = "text-embedding-3-small";
+// Match stock Honcho's default 2,048-item embedding batch while retaining an
+// independent byte, per-item, and aggregate character bound at the broker.
+export const HONCHO_MAX_EMBEDDING_INPUTS = 2_048;
+export const HONCHO_MAX_EMBEDDING_INPUT_CHARS = 32_000;
+export const HONCHO_MAX_EMBEDDING_TOTAL_CHARS = 1_200_000;
+const HONCHO_MAX_IN_FLIGHT_PER_CLIENT = 10;
+const HONCHO_MAX_RESPONSE_INPUT_ITEMS = 256;
+const HONCHO_MAX_RESPONSE_INPUT_CHARS = 512_000;
+const HONCHO_MAX_RESPONSE_INSTRUCTIONS_CHARS = 64_000;
+
+type BrokerEndpoint = "embeddings" | "responses";
+
+export type OpenAICodexBrokerCredential = {
+  accessToken: string;
+  accountId: string;
+  profileId: string;
+};
+
+export type ResolveCodexCredentialOptions = {
+  forceRefresh?: boolean;
+  profileId?: string;
+};
+
+export type HonchoAuthBrokerDependencies = {
+  fetch?: typeof fetch;
+  resolveCredential: (
+    options?: ResolveCodexCredentialOptions,
+  ) => Promise<OpenAICodexBrokerCredential>;
+  resolveBearerToken: () => Promise<string | undefined>;
+  logger?: Pick<OpenClawPluginApi["logger"], "warn">;
+};
+
+class BrokerCredentialUnavailableError extends Error {
+  constructor() {
+    super("OpenAI Codex OAuth is unavailable");
+    this.name = "BrokerCredentialUnavailableError";
+  }
+}
+
+function requestPath(req: IncomingMessage): string | undefined {
+  if (!req.url) return undefined;
+  try {
+    return new URL(req.url, "http://127.0.0.1").pathname.replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveEndpoint(req: IncomingMessage): BrokerEndpoint | undefined {
+  const path = requestPath(req);
+  if (path === `${HONCHO_AUTH_BROKER_BASE_PATH}/embeddings`) return "embeddings";
+  if (path === `${HONCHO_AUTH_BROKER_BASE_PATH}/responses`) return "responses";
+  return undefined;
+}
+
+function readBearerToken(req: IncomingMessage): string | undefined {
+  const raw = req.headers.authorization;
+  if (typeof raw !== "string") return undefined;
+  return /^Bearer\s+([^\s]+)$/i.exec(raw)?.[1];
+}
+
+function setResponseHeaders(res: ServerResponse, contentType = "application/json; charset=utf-8") {
+  res.setHeader("cache-control", "no-store, max-age=0");
+  res.setHeader("content-type", contentType);
+  res.setHeader("x-content-type-options", "nosniff");
+  res.setHeader("referrer-policy", "no-referrer");
+}
+
+function respondJson(res: ServerResponse, statusCode: number, code: string, message: string): void {
+  if (res.headersSent || res.writableEnded) return;
+  res.statusCode = statusCode;
+  setResponseHeaders(res);
+  res.end(
+    JSON.stringify({
+      error: {
+        type: "openclaw_honcho_auth_broker_error",
+        code,
+        message,
+      },
+    }),
+  );
+}
+
+function isJsonContentType(req: IncomingMessage): boolean {
+  const value = req.headers["content-type"];
+  return typeof value === "string" && /^application\/json(?:\s*;|$)/i.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+type PayloadValidation<T> = { ok: true; value: T } | { ok: false; message: string };
+
+const EMBEDDING_REQUEST_FIELDS = new Set(["model", "input", "encoding_format", "dimensions"]);
+const RESPONSE_REQUEST_FIELDS = new Set([
+  "model",
+  "input",
+  "instructions",
+  "stream",
+  "store",
+  "temperature",
+  "max_output_tokens",
+  "text",
+  "include",
+  "tools",
+  "tool_choice",
+  "parallel_tool_calls",
+  "reasoning",
+]);
+
+function findUnsupportedField(
+  payload: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+): string | undefined {
+  return Object.keys(payload).find((field) => !allowed.has(field));
+}
+
+function validateEmbeddingPayload(
+  payload: Record<string, unknown>,
+): PayloadValidation<Record<string, unknown>> {
+  const unsupported = findUnsupportedField(payload, EMBEDDING_REQUEST_FIELDS);
+  if (unsupported) return { ok: false, message: `Unsupported embeddings field: ${unsupported}` };
+  if (payload.model !== HONCHO_EMBEDDING_MODEL) {
+    return { ok: false, message: `Embeddings model must be ${HONCHO_EMBEDDING_MODEL}` };
+  }
+  if (payload.encoding_format !== undefined && payload.encoding_format !== "float") {
+    return { ok: false, message: "Embeddings encoding_format must be float" };
+  }
+  if (payload.dimensions !== undefined && payload.dimensions !== 1536) {
+    return { ok: false, message: "Embeddings dimensions must be 1536" };
+  }
+
+  const inputs = typeof payload.input === "string" ? [payload.input] : payload.input;
+  if (
+    !Array.isArray(inputs) ||
+    inputs.length === 0 ||
+    inputs.length > HONCHO_MAX_EMBEDDING_INPUTS
+  ) {
+    return {
+      ok: false,
+      message: `Embeddings input must contain between 1 and ${HONCHO_MAX_EMBEDDING_INPUTS} strings`,
+    };
+  }
+  if (inputs.some((input) => typeof input !== "string" || input.length === 0)) {
+    return { ok: false, message: "Every embeddings input must be a non-empty string" };
+  }
+  const stringInputs = inputs as string[];
+  if (stringInputs.some((input) => input.length > HONCHO_MAX_EMBEDDING_INPUT_CHARS)) {
+    return {
+      ok: false,
+      message: `Each embeddings input is limited to ${HONCHO_MAX_EMBEDDING_INPUT_CHARS} characters`,
+    };
+  }
+  if (
+    stringInputs.reduce((total, input) => total + input.length, 0) >
+    HONCHO_MAX_EMBEDDING_TOTAL_CHARS
+  ) {
+    return {
+      ok: false,
+      message: `Total embeddings input is limited to ${HONCHO_MAX_EMBEDDING_TOTAL_CHARS} characters`,
+    };
+  }
+  return { ok: true, value: { ...payload, input: stringInputs } };
+}
+
+function validateResponsePayload(
+  payload: Record<string, unknown>,
+  allowedModels: readonly string[],
+): PayloadValidation<Record<string, unknown>> {
+  const unsupported = findUnsupportedField(payload, RESPONSE_REQUEST_FIELDS);
+  if (unsupported) return { ok: false, message: `Unsupported Responses field: ${unsupported}` };
+  if (typeof payload.model !== "string" || !allowedModels.includes(payload.model)) {
+    return { ok: false, message: "Responses model is not allowed by authBroker.responseModels" };
+  }
+  if (typeof payload.input !== "string" && !Array.isArray(payload.input)) {
+    return { ok: false, message: "Responses input must be a string or array" };
+  }
+  if (
+    Array.isArray(payload.input) &&
+    (payload.input.length === 0 || payload.input.length > HONCHO_MAX_RESPONSE_INPUT_ITEMS)
+  ) {
+    return {
+      ok: false,
+      message: `Responses input is limited to ${HONCHO_MAX_RESPONSE_INPUT_ITEMS} items`,
+    };
+  }
+  const inputChars =
+    typeof payload.input === "string" ? payload.input.length : JSON.stringify(payload.input).length;
+  if (inputChars === 0 || inputChars > HONCHO_MAX_RESPONSE_INPUT_CHARS) {
+    return {
+      ok: false,
+      message: `Responses input is limited to ${HONCHO_MAX_RESPONSE_INPUT_CHARS} characters`,
+    };
+  }
+  if (
+    payload.instructions !== undefined &&
+    (typeof payload.instructions !== "string" ||
+      payload.instructions.length > HONCHO_MAX_RESPONSE_INSTRUCTIONS_CHARS)
+  ) {
+    return {
+      ok: false,
+      message: `Responses instructions are limited to ${HONCHO_MAX_RESPONSE_INSTRUCTIONS_CHARS} characters`,
+    };
+  }
+  if (payload.stream !== undefined && typeof payload.stream !== "boolean") {
+    return { ok: false, message: "Responses stream must be a boolean" };
+  }
+  if (payload.store !== undefined && typeof payload.store !== "boolean") {
+    return { ok: false, message: "Responses store must be a boolean" };
+  }
+  if (
+    payload.temperature !== undefined &&
+    (typeof payload.temperature !== "number" ||
+      !Number.isFinite(payload.temperature) ||
+      payload.temperature < 0 ||
+      payload.temperature > 2)
+  ) {
+    return { ok: false, message: "Responses temperature must be between 0 and 2" };
+  }
+  if (
+    payload.max_output_tokens !== undefined &&
+    (typeof payload.max_output_tokens !== "number" ||
+      !Number.isInteger(payload.max_output_tokens) ||
+      payload.max_output_tokens < 1 ||
+      payload.max_output_tokens > 65_536)
+  ) {
+    return { ok: false, message: "Responses max_output_tokens must be between 1 and 65536" };
+  }
+  if (payload.tools !== undefined && (!Array.isArray(payload.tools) || payload.tools.length > 64)) {
+    return { ok: false, message: "Responses tools must be an array with at most 64 entries" };
+  }
+  if (
+    payload.include !== undefined &&
+    (!Array.isArray(payload.include) ||
+      payload.include.some((entry) => entry !== "reasoning.encrypted_content"))
+  ) {
+    return { ok: false, message: "Responses include contains an unsupported value" };
+  }
+  for (const [field, value] of [
+    ["text", payload.text],
+    ["reasoning", payload.reasoning],
+  ] as const) {
+    if (value !== undefined && !isRecord(value)) {
+      return { ok: false, message: `Responses ${field} must be an object` };
+    }
+  }
+  if (
+    payload.parallel_tool_calls !== undefined &&
+    typeof payload.parallel_tool_calls !== "boolean"
+  ) {
+    return { ok: false, message: "Responses parallel_tool_calls must be a boolean" };
+  }
+  if (
+    payload.tool_choice !== undefined &&
+    typeof payload.tool_choice !== "string" &&
+    !isRecord(payload.tool_choice)
+  ) {
+    return { ok: false, message: "Responses tool_choice must be a string or object" };
+  }
+  return { ok: true, value: { ...payload, store: false } };
+}
+
+function upstreamHeaders(
+  endpoint: BrokerEndpoint,
+  credential: OpenAICodexBrokerCredential,
+  stream: boolean,
+): Headers {
+  const headers = new Headers({
+    accept: stream ? "text/event-stream" : "application/json",
+    authorization: `Bearer ${credential.accessToken}`,
+    "content-type": "application/json",
+    "user-agent": "openclaw-honcho-auth-broker",
+  });
+  if (endpoint === "responses") {
+    const requestId = `honcho-${randomUUID()}`;
+    headers.set("chatgpt-account-id", credential.accountId);
+    headers.set("originator", "openclaw");
+    headers.set("openai-beta", "responses=experimental");
+    headers.set("session_id", requestId);
+    headers.set("x-client-request-id", requestId);
+  }
+  return headers;
+}
+
+function copySafeUpstreamHeaders(upstream: Response, res: ServerResponse): void {
+  const contentType = upstream.headers.get("content-type");
+  setResponseHeaders(res, contentType || "application/octet-stream");
+  for (const name of [
+    "openai-processing-ms",
+    "openai-version",
+    "x-request-id",
+    "x-ratelimit-limit-requests",
+    "x-ratelimit-remaining-requests",
+    "x-ratelimit-reset-requests",
+  ]) {
+    const value = upstream.headers.get(name);
+    if (value) res.setHeader(name, value);
+  }
+}
+
+async function discardResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {}
+}
+
+async function streamUpstreamResponse(upstream: Response, res: ServerResponse): Promise<void> {
+  res.statusCode = upstream.status;
+  copySafeUpstreamHeaders(upstream, res);
+  if (!upstream.body) {
+    res.end();
+    return;
+  }
+  await pipeline(Readable.fromWeb(upstream.body as never), res);
+}
+
+function currentConfig(api: OpenClawPluginApi): OpenClawConfig {
+  // The runtime snapshot is intentionally readonly to plugin callers, while
+  // the canonical auth helpers retain a mutable config type for compatibility.
+  // They only read this value, so keep the freshest snapshot and narrow that
+  // type mismatch at this boundary.
+  return (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
+}
+
+function configuredAgentDir(
+  cfg: OpenClawConfig,
+  config: HonchoAuthBrokerConfig,
+): string | undefined {
+  return config.authAgentId ? resolveAgentDir(cfg, config.authAgentId) : undefined;
+}
+
+export async function resolveCanonicalOpenAICodexCredential(
+  api: OpenClawPluginApi,
+  config: HonchoAuthBrokerConfig,
+  options: ResolveCodexCredentialOptions = {},
+): Promise<OpenAICodexBrokerCredential> {
+  const cfg = currentConfig(api);
+  const agentDir = configuredAgentDir(cfg, config);
+  const usable = listUsableProviderAuthProfileIds({
+    provider: "openai",
+    cfg,
+    agentDir,
+    profileTypes: ["oauth"],
+    allowKeychainPrompt: false,
+    includeExternalCliAuth: true,
+  });
+  const profileIds = options.profileId
+    ? usable.profileIds.includes(options.profileId)
+      ? [options.profileId]
+      : []
+    : usable.profileIds;
+
+  for (const profileId of profileIds) {
+    try {
+      const auth = await resolveApiKeyForProvider({
+        provider: "openai",
+        cfg,
+        agentDir: usable.agentDir || agentDir,
+        profileId,
+        lockedProfile: true,
+        forceRefresh: options.forceRefresh === true,
+      });
+      if (auth.mode !== "oauth" || !auth.apiKey) continue;
+      const metadata = resolveProviderAuthProfileMetadata({
+        provider: "openai",
+        cfg,
+        agentDir: usable.agentDir || agentDir,
+        profileId,
+      });
+      const accountId = resolveOpenAICodexAuthIdentity({
+        access: auth.apiKey,
+        accountId: metadata.accountId,
+      }).accountId;
+      if (!accountId) continue;
+      return { accessToken: auth.apiKey, accountId, profileId };
+    } catch {
+      // Try the next configured OAuth profile in normal resolution. A
+      // profile-pinned refresh has exactly one candidate and therefore fails
+      // closed without silently switching accounts.
+    }
+  }
+  throw new BrokerCredentialUnavailableError();
+}
+
+async function resolveConfiguredBrokerBearerToken(
+  api: OpenClawPluginApi,
+): Promise<string | undefined> {
+  const cfg = currentConfig(api);
+  const pluginEntry = cfg.plugins?.entries?.["openclaw-honcho"];
+  const pluginConfig = isRecord(pluginEntry?.config) ? pluginEntry.config : undefined;
+  const authBroker = isRecord(pluginConfig?.authBroker) ? pluginConfig.authBroker : undefined;
+  const configuredValue = authBroker
+    ? Object.hasOwn(authBroker, "bearerToken")
+      ? authBroker.bearerToken
+      : process.env.HONCHO_AUTH_BROKER_TOKEN
+    : process.env.HONCHO_AUTH_BROKER_TOKEN;
+  const resolved = await resolveConfiguredSecretInputString({
+    config: cfg,
+    env: process.env,
+    value: configuredValue,
+    path: BROKER_TOKEN_CONFIG_PATH,
+    unresolvedReasonStyle: "generic",
+  });
+  if (resolved.unresolvedRefReason) return undefined;
+  const token = resolved.value?.trim();
+  return token && token.length >= 32 ? token : undefined;
+}
+
+/** Build the prefix-route handler. Exported for focused loopback tests. */
+export function createHonchoAuthBrokerHandler(
+  config: HonchoAuthBrokerConfig,
+  dependencies: HonchoAuthBrokerDependencies,
+) {
+  const fetchImpl = dependencies.fetch ?? fetch;
+  const rateLimiter = createFixedWindowRateLimiter(WEBHOOK_RATE_LIMIT_DEFAULTS);
+  const inFlightLimiter = createWebhookInFlightLimiter({
+    ...WEBHOOK_IN_FLIGHT_DEFAULTS,
+    maxInFlightPerKey: HONCHO_MAX_IN_FLIGHT_PER_CLIENT,
+  });
+
+  return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+    const endpoint = resolveEndpoint(req);
+    if (!endpoint) return false;
+
+    if (req.method !== "POST") {
+      res.setHeader("allow", "POST");
+      respondJson(res, 405, "method_not_allowed", "Only POST is supported");
+      return true;
+    }
+
+    const clientKey = `${endpoint}:${req.socket?.remoteAddress ?? "unknown"}`;
+    if (rateLimiter.isRateLimited(clientKey)) {
+      respondJson(res, 429, "rate_limited", "Too many broker requests");
+      return true;
+    }
+
+    const presentedToken = readBearerToken(req);
+    if (!presentedToken) {
+      res.setHeader("www-authenticate", 'Bearer realm="openclaw-honcho-auth-broker"');
+      respondJson(res, 401, "unauthorized", "Bearer authentication failed");
+      return true;
+    }
+
+    let expectedToken: string | undefined;
+    try {
+      expectedToken = await dependencies.resolveBearerToken();
+    } catch {
+      dependencies.logger?.warn("Honcho auth broker could not resolve its bearer token");
+      respondJson(
+        res,
+        503,
+        "broker_auth_unavailable",
+        "Honcho auth broker authentication is unavailable",
+      );
+      return true;
+    }
+    if (!expectedToken || !safeEqualSecret(expectedToken, presentedToken)) {
+      res.setHeader("www-authenticate", 'Bearer realm="openclaw-honcho-auth-broker"');
+      respondJson(res, 401, "unauthorized", "Bearer authentication failed");
+      return true;
+    }
+
+    if (!isJsonContentType(req)) {
+      respondJson(res, 415, "unsupported_media_type", "Content-Type must be application/json");
+      return true;
+    }
+
+    if (!inFlightLimiter.tryAcquire(clientKey)) {
+      respondJson(res, 429, "too_many_in_flight", "Too many concurrent broker requests");
+      return true;
+    }
+
+    try {
+      const body = await readJsonWebhookBodyOrReject({
+        req,
+        res,
+        maxBytes: config.maxRequestBytes,
+        timeoutMs: Math.min(config.timeoutMs, 30_000),
+        invalidJsonMessage: "Request body must be valid JSON",
+      });
+      if (!body.ok) return true;
+      if (!isRecord(body.value)) {
+        respondJson(res, 400, "invalid_request", "Request body must be a JSON object");
+        return true;
+      }
+
+      let embeddingPayload: Record<string, unknown> | undefined;
+      let responsePayload: Record<string, unknown> | undefined;
+      if (endpoint === "embeddings") {
+        const validation = validateEmbeddingPayload(body.value);
+        if (validation.ok === false) {
+          respondJson(res, 400, "invalid_request", validation.message);
+          return true;
+        }
+        embeddingPayload = validation.value;
+      } else {
+        const validation = validateResponsePayload(body.value, config.responseModels);
+        if (validation.ok === false) {
+          respondJson(res, 400, "invalid_request", validation.message);
+          return true;
+        }
+        responsePayload = validation.value;
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+      const abort = () => controller.abort();
+      req.once("aborted", abort);
+      res.once("close", abort);
+
+      try {
+        let credential: OpenAICodexBrokerCredential;
+        try {
+          credential = await dependencies.resolveCredential();
+        } catch {
+          dependencies.logger?.warn("Honcho auth broker could not resolve OpenAI Codex OAuth");
+          respondJson(
+            res,
+            503,
+            "oauth_unavailable",
+            "OpenAI Codex OAuth is unavailable; renew the OpenClaw login and retry",
+          );
+          return true;
+        }
+
+        const payload =
+          endpoint === "embeddings" ? (embeddingPayload ?? {}) : (responsePayload ?? {});
+        const stream = endpoint === "responses" && payload.stream === true;
+        const upstreamUrl =
+          endpoint === "embeddings" ? EMBEDDINGS_UPSTREAM_URL : CODEX_RESPONSES_UPSTREAM_URL;
+        const requestUpstream = async (selected: OpenAICodexBrokerCredential) =>
+          await fetchImpl(upstreamUrl, {
+            method: "POST",
+            headers: upstreamHeaders(endpoint, selected, stream),
+            body: JSON.stringify(payload),
+            redirect: "error",
+            signal: controller.signal,
+          });
+
+        let upstream = await requestUpstream(credential);
+        if (upstream.status === 401) {
+          await discardResponseBody(upstream);
+          try {
+            const replacement = await dependencies.resolveCredential({
+              forceRefresh: true,
+              profileId: credential.profileId,
+            });
+            if (
+              replacement.accountId === credential.accountId &&
+              !safeEqualSecret(replacement.accessToken, credential.accessToken)
+            ) {
+              credential = replacement;
+              upstream = await requestUpstream(credential);
+            }
+          } catch {
+            // The generic rejected-credential response below is intentionally
+            // the only externally visible result of a refresh-read failure.
+          }
+        }
+        if (upstream.status === 401 || upstream.status === 403) {
+          await discardResponseBody(upstream);
+          dependencies.logger?.warn(
+            `Honcho auth broker upstream rejected OpenAI OAuth (${upstream.status})`,
+          );
+          respondJson(
+            res,
+            503,
+            "oauth_rejected",
+            "OpenAI rejected the current OAuth credential; renew the OpenClaw login and retry",
+          );
+          return true;
+        }
+        await streamUpstreamResponse(upstream, res);
+        return true;
+      } catch {
+        if (!res.headersSent && !res.writableEnded) {
+          respondJson(
+            res,
+            controller.signal.aborted ? 504 : 502,
+            controller.signal.aborted ? "upstream_timeout" : "upstream_unavailable",
+            controller.signal.aborted
+              ? "OpenAI upstream request timed out"
+              : "OpenAI upstream request failed",
+          );
+        }
+        return true;
+      } finally {
+        clearTimeout(timeout);
+        req.off("aborted", abort);
+        res.off("close", abort);
+      }
+    } finally {
+      inFlightLimiter.release(clientKey);
+    }
+  };
+}
+
+/** Register the broker only when explicitly enabled. */
+export function registerHonchoAuthBroker(
+  api: OpenClawPluginApi,
+  config: HonchoAuthBrokerConfig,
+): void {
+  if (!config.enabled) return;
+  api.registerHttpRoute({
+    path: HONCHO_AUTH_BROKER_BASE_PATH,
+    auth: "plugin",
+    match: "prefix",
+    handler: createHonchoAuthBrokerHandler(config, {
+      resolveBearerToken: () => resolveConfiguredBrokerBearerToken(api),
+      resolveCredential: (options) => resolveCanonicalOpenAICodexCredential(api, config, options),
+      logger: api.logger,
+    }),
+  });
+}

--- a/broker.ts
+++ b/broker.ts
@@ -176,19 +176,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function isTextOnlyResponseInput(input: unknown[]): boolean {
-  return input.every(
-    (item) =>
-      isRecord(item) &&
-      (typeof item.content === "string" ||
-        (Array.isArray(item.content) &&
-          item.content.every(
-            (content) =>
-              isRecord(content) && content.type === "input_text" && typeof content.text === "string",
-          ))),
-  );
-}
-
 type PayloadValidation<T> = { ok: true; value: T } | { ok: false; message: string };
 
 const EMBEDDING_REQUEST_FIELDS = new Set(["model", "input", "encoding_format", "dimensions"]);
@@ -207,12 +194,132 @@ const RESPONSE_REQUEST_FIELDS = new Set([
   "parallel_tool_calls",
   "reasoning",
 ]);
+const USER_MESSAGE_FIELDS = new Set(["role", "content"]);
+const INPUT_TEXT_FIELDS = new Set(["type", "text"]);
+const ASSISTANT_MESSAGE_FIELDS = new Set(["type", "role", "content", "status", "id"]);
+const OUTPUT_TEXT_FIELDS = new Set(["type", "text", "annotations"]);
+const FUNCTION_CALL_FIELDS = new Set(["type", "id", "call_id", "name", "arguments"]);
+const FUNCTION_CALL_OUTPUT_FIELDS = new Set(["type", "call_id", "output"]);
+const FUNCTION_TOOL_FIELDS = new Set([
+  "type",
+  "name",
+  "description",
+  "parameters",
+  "strict",
+]);
+const FUNCTION_TOOL_CHOICE_FIELDS = new Set(["type", "name"]);
+const SIMPLE_TOOL_CHOICES = new Set(["auto", "none", "required"]);
 
 function findUnsupportedField(
   payload: Record<string, unknown>,
   allowed: ReadonlySet<string>,
 ): string | undefined {
   return Object.keys(payload).find((field) => !allowed.has(field));
+}
+
+function hasOnlyFields(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  return findUnsupportedField(value, allowed) === undefined;
+}
+
+function isInputTextPart(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyFields(value, INPUT_TEXT_FIELDS) &&
+    value.type === "input_text" &&
+    typeof value.text === "string"
+  );
+}
+
+function isUserMessageItem(value: Record<string, unknown>): boolean {
+  return (
+    hasOnlyFields(value, USER_MESSAGE_FIELDS) &&
+    value.role === "user" &&
+    Array.isArray(value.content) &&
+    value.content.length > 0 &&
+    value.content.every(isInputTextPart)
+  );
+}
+
+function isOutputTextPart(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyFields(value, OUTPUT_TEXT_FIELDS) &&
+    value.type === "output_text" &&
+    typeof value.text === "string" &&
+    Array.isArray(value.annotations) &&
+    value.annotations.length === 0
+  );
+}
+
+function isAssistantMessageItem(value: Record<string, unknown>): boolean {
+  return (
+    hasOnlyFields(value, ASSISTANT_MESSAGE_FIELDS) &&
+    value.type === "message" &&
+    value.role === "assistant" &&
+    Array.isArray(value.content) &&
+    value.content.length > 0 &&
+    value.content.every(isOutputTextPart) &&
+    value.status === "completed" &&
+    typeof value.id === "string" &&
+    value.id.length > 0
+  );
+}
+
+function isFunctionCallItem(value: Record<string, unknown>): boolean {
+  return (
+    hasOnlyFields(value, FUNCTION_CALL_FIELDS) &&
+    value.type === "function_call" &&
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    typeof value.call_id === "string" &&
+    value.call_id.length > 0 &&
+    typeof value.name === "string" &&
+    value.name.length > 0 &&
+    typeof value.arguments === "string"
+  );
+}
+
+function isFunctionCallOutputItem(value: Record<string, unknown>): boolean {
+  return (
+    hasOnlyFields(value, FUNCTION_CALL_OUTPUT_FIELDS) &&
+    value.type === "function_call_output" &&
+    typeof value.call_id === "string" &&
+    value.call_id.length > 0 &&
+    typeof value.output === "string"
+  );
+}
+
+function isAllowedResponseInputItem(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value.type === undefined) return isUserMessageItem(value);
+  if (value.type === "message") return isAssistantMessageItem(value);
+  if (value.type === "function_call") return isFunctionCallItem(value);
+  if (value.type === "function_call_output") return isFunctionCallOutputItem(value);
+  return false;
+}
+
+function isFunctionTool(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyFields(value, FUNCTION_TOOL_FIELDS) &&
+    value.type === "function" &&
+    typeof value.name === "string" &&
+    value.name.length > 0 &&
+    typeof value.description === "string" &&
+    isRecord(value.parameters) &&
+    value.strict === false
+  );
+}
+
+function isAllowedToolChoice(value: unknown): boolean {
+  if (typeof value === "string") return SIMPLE_TOOL_CHOICES.has(value);
+  return (
+    isRecord(value) &&
+    hasOnlyFields(value, FUNCTION_TOOL_CHOICE_FIELDS) &&
+    value.type === "function" &&
+    typeof value.name === "string" &&
+    value.name.length > 0
+  );
 }
 
 function validateEmbeddingPayload(
@@ -304,8 +411,8 @@ function validateResponsePayload(
       message: `Responses input is limited to ${HONCHO_MAX_RESPONSE_INPUT_ITEMS} items`,
     };
   }
-  if (Array.isArray(payload.input) && !isTextOnlyResponseInput(payload.input)) {
-    return { ok: false, message: "Responses input only supports text content" };
+  if (Array.isArray(payload.input) && !payload.input.every(isAllowedResponseInputItem)) {
+    return { ok: false, message: "Responses input contains an unsupported item" };
   }
   const inputChars =
     typeof payload.input === "string" ? payload.input.length : JSON.stringify(payload.input).length;
@@ -352,8 +459,9 @@ function validateResponsePayload(
   if (
     payload.tools !== undefined &&
     (!Array.isArray(payload.tools) ||
+      payload.tools.length === 0 ||
       payload.tools.length > 64 ||
-      payload.tools.some((tool) => !isRecord(tool) || tool.type !== "function"))
+      !payload.tools.every(isFunctionTool))
   ) {
     return { ok: false, message: "Responses tools must contain only caller-defined functions" };
   }
@@ -378,12 +486,8 @@ function validateResponsePayload(
   ) {
     return { ok: false, message: "Responses parallel_tool_calls must be a boolean" };
   }
-  if (
-    payload.tool_choice !== undefined &&
-    typeof payload.tool_choice !== "string" &&
-    !isRecord(payload.tool_choice)
-  ) {
-    return { ok: false, message: "Responses tool_choice must be a string or object" };
+  if (payload.tool_choice !== undefined && !isAllowedToolChoice(payload.tool_choice)) {
+    return { ok: false, message: "Responses tool_choice must select caller-defined functions" };
   }
   return { ok: true, value: { ...payload, input: normalizedInput, store: false } };
 }

--- a/broker.ts
+++ b/broker.ts
@@ -27,9 +27,14 @@ import {
   resolveProviderAuthProfileMetadata,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
 // @ts-ignore - resolved by openclaw runtime
+import { getRuntimeConfigSourceSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+// @ts-ignore - resolved by openclaw runtime
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 // @ts-ignore - resolved by openclaw runtime
-import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+import {
+  isSecretRef,
+  resolveConfiguredSecretInputString,
+} from "openclaw/plugin-sdk/secret-input-runtime";
 // @ts-ignore - resolved by openclaw runtime
 import {
   createFixedWindowRateLimiter,
@@ -77,6 +82,32 @@ export type HonchoAuthBrokerDependencies = {
   ) => Promise<OpenAICodexBrokerCredential>;
   resolveBearerToken: () => Promise<string | undefined>;
   logger?: Pick<OpenClawPluginApi["logger"], "warn">;
+};
+
+export type CanonicalCodexCredentialDependencies = {
+  resolveAgentDir: typeof resolveAgentDir;
+  listUsableProviderAuthProfileIds: typeof listUsableProviderAuthProfileIds;
+  resolveApiKeyForProvider: typeof resolveApiKeyForProvider;
+  resolveProviderAuthProfileMetadata: typeof resolveProviderAuthProfileMetadata;
+  resolveOpenAICodexAuthIdentity: typeof resolveOpenAICodexAuthIdentity;
+};
+
+export type BrokerBearerTokenDependencies = {
+  getRuntimeConfigSourceSnapshot: typeof getRuntimeConfigSourceSnapshot;
+  resolveConfiguredSecretInputString: typeof resolveConfiguredSecretInputString;
+};
+
+const canonicalCodexCredentialDependencies: CanonicalCodexCredentialDependencies = {
+  resolveAgentDir,
+  listUsableProviderAuthProfileIds,
+  resolveApiKeyForProvider,
+  resolveProviderAuthProfileMetadata,
+  resolveOpenAICodexAuthIdentity,
+};
+
+const brokerBearerTokenDependencies: BrokerBearerTokenDependencies = {
+  getRuntimeConfigSourceSnapshot,
+  resolveConfiguredSecretInputString,
 };
 
 class BrokerCredentialUnavailableError extends Error {
@@ -173,8 +204,12 @@ function validateEmbeddingPayload(
   if (payload.model !== HONCHO_EMBEDDING_MODEL) {
     return { ok: false, message: `Embeddings model must be ${HONCHO_EMBEDDING_MODEL}` };
   }
-  if (payload.encoding_format !== undefined && payload.encoding_format !== "float") {
-    return { ok: false, message: "Embeddings encoding_format must be float" };
+  if (
+    payload.encoding_format !== undefined &&
+    payload.encoding_format !== "float" &&
+    payload.encoding_format !== "base64"
+  ) {
+    return { ok: false, message: "Embeddings encoding_format must be float or base64" };
   }
   if (payload.dimensions !== undefined && payload.dimensions !== 1536) {
     return { ok: false, message: "Embeddings dimensions must be 1536" };
@@ -210,7 +245,14 @@ function validateEmbeddingPayload(
       message: `Total embeddings input is limited to ${HONCHO_MAX_EMBEDDING_TOTAL_CHARS} characters`,
     };
   }
-  return { ok: true, value: { ...payload, input: stringInputs } };
+  // OpenAI's Python SDK sends `base64` by default when its caller omits this
+  // option, but its post-parser also accepts float-array responses. Force the
+  // fixed upstream request to float so the broker never decodes caller-shaped
+  // binary data and Honcho consistently receives number arrays.
+  return {
+    ok: true,
+    value: { ...payload, input: stringInputs, encoding_format: "float" },
+  };
 }
 
 function validateResponsePayload(
@@ -381,79 +423,87 @@ function currentConfig(api: OpenClawPluginApi): OpenClawConfig {
   return (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
 }
 
-function configuredAgentDir(
-  cfg: OpenClawConfig,
-  config: HonchoAuthBrokerConfig,
-): string | undefined {
-  return config.authAgentId ? resolveAgentDir(cfg, config.authAgentId) : undefined;
-}
-
 export async function resolveCanonicalOpenAICodexCredential(
   api: OpenClawPluginApi,
   config: HonchoAuthBrokerConfig,
   options: ResolveCodexCredentialOptions = {},
+  dependencies: CanonicalCodexCredentialDependencies = canonicalCodexCredentialDependencies,
 ): Promise<OpenAICodexBrokerCredential> {
+  if (!config.authAgentId || !config.authProfileId) {
+    throw new BrokerCredentialUnavailableError();
+  }
+  if (options.profileId && options.profileId !== config.authProfileId) {
+    throw new BrokerCredentialUnavailableError();
+  }
+
   const cfg = currentConfig(api);
-  const agentDir = configuredAgentDir(cfg, config);
-  const usable = listUsableProviderAuthProfileIds({
+  const agentDir = dependencies.resolveAgentDir(cfg, config.authAgentId);
+  const usable = dependencies.listUsableProviderAuthProfileIds({
     provider: "openai",
     cfg,
     agentDir,
     profileTypes: ["oauth"],
     allowKeychainPrompt: false,
-    includeExternalCliAuth: true,
+    includeExternalCliAuth: false,
   });
-  const profileIds = options.profileId
-    ? usable.profileIds.includes(options.profileId)
-      ? [options.profileId]
-      : []
-    : usable.profileIds;
-
-  for (const profileId of profileIds) {
-    try {
-      const auth = await resolveApiKeyForProvider({
-        provider: "openai",
-        cfg,
-        agentDir: usable.agentDir || agentDir,
-        profileId,
-        lockedProfile: true,
-        forceRefresh: options.forceRefresh === true,
-      });
-      if (auth.mode !== "oauth" || !auth.apiKey) continue;
-      const metadata = resolveProviderAuthProfileMetadata({
-        provider: "openai",
-        cfg,
-        agentDir: usable.agentDir || agentDir,
-        profileId,
-      });
-      const accountId = resolveOpenAICodexAuthIdentity({
-        access: auth.apiKey,
-        accountId: metadata.accountId,
-      }).accountId;
-      if (!accountId) continue;
-      return { accessToken: auth.apiKey, accountId, profileId };
-    } catch {
-      // Try the next configured OAuth profile in normal resolution. A
-      // profile-pinned refresh has exactly one candidate and therefore fails
-      // closed without silently switching accounts.
-    }
+  const profileId = config.authProfileId;
+  if (!usable.profileIds.includes(profileId)) {
+    throw new BrokerCredentialUnavailableError();
   }
-  throw new BrokerCredentialUnavailableError();
+
+  try {
+    const auth = await dependencies.resolveApiKeyForProvider({
+      provider: "openai",
+      cfg,
+      agentDir: usable.agentDir || agentDir,
+      profileId,
+      lockedProfile: true,
+      forceRefresh: options.forceRefresh === true,
+    });
+    if (auth.mode !== "oauth" || !auth.apiKey) {
+      throw new BrokerCredentialUnavailableError();
+    }
+    const metadata = dependencies.resolveProviderAuthProfileMetadata({
+      provider: "openai",
+      cfg,
+      agentDir: usable.agentDir || agentDir,
+      profileId,
+    });
+    const accountId = dependencies.resolveOpenAICodexAuthIdentity({
+      access: auth.apiKey,
+      accountId: metadata.accountId,
+    }).accountId;
+    if (!accountId) throw new BrokerCredentialUnavailableError();
+    return { accessToken: auth.apiKey, accountId, profileId };
+  } catch {
+    throw new BrokerCredentialUnavailableError();
+  }
 }
 
-async function resolveConfiguredBrokerBearerToken(
-  api: OpenClawPluginApi,
+export async function resolveConfiguredBrokerBearerToken(
+  dependencies: BrokerBearerTokenDependencies = brokerBearerTokenDependencies,
 ): Promise<string | undefined> {
-  const cfg = currentConfig(api);
+  const cfg = dependencies.getRuntimeConfigSourceSnapshot();
+  if (!cfg) return undefined;
   const pluginEntry = cfg.plugins?.entries?.["openclaw-honcho"];
   const pluginConfig = isRecord(pluginEntry?.config) ? pluginEntry.config : undefined;
   const authBroker = isRecord(pluginConfig?.authBroker) ? pluginConfig.authBroker : undefined;
-  const configuredValue = authBroker
-    ? Object.hasOwn(authBroker, "bearerToken")
-      ? authBroker.bearerToken
-      : process.env.HONCHO_AUTH_BROKER_TOKEN
-    : process.env.HONCHO_AUTH_BROKER_TOKEN;
-  const resolved = await resolveConfiguredSecretInputString({
+  const configuredValue = authBroker?.bearerToken;
+
+  // The host materializes SecretRefs before plugin manifest/runtime validation,
+  // so the parsed plugin config legitimately contains a string. Authentication
+  // must nevertheless be authorized from the canonical authored-source
+  // snapshot on every request. A raw literal, shorthand, store ref, missing
+  // snapshot, or disabled broker therefore fails closed before secret access.
+  if (
+    authBroker?.enabled !== true ||
+    !isSecretRef(configuredValue) ||
+    !["env", "file", "exec"].includes(configuredValue.source)
+  ) {
+    return undefined;
+  }
+
+  const resolved = await dependencies.resolveConfiguredSecretInputString({
     config: cfg,
     env: process.env,
     value: configuredValue,
@@ -665,7 +715,7 @@ export function registerHonchoAuthBroker(
     auth: "plugin",
     match: "prefix",
     handler: createHonchoAuthBrokerHandler(config, {
-      resolveBearerToken: () => resolveConfiguredBrokerBearerToken(api),
+      resolveBearerToken: () => resolveConfiguredBrokerBearerToken(),
       resolveCredential: (options) => resolveCanonicalOpenAICodexCredential(api, config, options),
       logger: api.logger,
     }),

--- a/broker.ts
+++ b/broker.ts
@@ -12,20 +12,20 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 // @ts-ignore - resolved by openclaw runtime
-import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  loadAuthProfileStoreWithoutExternalProfiles,
+  resolveAgentDir,
+} from "openclaw/plugin-sdk/agent-runtime";
 // @ts-ignore - resolved by openclaw runtime
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 // @ts-ignore - resolved by openclaw runtime
 import {
-  listUsableProviderAuthProfileIds,
+  listProfilesForProvider,
   resolveOpenAICodexAuthIdentity,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-auth";
 // @ts-ignore - resolved by openclaw runtime
-import {
-  resolveApiKeyForProvider,
-  resolveProviderAuthProfileMetadata,
-} from "openclaw/plugin-sdk/provider-auth-runtime";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 // @ts-ignore - resolved by openclaw runtime
 import { getRuntimeConfigSourceSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 // @ts-ignore - resolved by openclaw runtime
@@ -86,9 +86,9 @@ export type HonchoAuthBrokerDependencies = {
 
 export type CanonicalCodexCredentialDependencies = {
   resolveAgentDir: typeof resolveAgentDir;
-  listUsableProviderAuthProfileIds: typeof listUsableProviderAuthProfileIds;
+  loadAuthProfileStoreWithoutExternalProfiles: typeof loadAuthProfileStoreWithoutExternalProfiles;
+  listProfilesForProvider: typeof listProfilesForProvider;
   resolveApiKeyForProvider: typeof resolveApiKeyForProvider;
-  resolveProviderAuthProfileMetadata: typeof resolveProviderAuthProfileMetadata;
   resolveOpenAICodexAuthIdentity: typeof resolveOpenAICodexAuthIdentity;
 };
 
@@ -99,9 +99,9 @@ export type BrokerBearerTokenDependencies = {
 
 const canonicalCodexCredentialDependencies: CanonicalCodexCredentialDependencies = {
   resolveAgentDir,
-  listUsableProviderAuthProfileIds,
+  loadAuthProfileStoreWithoutExternalProfiles,
+  listProfilesForProvider,
   resolveApiKeyForProvider,
-  resolveProviderAuthProfileMetadata,
   resolveOpenAICodexAuthIdentity,
 };
 
@@ -438,16 +438,15 @@ export async function resolveCanonicalOpenAICodexCredential(
 
   const cfg = currentConfig(api);
   const agentDir = dependencies.resolveAgentDir(cfg, config.authAgentId);
-  const usable = dependencies.listUsableProviderAuthProfileIds({
-    provider: "openai",
-    cfg,
-    agentDir,
-    profileTypes: ["oauth"],
+  const store = dependencies.loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
     allowKeychainPrompt: false,
-    includeExternalCliAuth: false,
   });
   const profileId = config.authProfileId;
-  if (!usable.profileIds.includes(profileId)) {
+  const storedProfile = store.profiles[profileId];
+  if (
+    storedProfile?.type !== "oauth" ||
+    !dependencies.listProfilesForProvider(store, "openai").includes(profileId)
+  ) {
     throw new BrokerCredentialUnavailableError();
   }
 
@@ -455,23 +454,18 @@ export async function resolveCanonicalOpenAICodexCredential(
     const auth = await dependencies.resolveApiKeyForProvider({
       provider: "openai",
       cfg,
-      agentDir: usable.agentDir || agentDir,
+      agentDir,
+      store,
       profileId,
       lockedProfile: true,
       forceRefresh: options.forceRefresh === true,
     });
-    if (auth.mode !== "oauth" || !auth.apiKey) {
+    if (auth.mode !== "oauth" || !auth.apiKey || auth.profileId !== profileId) {
       throw new BrokerCredentialUnavailableError();
     }
-    const metadata = dependencies.resolveProviderAuthProfileMetadata({
-      provider: "openai",
-      cfg,
-      agentDir: usable.agentDir || agentDir,
-      profileId,
-    });
     const accountId = dependencies.resolveOpenAICodexAuthIdentity({
       access: auth.apiKey,
-      accountId: metadata.accountId,
+      accountId: storedProfile.accountId,
     }).accountId;
     if (!accountId) throw new BrokerCredentialUnavailableError();
     return { accessToken: auth.apiKey, accountId, profileId };

--- a/broker.ts
+++ b/broker.ts
@@ -176,6 +176,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function isTextOnlyResponseInput(input: unknown[]): boolean {
+  return input.every(
+    (item) =>
+      isRecord(item) &&
+      (typeof item.content === "string" ||
+        (Array.isArray(item.content) &&
+          item.content.every(
+            (content) =>
+              isRecord(content) && content.type === "input_text" && typeof content.text === "string",
+          ))),
+  );
+}
+
 type PayloadValidation<T> = { ok: true; value: T } | { ok: false; message: string };
 
 const EMBEDDING_REQUEST_FIELDS = new Set(["model", "input", "encoding_format", "dimensions"]);
@@ -291,6 +304,9 @@ function validateResponsePayload(
       message: `Responses input is limited to ${HONCHO_MAX_RESPONSE_INPUT_ITEMS} items`,
     };
   }
+  if (Array.isArray(payload.input) && !isTextOnlyResponseInput(payload.input)) {
+    return { ok: false, message: "Responses input only supports text content" };
+  }
   const inputChars =
     typeof payload.input === "string" ? payload.input.length : JSON.stringify(payload.input).length;
   if (inputChars === 0 || inputChars > HONCHO_MAX_RESPONSE_INPUT_CHARS) {
@@ -333,8 +349,13 @@ function validateResponsePayload(
   ) {
     return { ok: false, message: "Responses max_output_tokens must be between 1 and 65536" };
   }
-  if (payload.tools !== undefined && (!Array.isArray(payload.tools) || payload.tools.length > 64)) {
-    return { ok: false, message: "Responses tools must be an array with at most 64 entries" };
+  if (
+    payload.tools !== undefined &&
+    (!Array.isArray(payload.tools) ||
+      payload.tools.length > 64 ||
+      payload.tools.some((tool) => !isRecord(tool) || tool.type !== "function"))
+  ) {
+    return { ok: false, message: "Responses tools must contain only caller-defined functions" };
   }
   if (
     payload.include !== undefined &&
@@ -409,6 +430,12 @@ async function discardResponseBody(response: Response): Promise<void> {
   try {
     await response.body?.cancel();
   } catch {}
+}
+
+function safeRetryAfter(upstream: Response): string | undefined {
+  const value = upstream.headers.get("retry-after");
+  if (!value || !/^(?:0|[1-9]\d{0,4})$/.test(value) || Number(value) > 86_400) return undefined;
+  return value;
 }
 
 async function streamUpstreamResponse(upstream: Response, res: ServerResponse): Promise<void> {
@@ -722,6 +749,23 @@ export function createHonchoAuthBrokerHandler(
             "oauth_rejected",
             "OpenAI rejected the current OAuth credential; renew the OpenClaw login and retry",
           );
+          return true;
+        }
+        if (upstream.status === 429) {
+          const retryAfter = safeRetryAfter(upstream);
+          await discardResponseBody(upstream);
+          if (retryAfter) res.setHeader("retry-after", retryAfter);
+          respondJson(
+            res,
+            429,
+            "upstream_rate_limited",
+            "OpenAI upstream rate limit exceeded; retry later",
+          );
+          return true;
+        }
+        if (!upstream.ok) {
+          await discardResponseBody(upstream);
+          respondJson(res, 502, "upstream_error", "OpenAI upstream request failed");
           return true;
         }
         await streamUpstreamResponse(upstream, res);

--- a/broker.ts
+++ b/broker.ts
@@ -225,6 +225,15 @@ function validateResponsePayload(
   if (typeof payload.input !== "string" && !Array.isArray(payload.input)) {
     return { ok: false, message: "Responses input must be a string or array" };
   }
+  const normalizedInput =
+    typeof payload.input === "string"
+      ? [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: payload.input }],
+          },
+        ]
+      : payload.input;
   if (
     Array.isArray(payload.input) &&
     (payload.input.length === 0 || payload.input.length > HONCHO_MAX_RESPONSE_INPUT_ITEMS)
@@ -307,7 +316,7 @@ function validateResponsePayload(
   ) {
     return { ok: false, message: "Responses tool_choice must be a string or object" };
   }
-  return { ok: true, value: { ...payload, store: false } };
+  return { ok: true, value: { ...payload, input: normalizedInput, store: false } };
 }
 
 function upstreamHeaders(

--- a/broker.ts
+++ b/broker.ts
@@ -489,6 +489,19 @@ function validateResponsePayload(
   if (payload.tool_choice !== undefined && !isAllowedToolChoice(payload.tool_choice)) {
     return { ok: false, message: "Responses tool_choice must select caller-defined functions" };
   }
+  const declaredFunctionTools = Array.isArray(payload.tools) ? payload.tools : [];
+  if (payload.tool_choice === "required" && declaredFunctionTools.length === 0) {
+    return { ok: false, message: "Responses tool_choice required needs declared functions" };
+  }
+  if (isRecord(payload.tool_choice)) {
+    const selectedToolName = payload.tool_choice.name;
+    if (
+      typeof selectedToolName === "string" &&
+      !declaredFunctionTools.some((tool) => isRecord(tool) && tool.name === selectedToolName)
+    ) {
+      return { ok: false, message: "Responses tool_choice function must be declared" };
+    }
+  }
   return { ok: true, value: { ...payload, input: normalizedInput, store: false } };
 }
 

--- a/config.ts
+++ b/config.ts
@@ -2,6 +2,22 @@
  * Configuration schema and parsing for the Honcho memory plugin.
  */
 
+// @ts-ignore - resolved by openclaw runtime
+import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
+
+export const DEFAULT_AUTH_BROKER_MAX_REQUEST_BYTES = 2 * 1024 * 1024;
+export const DEFAULT_AUTH_BROKER_TIMEOUT_MS = 10 * 60 * 1000;
+export const DEFAULT_AUTH_BROKER_RESPONSE_MODELS = ["gpt-5.4-mini", "gpt-5.4"];
+
+export type HonchoAuthBrokerConfig = {
+  enabled: boolean;
+  bearerToken?: SecretInput;
+  authAgentId?: string;
+  responseModels: string[];
+  maxRequestBytes: number;
+  timeoutMs: number;
+};
+
 export const DEFAULT_NOISE_PATTERNS: string[] = [
   "HEARTBEAT_OK",
   "A scheduled reminder has been triggered",
@@ -18,6 +34,7 @@ export type HonchoConfig = {
   disableDefaultNoisePatterns: boolean;
   ownerObserveOthers: boolean;
   crossSessionSearch: boolean;
+  authBroker: HonchoAuthBrokerConfig;
 };
 
 /**
@@ -32,6 +49,99 @@ function resolveEnvVars(value: string): string {
     }
     return envValue;
   });
+}
+
+function positiveIntegerInRange(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= min && value <= max
+    ? value
+    : fallback;
+}
+
+function isSecretRefLike(value: unknown): value is Exclude<SecretInput, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const ref = value as Record<string, unknown>;
+  return (
+    typeof ref.source === "string" &&
+    ["env", "file", "exec"].includes(ref.source) &&
+    typeof ref.provider === "string" &&
+    typeof ref.id === "string" &&
+    ref.source.trim().length > 0 &&
+    ref.provider.trim().length > 0 &&
+    ref.id.trim().length > 0
+  );
+}
+
+function parseResponseModels(value: unknown): string[] {
+  if (value === undefined) return [...DEFAULT_AUTH_BROKER_RESPONSE_MODELS];
+  if (!Array.isArray(value) || value.length === 0 || value.length > 16) {
+    throw new Error("authBroker.responseModels must contain between 1 and 16 model IDs");
+  }
+  const models = value.map((entry) => (typeof entry === "string" ? entry.trim() : ""));
+  if (
+    models.some(
+      (model) =>
+        model.length === 0 || model.length > 128 || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(model),
+    )
+  ) {
+    throw new Error("authBroker.responseModels contains an invalid model ID");
+  }
+  if (new Set(models).size !== models.length) {
+    throw new Error("authBroker.responseModels must not contain duplicate model IDs");
+  }
+  return models;
+}
+
+function parseAuthBrokerConfig(value: unknown): HonchoAuthBrokerConfig {
+  const raw =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  const enabled = raw.enabled === true;
+  const configuredToken = raw.bearerToken ?? process.env.HONCHO_AUTH_BROKER_TOKEN;
+  const bearerToken =
+    typeof configuredToken === "string" && configuredToken.trim().length > 0
+      ? configuredToken.trim()
+      : isSecretRefLike(configuredToken)
+        ? configuredToken
+        : undefined;
+
+  if (enabled && bearerToken === undefined) {
+    throw new Error(
+      "authBroker.enabled requires authBroker.bearerToken or HONCHO_AUTH_BROKER_TOKEN",
+    );
+  }
+  // A SecretRef is validated after OpenClaw resolves it. Literal bearer tokens
+  // must be long enough to resist online guessing.
+  if (enabled && typeof bearerToken === "string" && bearerToken.length < 32) {
+    throw new Error("authBroker.bearerToken must contain at least 32 characters");
+  }
+
+  return {
+    enabled,
+    bearerToken,
+    authAgentId:
+      typeof raw.authAgentId === "string" && raw.authAgentId.trim().length > 0
+        ? raw.authAgentId.trim()
+        : undefined,
+    responseModels: parseResponseModels(raw.responseModels),
+    maxRequestBytes: positiveIntegerInRange(
+      raw.maxRequestBytes,
+      DEFAULT_AUTH_BROKER_MAX_REQUEST_BYTES,
+      1024,
+      16 * 1024 * 1024,
+    ),
+    timeoutMs: positiveIntegerInRange(
+      raw.timeoutMs,
+      DEFAULT_AUTH_BROKER_TIMEOUT_MS,
+      1000,
+      15 * 60 * 1000,
+    ),
+  };
 }
 
 export const honchoConfigSchema = {
@@ -81,6 +191,7 @@ export const honchoConfigSchema = {
       disableDefaultNoisePatterns,
       ownerObserveOthers: typeof cfg.ownerObserveOthers === "boolean" ? cfg.ownerObserveOthers : false,
       crossSessionSearch: typeof cfg.crossSessionSearch === "boolean" ? cfg.crossSessionSearch : true,
+      authBroker: parseAuthBrokerConfig(cfg.authBroker),
     };
   },
 };

--- a/config.ts
+++ b/config.ts
@@ -13,6 +13,7 @@ export type HonchoAuthBrokerConfig = {
   enabled: boolean;
   bearerToken?: SecretInput;
   authAgentId?: string;
+  authProfileId?: string;
   responseModels: string[];
   maxRequestBytes: number;
   timeoutMs: number;
@@ -76,6 +77,10 @@ function isSecretRefLike(value: unknown): value is Exclude<SecretInput, string> 
   );
 }
 
+function isResolvedBrokerBearerToken(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length >= 32;
+}
+
 function parseResponseModels(value: unknown): string[] {
   if (value === undefined) return [...DEFAULT_AUTH_BROKER_RESPONSE_MODELS];
   if (!Array.isArray(value) || value.length === 0 || value.length > 16) {
@@ -102,46 +107,53 @@ function parseAuthBrokerConfig(value: unknown): HonchoAuthBrokerConfig {
       ? (value as Record<string, unknown>)
       : {};
   const enabled = raw.enabled === true;
-  const configuredToken = raw.bearerToken ?? process.env.HONCHO_AUTH_BROKER_TOKEN;
-  const bearerToken =
-    typeof configuredToken === "string" && configuredToken.trim().length > 0
+  const configuredToken = raw.bearerToken;
+  const bearerToken = isSecretRefLike(configuredToken)
+    ? configuredToken
+    : isResolvedBrokerBearerToken(configuredToken)
       ? configuredToken.trim()
-      : isSecretRefLike(configuredToken)
-        ? configuredToken
-        : undefined;
+      : undefined;
+  const authAgentId =
+    typeof raw.authAgentId === "string" && raw.authAgentId.trim().length > 0
+      ? raw.authAgentId.trim()
+      : undefined;
+  const authProfileId =
+    typeof raw.authProfileId === "string" && raw.authProfileId.trim().length > 0
+      ? raw.authProfileId.trim()
+      : undefined;
 
   if (
-    enabled &&
-    configuredToken &&
-    typeof configuredToken === "object" &&
-    !Array.isArray(configuredToken) &&
-    typeof (configuredToken as Record<string, unknown>).source === "string" &&
-    !["env", "file", "exec"].includes(
-      (configuredToken as Record<string, unknown>).source as string,
-    )
+    configuredToken !== undefined &&
+    !isSecretRefLike(configuredToken) &&
+    !isResolvedBrokerBearerToken(configuredToken)
   ) {
     throw new Error(
-      "authBroker.bearerToken SecretRef source must be env, file, or exec for OpenClaw 2026.7.1 compatibility",
+      "authBroker.bearerToken must be an env, file, or exec OpenClaw SecretRef or a host-resolved string of at least 32 characters",
     );
   }
   if (enabled && bearerToken === undefined) {
     throw new Error(
-      "authBroker.enabled requires authBroker.bearerToken or HONCHO_AUTH_BROKER_TOKEN",
+      "authBroker.enabled requires an explicit authBroker.bearerToken SecretRef or host-resolved token",
     );
   }
-  // A SecretRef is validated after OpenClaw resolves it. Literal bearer tokens
-  // must be long enough to resist online guessing.
-  if (enabled && typeof bearerToken === "string" && bearerToken.length < 32) {
-    throw new Error("authBroker.bearerToken must contain at least 32 characters");
+  if (enabled && authAgentId === undefined) {
+    throw new Error("authBroker.enabled requires an explicit authBroker.authAgentId");
+  }
+  if (enabled && authProfileId === undefined) {
+    throw new Error("authBroker.enabled requires an explicit authBroker.authProfileId");
+  }
+  if (
+    authProfileId !== undefined &&
+    (authProfileId.length > 256 || !/^[A-Za-z0-9][A-Za-z0-9._:@+-]*$/.test(authProfileId))
+  ) {
+    throw new Error("authBroker.authProfileId contains an invalid profile ID");
   }
 
   return {
     enabled,
     bearerToken,
-    authAgentId:
-      typeof raw.authAgentId === "string" && raw.authAgentId.trim().length > 0
-        ? raw.authAgentId.trim()
-        : undefined,
+    authAgentId,
+    authProfileId,
     responseModels: parseResponseModels(raw.responseModels),
     maxRequestBytes: positiveIntegerInRange(
       raw.maxRequestBytes,

--- a/config.ts
+++ b/config.ts
@@ -143,6 +143,12 @@ function parseAuthBrokerConfig(value: unknown): HonchoAuthBrokerConfig {
     throw new Error("authBroker.enabled requires an explicit authBroker.authProfileId");
   }
   if (
+    authAgentId !== undefined &&
+    (authAgentId.length > 256 || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(authAgentId))
+  ) {
+    throw new Error("authBroker.authAgentId contains an invalid agent ID");
+  }
+  if (
     authProfileId !== undefined &&
     (authProfileId.length > 256 || !/^[A-Za-z0-9][A-Za-z0-9._:@+-]*$/.test(authProfileId))
   ) {

--- a/config.ts
+++ b/config.ts
@@ -110,6 +110,20 @@ function parseAuthBrokerConfig(value: unknown): HonchoAuthBrokerConfig {
         ? configuredToken
         : undefined;
 
+  if (
+    enabled &&
+    configuredToken &&
+    typeof configuredToken === "object" &&
+    !Array.isArray(configuredToken) &&
+    typeof (configuredToken as Record<string, unknown>).source === "string" &&
+    !["env", "file", "exec"].includes(
+      (configuredToken as Record<string, unknown>).source as string,
+    )
+  ) {
+    throw new Error(
+      "authBroker.bearerToken SecretRef source must be env, file, or exec for OpenClaw 2026.7.1 compatibility",
+    );
+  }
   if (enabled && bearerToken === undefined) {
     throw new Error(
       "authBroker.enabled requires authBroker.bearerToken or HONCHO_AUTH_BROKER_TOKEN",

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ import { registerMemoryPassthrough } from "./tools/memory-passthrough.js";
 import { registerMessageSearchTool } from "./tools/message-search.js";
 import { registerCli } from "./commands/cli.js";
 import { createHonchoMemoryRuntime } from "./runtime.js";
+import { registerHonchoAuthBroker } from "./broker.js";
 
 /**
  * Memory prompt section builder for Honcho tools.
@@ -113,6 +114,11 @@ const honchoPlugin: OpenClawPluginDefinition = definePluginEntry({
     registerAskTool(api, state);
     registerMessageSearchTool(api, state);
     registerMemoryPassthrough(api, state);
+
+    // Optional OpenClaw-owned auth broker for self-hosted Honcho. The broker
+    // exposes only embeddings and Codex Responses and never shares a credential
+    // store with the Honcho containers.
+    registerHonchoAuthBroker(api, state.cfg.authBroker);
 
     // CLI
     registerCli(api, state);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -15,7 +15,8 @@
       "paths": [
         {
           "path": "authBroker.bearerToken",
-          "expected": "string"
+          "expected": "string",
+          "ownerKind": "route"
         }
       ]
     }
@@ -47,12 +48,6 @@
           "id": { "type": "string", "minLength": 1 }
         },
         "required": ["source", "provider", "id"]
-      },
-      "secretInput": {
-        "anyOf": [
-          { "type": "string", "minLength": 32 },
-          { "$ref": "#/$defs/secretRef" }
-        ]
       }
     },
     "properties": {
@@ -103,13 +98,28 @@
             "default": false
           },
           "bearerToken": {
-            "$ref": "#/$defs/secretInput",
-            "description": "Strong bearer token Honcho presents to the broker. Prefer an OpenClaw SecretRef."
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 32
+              },
+              {
+                "$ref": "#/$defs/secretRef"
+              }
+            ],
+            "description": "SecretRef resolving the strong bearer token Honcho presents to the broker. The string form exists only for OpenClaw's host-resolved runtime config; the route rejects raw literal configuration and ambient fallback."
           },
           "authAgentId": {
             "type": "string",
             "minLength": 1,
-            "description": "Optional agent whose OpenAI auth scope the broker uses."
+            "description": "Required agent whose stored OpenAI auth scope the broker uses."
+          },
+          "authProfileId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@+-]*$",
+            "description": "Required stored OpenAI OAuth profile ID. The broker fails closed rather than trying another profile or external CLI auth."
           },
           "responseModels": {
             "type": "array",
@@ -136,7 +146,18 @@
             "maximum": 900000,
             "default": 600000
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": { "enabled": { "const": true } },
+              "required": ["enabled"]
+            },
+            "then": {
+              "required": ["bearerToken", "authAgentId", "authProfileId"]
+            }
+          }
+        ]
       }
     }
   },
@@ -192,12 +213,17 @@
       "label": "Auth Broker Bearer Token",
       "sensitive": true,
       "advanced": true,
-      "help": "Use a random value of at least 32 characters. Prefer an OpenClaw SecretRef."
+      "help": "Required SecretRef for a random bearer of at least 32 characters. Literal and ambient environment fallbacks are rejected."
     },
     "authBroker.authAgentId": {
       "label": "Auth Agent ID",
       "advanced": true,
-      "help": "Bind Codex OAuth resolution to one agent. Omit to use OpenClaw's ambient owner agent."
+      "help": "Required agent whose stored Codex OAuth profile is used. No ambient-agent fallback."
+    },
+    "authBroker.authProfileId": {
+      "label": "Auth Profile ID",
+      "advanced": true,
+      "help": "Required stored OpenAI OAuth profile ID. External CLI auth and alternate-profile fallback are disabled."
     },
     "authBroker.responseModels": {
       "label": "Allowed Responses Models",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -112,6 +112,8 @@
           "authAgentId": {
             "type": "string",
             "minLength": 1,
+            "maxLength": 256,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
             "description": "Required agent whose stored OpenAI auth scope the broker uses."
           },
           "authProfileId": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -10,6 +10,16 @@
       }
     ]
   },
+  "configContracts": {
+    "secretInputs": {
+      "paths": [
+        {
+          "path": "authBroker.bearerToken",
+          "expected": "string"
+        }
+      ]
+    }
+  },
   "contracts": {
     "tools": [
       "honcho_session",
@@ -24,6 +34,27 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
+    "$defs": {
+      "secretRef": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": ["env", "file", "exec"]
+          },
+          "provider": { "type": "string", "minLength": 1 },
+          "id": { "type": "string", "minLength": 1 }
+        },
+        "required": ["source", "provider", "id"]
+      },
+      "secretInput": {
+        "anyOf": [
+          { "type": "string", "minLength": 32 },
+          { "$ref": "#/$defs/secretRef" }
+        ]
+      }
+    },
     "properties": {
       "apiKey": {
         "type": "string",
@@ -61,6 +92,51 @@
         "type": "boolean",
         "default": true,
         "description": "Default scope for memory_search. When true (default), results span every session the participant peer has written to. When false, results are scoped to the active session. Per-call override available via the memory_search `crossSession` parameter."
+      },
+      "authBroker": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Optional OpenClaw-owned auth broker for self-hosted Honcho.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "bearerToken": {
+            "$ref": "#/$defs/secretInput",
+            "description": "Strong bearer token Honcho presents to the broker. Prefer an OpenClaw SecretRef."
+          },
+          "authAgentId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional agent whose OpenAI auth scope the broker uses."
+          },
+          "responseModels": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 16,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+            },
+            "default": ["gpt-5.4-mini", "gpt-5.4"]
+          },
+          "maxRequestBytes": {
+            "type": "integer",
+            "minimum": 1024,
+            "maximum": 16777216,
+            "default": 2097152
+          },
+          "timeoutMs": {
+            "type": "integer",
+            "minimum": 1000,
+            "maximum": 900000,
+            "default": 600000
+          }
+        }
       }
     }
   },
@@ -106,6 +182,35 @@
       "label": "Cross-Session Search",
       "advanced": true,
       "help": "When enabled (default), memory tools can return results from any session in the workspace. Disable to scope results to the active session only."
+    },
+    "authBroker.enabled": {
+      "label": "Enable OpenClaw Auth Broker",
+      "advanced": true,
+      "help": "Expose narrowly scoped embeddings and Codex Responses routes for self-hosted Honcho."
+    },
+    "authBroker.bearerToken": {
+      "label": "Auth Broker Bearer Token",
+      "sensitive": true,
+      "advanced": true,
+      "help": "Use a random value of at least 32 characters. Prefer an OpenClaw SecretRef."
+    },
+    "authBroker.authAgentId": {
+      "label": "Auth Agent ID",
+      "advanced": true,
+      "help": "Bind Codex OAuth resolution to one agent. Omit to use OpenClaw's ambient owner agent."
+    },
+    "authBroker.responseModels": {
+      "label": "Allowed Responses Models",
+      "advanced": true,
+      "help": "Exact Codex Responses model IDs accepted by the broker."
+    },
+    "authBroker.maxRequestBytes": {
+      "label": "Auth Broker Request Limit",
+      "advanced": true
+    },
+    "authBroker.timeoutMs": {
+      "label": "Auth Broker Timeout (ms)",
+      "advanced": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.7"
+    "openclaw": ">=2026.7.1"
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
@@ -39,10 +39,10 @@
       "./dist/index.js"
     ],
     "build": {
-      "openclawVersion": ">=2026.4.7"
+      "openclawVersion": ">=2026.7.1"
     },
     "compat": {
-      "pluginApi": ">=2026.4.7"
+      "pluginApi": ">=2026.7.1"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^0.32.0
         version: 0.32.35
       openclaw:
-        specifier: '>=2026.4.7'
+        specifier: '>=2026.7.1'
         version: 2026.7.1(@aws-sdk/credential-provider-node@3.972.24)
     devDependencies:
       '@types/node':

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -8,6 +8,10 @@ import {
   HONCHO_MAX_EMBEDDING_INPUT_CHARS,
   HONCHO_MAX_EMBEDDING_INPUTS,
   registerHonchoAuthBroker,
+  resolveCanonicalOpenAICodexCredential,
+  resolveConfiguredBrokerBearerToken,
+  type BrokerBearerTokenDependencies,
+  type CanonicalCodexCredentialDependencies,
   type HonchoAuthBrokerDependencies,
 } from "../broker.js";
 import type { HonchoAuthBrokerConfig } from "../config.js";
@@ -19,6 +23,7 @@ const config: HonchoAuthBrokerConfig = {
   enabled: true,
   bearerToken: BROKER_TOKEN,
   authAgentId: "main",
+  authProfileId: "openai:codex",
   responseModels: ["gpt-5.4-mini", "gpt-5.4"],
   maxRequestBytes: 4096,
   timeoutMs: 5000,
@@ -104,6 +109,196 @@ async function invokeBrokerDirectly(
   await createHonchoAuthBrokerHandler(brokerConfig, dependencies)(request, response);
   return { body: responseBody, statusCode: response.statusCode };
 }
+
+function canonicalResolverHarness(profileIds: string[] = ["openai:codex"]) {
+  const resolveAgentDir = vi.fn(() => "/agent/main");
+  const listUsableProviderAuthProfileIds = vi.fn(() => ({
+    agentDir: "/agent/main",
+    profileIds,
+  }));
+  const resolveApiKeyForProvider = vi.fn(async () => ({
+    apiKey: OAUTH_TOKEN,
+    mode: "oauth" as const,
+  }));
+  const resolveProviderAuthProfileMetadata = vi.fn(() => ({ accountId: "account-123" }));
+  const resolveOpenAICodexAuthIdentity = vi.fn(() => ({ accountId: "account-123" }));
+  const dependencies = {
+    resolveAgentDir,
+    listUsableProviderAuthProfileIds,
+    resolveApiKeyForProvider,
+    resolveProviderAuthProfileMetadata,
+    resolveOpenAICodexAuthIdentity,
+  } as unknown as CanonicalCodexCredentialDependencies;
+  const api = {
+    config: {},
+    runtime: { config: { current: () => ({}) } },
+  } as never;
+  return {
+    api,
+    dependencies,
+    listUsableProviderAuthProfileIds,
+    resolveAgentDir,
+    resolveApiKeyForProvider,
+    resolveOpenAICodexAuthIdentity,
+    resolveProviderAuthProfileMetadata,
+  };
+}
+
+function brokerBearerResolverHarness(rawBearerToken: unknown, enabled = true) {
+  const sourceConfig = {
+    plugins: {
+      entries: {
+        "openclaw-honcho": {
+          config: {
+            authBroker: {
+              enabled,
+              bearerToken: rawBearerToken,
+            },
+          },
+        },
+      },
+    },
+  };
+  const getRuntimeConfigSourceSnapshot = vi.fn(() => sourceConfig);
+  const resolveConfiguredSecretInputString = vi.fn(async () => ({ value: BROKER_TOKEN }));
+  const dependencies = {
+    getRuntimeConfigSourceSnapshot,
+    resolveConfiguredSecretInputString,
+  } as unknown as BrokerBearerTokenDependencies;
+  return {
+    dependencies,
+    getRuntimeConfigSourceSnapshot,
+    resolveConfiguredSecretInputString,
+  };
+}
+
+describe("canonical Codex OAuth resolution", () => {
+  it("uses only the explicit agent-scoped stored OAuth profile", async () => {
+    const harness = canonicalResolverHarness(["openai:other", "openai:codex"]);
+
+    await expect(
+      resolveCanonicalOpenAICodexCredential(
+        harness.api,
+        config,
+        {},
+        harness.dependencies,
+      ),
+    ).resolves.toEqual({
+      accessToken: OAUTH_TOKEN,
+      accountId: "account-123",
+      profileId: "openai:codex",
+    });
+
+    expect(harness.resolveAgentDir).toHaveBeenCalledWith({}, "main");
+    expect(harness.listUsableProviderAuthProfileIds).toHaveBeenCalledWith({
+      provider: "openai",
+      cfg: {},
+      agentDir: "/agent/main",
+      profileTypes: ["oauth"],
+      allowKeychainPrompt: false,
+      includeExternalCliAuth: false,
+    });
+    expect(harness.resolveApiKeyForProvider).toHaveBeenCalledTimes(1);
+    expect(harness.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        agentDir: "/agent/main",
+        profileId: "openai:codex",
+        lockedProfile: true,
+        forceRefresh: false,
+      }),
+    );
+  });
+
+  it("fails closed when the pin is unavailable or a retry requests another profile", async () => {
+    const unavailable = canonicalResolverHarness(["openai:other"]);
+    await expect(
+      resolveCanonicalOpenAICodexCredential(
+        unavailable.api,
+        config,
+        {},
+        unavailable.dependencies,
+      ),
+    ).rejects.toThrow("OpenAI Codex OAuth is unavailable");
+    expect(unavailable.resolveApiKeyForProvider).not.toHaveBeenCalled();
+
+    const mismatchedRetry = canonicalResolverHarness();
+    await expect(
+      resolveCanonicalOpenAICodexCredential(
+        mismatchedRetry.api,
+        config,
+        { forceRefresh: true, profileId: "openai:other" },
+        mismatchedRetry.dependencies,
+      ),
+    ).rejects.toThrow("OpenAI Codex OAuth is unavailable");
+    expect(mismatchedRetry.listUsableProviderAuthProfileIds).not.toHaveBeenCalled();
+  });
+});
+
+describe("broker bearer SecretRef resolution", () => {
+  it.each([
+    {
+      name: "a raw literal",
+      rawBearerToken: BROKER_TOKEN,
+    },
+    {
+      name: "a raw environment shorthand",
+      rawBearerToken: "${HONCHO_AUTH_BROKER_TOKEN}",
+    },
+    {
+      name: "a store SecretRef",
+      rawBearerToken: {
+        source: "store",
+        provider: "default",
+        id: "HONCHO_AUTH_BROKER_TOKEN",
+      },
+    },
+  ])("rejects $name before reading secret material", async ({ rawBearerToken }) => {
+    const harness = brokerBearerResolverHarness(rawBearerToken);
+
+    await expect(resolveConfiguredBrokerBearerToken(harness.dependencies)).resolves.toBeUndefined();
+    expect(harness.getRuntimeConfigSourceSnapshot).toHaveBeenCalledTimes(1);
+    expect(harness.resolveConfiguredSecretInputString).not.toHaveBeenCalled();
+  });
+
+  it.each(["env", "file", "exec"] as const)(
+    "resolves an explicit raw %s SecretRef from the canonical source snapshot",
+    async (source) => {
+      const rawBearerToken = {
+        source,
+        provider: "default",
+        id: "HONCHO_AUTH_BROKER_TOKEN",
+      };
+      const harness = brokerBearerResolverHarness(rawBearerToken);
+
+      await expect(resolveConfiguredBrokerBearerToken(harness.dependencies)).resolves.toBe(
+        BROKER_TOKEN,
+      );
+      expect(harness.resolveConfiguredSecretInputString).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.any(Object),
+          value: rawBearerToken,
+          path: "plugins.entries.openclaw-honcho.config.authBroker.bearerToken",
+          unresolvedReasonStyle: "generic",
+        }),
+      );
+    },
+  );
+
+  it("fails closed when the raw broker is disabled", async () => {
+    const harness = brokerBearerResolverHarness(
+      {
+        source: "env",
+        provider: "default",
+        id: "HONCHO_AUTH_BROKER_TOKEN",
+      },
+      false,
+    );
+
+    await expect(resolveConfiguredBrokerBearerToken(harness.dependencies)).resolves.toBeUndefined();
+    expect(harness.resolveConfiguredSecretInputString).not.toHaveBeenCalled();
+  });
+});
 
 describe("Honcho auth broker", () => {
   it("rejects unauthenticated requests before resolving OAuth or reading upstream", async () => {
@@ -214,7 +409,48 @@ describe("Honcho auth broker", () => {
     expect(JSON.parse(String(init?.body))).toEqual({
       model: "text-embedding-3-small",
       input: ["hello"],
+      encoding_format: "float",
     });
+  });
+
+  it("normalizes the OpenAI Python SDK base64 wire default to float arrays", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (_url, init) => {
+      expect(JSON.parse(String(init?.body))).toEqual({
+        model: "text-embedding-3-small",
+        input: ["hello"],
+        encoding_format: "float",
+      });
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          model: "text-embedding-3-small",
+          data: [{ object: "embedding", index: 0, embedding: [0.25, 0.5] }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/embeddings`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "text-embedding-3-small",
+          input: "hello",
+          encoding_format: "base64",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        data: [{ embedding: [0.25, 0.5] }],
+      });
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -228,6 +464,14 @@ describe("Honcho auth broker", () => {
         model: "text-embedding-3-small",
         input: "hello",
         url: "https://attacker.invalid/v1/embeddings",
+      },
+    },
+    {
+      name: "an unsupported encoding format",
+      body: {
+        model: "text-embedding-3-small",
+        input: "hello",
+        encoding_format: "binary",
       },
     },
     {

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -777,11 +777,149 @@ describe("Honcho auth broker", () => {
 
   it.each([
     {
-      name: "a hosted web-search tool",
+      name: "an assistant message with output text",
+      input: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "I will check.", annotations: [] }],
+          status: "completed",
+          id: "msg_0123456789abcdef",
+        },
+      ],
+    },
+    {
+      name: "a function call",
+      input: [
+        {
+          type: "function_call",
+          id: "fc_0123456789abcdef",
+          call_id: "call_0123456789abcdef",
+          name: "lookup_memory",
+          arguments: '{"query":"Taipei"}',
+        },
+      ],
+    },
+    {
+      name: "a function call output",
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_0123456789abcdef",
+          output: '{"timezone":"Asia/Taipei"}',
+        },
+      ],
+    },
+  ])("forwards the relay's exact Responses shape for $name", async ({ input }) => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ id: "resp-1", status: "completed" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "gpt-5.4-mini", input, tool_choice: "auto" }),
+      });
+      expect(response.status).toBe(200);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(JSON.parse(String(init?.body))).toMatchObject({ input });
+  });
+
+  it("forwards the relay's exact caller-defined function tool shape", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ id: "resp-1", status: "completed" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const tools = [
+      {
+        type: "function",
+        name: "lookup_memory",
+        description: "Look up memory",
+        parameters: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+        strict: false,
+      },
+    ];
+
+    await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "gpt-5.4-mini",
+          input: "hello",
+          tools,
+          tool_choice: { type: "function", name: "lookup_memory" },
+        }),
+      });
+      expect(response.status).toBe(200);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(JSON.parse(String(init?.body))).toMatchObject({ tools });
+  });
+
+  it.each([
+    {
+      name: "a non-function tool definition",
       body: {
         model: "gpt-5.4-mini",
         input: "hello",
         tools: [{ type: "web_search_preview" }],
+      },
+    },
+    {
+      name: "a function tool definition with an extra field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        tools: [
+          {
+            type: "function",
+            name: "lookup_memory",
+            description: "Look up memory",
+            parameters: { type: "object", properties: {} },
+            strict: false,
+            endpoint: "https://attacker.invalid/tool",
+          },
+        ],
+      },
+    },
+    {
+      name: "a hosted tool choice",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        tool_choice: { type: "web_search_preview" },
+      },
+    },
+    {
+      name: "a hosted string tool choice",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        tool_choice: "web_search_preview",
       },
     },
     {
@@ -811,6 +949,112 @@ describe("Honcho auth broker", () => {
           {
             role: "user",
             content: [{ type: "input_image", image_url: "https://attacker.invalid/image" }],
+          },
+        ],
+      },
+    },
+    {
+      name: "an arbitrary input item type",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [{ type: "reasoning", encrypted_content: "opaque" }],
+      },
+    },
+    {
+      name: "an extra assistant-message field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "hello", annotations: [] }],
+            status: "completed",
+            id: "msg_0123456789abcdef",
+            file_url: "https://attacker.invalid/file",
+          },
+        ],
+      },
+    },
+    {
+      name: "an extra output-text field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "hello",
+                annotations: [],
+                file_url: "https://attacker.invalid/file",
+              },
+            ],
+            status: "completed",
+            id: "msg_0123456789abcdef",
+          },
+        ],
+      },
+    },
+    {
+      name: "an extra function-call field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [
+          {
+            type: "function_call",
+            id: "fc_0123456789abcdef",
+            call_id: "call_0123456789abcdef",
+            name: "lookup_memory",
+            arguments: "{}",
+            url: "https://attacker.invalid/call",
+          },
+        ],
+      },
+    },
+    {
+      name: "an extra function-call-output field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [
+          {
+            type: "function_call_output",
+            call_id: "call_0123456789abcdef",
+            output: "done",
+            file_id: "file-123",
+          },
+        ],
+      },
+    },
+    {
+      name: "an extra user-message field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "hello" }],
+            name: "attacker-controlled",
+          },
+        ],
+      },
+    },
+    {
+      name: "an extra input-text field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "hello",
+                image_url: "https://attacker.invalid/image",
+              },
+            ],
           },
         ],
       },

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -18,6 +18,7 @@ import type { HonchoAuthBrokerConfig } from "../config.js";
 
 const BROKER_TOKEN = "broker-test-token-that-is-at-least-32-characters";
 const OAUTH_TOKEN = "oauth-access-token-never-returned-to-the-client";
+const EXTERNAL_CLI_TOKEN = "external-cli-token-that-must-not-be-used";
 
 const config: HonchoAuthBrokerConfig = {
   enabled: true,
@@ -111,22 +112,41 @@ async function invokeBrokerDirectly(
 }
 
 function canonicalResolverHarness(profileIds: string[] = ["openai:codex"]) {
+  const store = {
+    version: 1,
+    profiles: Object.fromEntries(
+      profileIds.map((profileId) => [
+        profileId,
+        {
+          type: "oauth" as const,
+          provider: "openai",
+          access: OAUTH_TOKEN,
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+          accountId: "account-123",
+        },
+      ]),
+    ),
+  };
   const resolveAgentDir = vi.fn(() => "/agent/main");
-  const listUsableProviderAuthProfileIds = vi.fn(() => ({
-    agentDir: "/agent/main",
-    profileIds,
-  }));
-  const resolveApiKeyForProvider = vi.fn(async () => ({
-    apiKey: OAUTH_TOKEN,
-    mode: "oauth" as const,
-  }));
-  const resolveProviderAuthProfileMetadata = vi.fn(() => ({ accountId: "account-123" }));
+  const loadAuthProfileStoreWithoutExternalProfiles = vi.fn(() => store);
+  const listProfilesForProvider = vi.fn(() => profileIds);
+  const resolveApiKeyForProvider = vi.fn(
+    async (params: { store?: typeof store; profileId?: string }) => {
+      const profile = params.profileId ? params.store?.profiles[params.profileId] : undefined;
+      return {
+        apiKey: profile?.access ?? EXTERNAL_CLI_TOKEN,
+        mode: "oauth" as const,
+        profileId: params.profileId,
+      };
+    },
+  );
   const resolveOpenAICodexAuthIdentity = vi.fn(() => ({ accountId: "account-123" }));
   const dependencies = {
     resolveAgentDir,
-    listUsableProviderAuthProfileIds,
+    loadAuthProfileStoreWithoutExternalProfiles,
+    listProfilesForProvider,
     resolveApiKeyForProvider,
-    resolveProviderAuthProfileMetadata,
     resolveOpenAICodexAuthIdentity,
   } as unknown as CanonicalCodexCredentialDependencies;
   const api = {
@@ -136,11 +156,12 @@ function canonicalResolverHarness(profileIds: string[] = ["openai:codex"]) {
   return {
     api,
     dependencies,
-    listUsableProviderAuthProfileIds,
+    listProfilesForProvider,
+    loadAuthProfileStoreWithoutExternalProfiles,
     resolveAgentDir,
     resolveApiKeyForProvider,
     resolveOpenAICodexAuthIdentity,
-    resolveProviderAuthProfileMetadata,
+    store,
   };
 }
 
@@ -190,19 +211,17 @@ describe("canonical Codex OAuth resolution", () => {
     });
 
     expect(harness.resolveAgentDir).toHaveBeenCalledWith({}, "main");
-    expect(harness.listUsableProviderAuthProfileIds).toHaveBeenCalledWith({
-      provider: "openai",
-      cfg: {},
-      agentDir: "/agent/main",
-      profileTypes: ["oauth"],
-      allowKeychainPrompt: false,
-      includeExternalCliAuth: false,
-    });
+    expect(harness.loadAuthProfileStoreWithoutExternalProfiles).toHaveBeenCalledWith(
+      "/agent/main",
+      { allowKeychainPrompt: false },
+    );
+    expect(harness.listProfilesForProvider).toHaveBeenCalledWith(harness.store, "openai");
     expect(harness.resolveApiKeyForProvider).toHaveBeenCalledTimes(1);
     expect(harness.resolveApiKeyForProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "openai",
         agentDir: "/agent/main",
+        store: harness.store,
         profileId: "openai:codex",
         lockedProfile: true,
         forceRefresh: false,
@@ -210,8 +229,25 @@ describe("canonical Codex OAuth resolution", () => {
     );
   });
 
+  it("cannot replace the stored OAuth token with a same-ID external CLI token", async () => {
+    const harness = canonicalResolverHarness();
+
+    const credential = await resolveCanonicalOpenAICodexCredential(
+      harness.api,
+      config,
+      {},
+      harness.dependencies,
+    );
+
+    expect(credential.accessToken).toBe(OAUTH_TOKEN);
+    expect(credential.accessToken).not.toBe(EXTERNAL_CLI_TOKEN);
+    expect(harness.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ store: harness.store }),
+    );
+  });
+
   it("fails closed when the pin is unavailable or a retry requests another profile", async () => {
-    const unavailable = canonicalResolverHarness(["openai:other"]);
+    const unavailable = canonicalResolverHarness([]);
     await expect(
       resolveCanonicalOpenAICodexCredential(
         unavailable.api,
@@ -231,7 +267,7 @@ describe("canonical Codex OAuth resolution", () => {
         mismatchedRetry.dependencies,
       ),
     ).rejects.toThrow("OpenAI Codex OAuth is unavailable");
-    expect(mismatchedRetry.listUsableProviderAuthProfileIds).not.toHaveBeenCalled();
+    expect(mismatchedRetry.loadAuthProfileStoreWithoutExternalProfiles).not.toHaveBeenCalled();
   });
 });
 

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createConfiguredBrokerBearerTokenResolver,
   createHonchoAuthBrokerHandler,
   HONCHO_AUTH_BROKER_BASE_PATH,
   HONCHO_MAX_EMBEDDING_INPUT_CHARS,
@@ -165,11 +166,15 @@ function canonicalResolverHarness(profileIds: string[] = ["openai:codex"]) {
   };
 }
 
-function brokerBearerResolverHarness(rawBearerToken: unknown, enabled = true) {
+function brokerBearerResolverHarness(
+  rawBearerToken: unknown,
+  enabled = true,
+  pluginId = "openclaw-honcho",
+) {
   const sourceConfig = {
     plugins: {
       entries: {
-        "openclaw-honcho": {
+        [pluginId]: {
           config: {
             authBroker: {
               enabled,
@@ -269,6 +274,84 @@ describe("canonical Codex OAuth resolution", () => {
     ).rejects.toThrow("OpenAI Codex OAuth is unavailable");
     expect(mismatchedRetry.loadAuthProfileStoreWithoutExternalProfiles).not.toHaveBeenCalled();
   });
+
+  it("fails closed when the pinned stored profile is not OAuth", async () => {
+    const harness = canonicalResolverHarness();
+    harness.store.profiles["openai:codex"] = {
+      type: "api_key",
+      provider: "openai",
+      key: "platform-api-key-that-must-not-be-used",
+    } as never;
+
+    await expect(
+      resolveCanonicalOpenAICodexCredential(harness.api, config, {}, harness.dependencies),
+    ).rejects.toMatchObject({
+      name: "BrokerCredentialUnavailableError",
+      message: "OpenAI Codex OAuth is unavailable",
+    });
+    expect(harness.resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("normalizes config, agent-directory, and store failures", async () => {
+    const configFailure = canonicalResolverHarness();
+    const failingApi = {
+      config: {},
+      runtime: {
+        config: {
+          current: () => {
+            throw new Error("config snapshot failed");
+          },
+        },
+      },
+    } as never;
+    await expect(
+      resolveCanonicalOpenAICodexCredential(
+        failingApi,
+        config,
+        {},
+        configFailure.dependencies,
+      ),
+    ).rejects.toMatchObject({ name: "BrokerCredentialUnavailableError" });
+
+    const agentDirFailure = canonicalResolverHarness();
+    agentDirFailure.resolveAgentDir.mockImplementation(() => {
+      throw new Error("agent path failed");
+    });
+    await expect(
+      resolveCanonicalOpenAICodexCredential(
+        agentDirFailure.api,
+        config,
+        {},
+        agentDirFailure.dependencies,
+      ),
+    ).rejects.toMatchObject({ name: "BrokerCredentialUnavailableError" });
+
+    const storeFailure = canonicalResolverHarness();
+    storeFailure.loadAuthProfileStoreWithoutExternalProfiles.mockImplementation(() => {
+      throw new Error("store read failed");
+    });
+    await expect(
+      resolveCanonicalOpenAICodexCredential(
+        storeFailure.api,
+        config,
+        {},
+        storeFailure.dependencies,
+      ),
+    ).rejects.toMatchObject({ name: "BrokerCredentialUnavailableError" });
+
+    const malformedStore = canonicalResolverHarness();
+    malformedStore.loadAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
+      version: 1,
+    } as never);
+    await expect(
+      resolveCanonicalOpenAICodexCredential(
+        malformedStore.api,
+        config,
+        {},
+        malformedStore.dependencies,
+      ),
+    ).rejects.toMatchObject({ name: "BrokerCredentialUnavailableError" });
+  });
 });
 
 describe("broker bearer SecretRef resolution", () => {
@@ -292,7 +375,9 @@ describe("broker bearer SecretRef resolution", () => {
   ])("rejects $name before reading secret material", async ({ rawBearerToken }) => {
     const harness = brokerBearerResolverHarness(rawBearerToken);
 
-    await expect(resolveConfiguredBrokerBearerToken(harness.dependencies)).resolves.toBeUndefined();
+    await expect(
+      resolveConfiguredBrokerBearerToken("openclaw-honcho", harness.dependencies),
+    ).resolves.toBeUndefined();
     expect(harness.getRuntimeConfigSourceSnapshot).toHaveBeenCalledTimes(1);
     expect(harness.resolveConfiguredSecretInputString).not.toHaveBeenCalled();
   });
@@ -307,9 +392,9 @@ describe("broker bearer SecretRef resolution", () => {
       };
       const harness = brokerBearerResolverHarness(rawBearerToken);
 
-      await expect(resolveConfiguredBrokerBearerToken(harness.dependencies)).resolves.toBe(
-        BROKER_TOKEN,
-      );
+      await expect(
+        resolveConfiguredBrokerBearerToken("openclaw-honcho", harness.dependencies),
+      ).resolves.toBe(BROKER_TOKEN);
       expect(harness.resolveConfiguredSecretInputString).toHaveBeenCalledWith(
         expect.objectContaining({
           config: expect.any(Object),
@@ -331,8 +416,120 @@ describe("broker bearer SecretRef resolution", () => {
       false,
     );
 
-    await expect(resolveConfiguredBrokerBearerToken(harness.dependencies)).resolves.toBeUndefined();
+    await expect(
+      resolveConfiguredBrokerBearerToken("openclaw-honcho", harness.dependencies),
+    ).resolves.toBeUndefined();
     expect(harness.resolveConfiguredSecretInputString).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "the reference does not resolve",
+      resolved: { unresolvedRefReason: "unavailable" },
+    },
+    {
+      name: "the resolved secret is too short",
+      resolved: { value: "short-token" },
+    },
+  ])("fails closed when $name", async ({ resolved }) => {
+    const harness = brokerBearerResolverHarness({
+      source: "env",
+      provider: "default",
+      id: "HONCHO_AUTH_BROKER_TOKEN",
+    });
+    harness.resolveConfiguredSecretInputString.mockResolvedValue(resolved);
+
+    await expect(
+      resolveConfiguredBrokerBearerToken("openclaw-honcho", harness.dependencies),
+    ).resolves.toBeUndefined();
+  });
+
+  it("derives the authored entry key and SecretRef path from the plugin API id", async () => {
+    const pluginId = "renamed-honcho";
+    const rawBearerToken = {
+      source: "file",
+      provider: "default",
+      id: "HONCHO_AUTH_BROKER_TOKEN",
+    };
+    const harness = brokerBearerResolverHarness(rawBearerToken, true, pluginId);
+
+    await expect(
+      resolveConfiguredBrokerBearerToken(pluginId, harness.dependencies),
+    ).resolves.toBe(BROKER_TOKEN);
+    expect(harness.resolveConfiguredSecretInputString).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: rawBearerToken,
+        path: "plugins.entries.renamed-honcho.config.authBroker.bearerToken",
+      }),
+    );
+  });
+
+  it("caches successful resolution until expiry", async () => {
+    let now = 1_000;
+    const harness = brokerBearerResolverHarness({
+      source: "exec",
+      provider: "default",
+      id: "HONCHO_AUTH_BROKER_TOKEN",
+    });
+    const resolveBearerToken = createConfiguredBrokerBearerTokenResolver(
+      "openclaw-honcho",
+      harness.dependencies,
+      { cacheTtlMs: 100, now: () => now },
+    );
+
+    await expect(resolveBearerToken(BROKER_TOKEN)).resolves.toBe(BROKER_TOKEN);
+    await expect(resolveBearerToken(BROKER_TOKEN)).resolves.toBe(BROKER_TOKEN);
+    expect(harness.resolveConfiguredSecretInputString).toHaveBeenCalledTimes(1);
+
+    now += 101;
+    await expect(resolveBearerToken(BROKER_TOKEN)).resolves.toBe(BROKER_TOKEN);
+    expect(harness.resolveConfiguredSecretInputString).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one in-flight SecretRef resolution across concurrent requests", async () => {
+    let settle!: (value: { value: string }) => void;
+    const pending = new Promise<{ value: string }>((resolve) => {
+      settle = resolve;
+    });
+    const harness = brokerBearerResolverHarness({
+      source: "exec",
+      provider: "default",
+      id: "HONCHO_AUTH_BROKER_TOKEN",
+    });
+    harness.resolveConfiguredSecretInputString.mockReturnValue(pending);
+    const resolveBearerToken = createConfiguredBrokerBearerTokenResolver(
+      "openclaw-honcho",
+      harness.dependencies,
+    );
+
+    const first = resolveBearerToken(BROKER_TOKEN);
+    const second = resolveBearerToken(BROKER_TOKEN);
+    expect(harness.resolveConfiguredSecretInputString).toHaveBeenCalledTimes(1);
+    settle({ value: BROKER_TOKEN });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([BROKER_TOKEN, BROKER_TOKEN]);
+  });
+
+  it("refreshes a still-live cache when the presented token rotates", async () => {
+    const rotatedToken = "rotated-broker-test-token-that-is-at-least-32-characters";
+    const harness = brokerBearerResolverHarness({
+      source: "file",
+      provider: "default",
+      id: "HONCHO_AUTH_BROKER_TOKEN",
+    });
+    harness.resolveConfiguredSecretInputString
+      .mockResolvedValueOnce({ value: BROKER_TOKEN })
+      .mockResolvedValueOnce({ value: rotatedToken });
+    const resolveBearerToken = createConfiguredBrokerBearerTokenResolver(
+      "openclaw-honcho",
+      harness.dependencies,
+      { cacheTtlMs: 60_000 },
+    );
+
+    await expect(resolveBearerToken(BROKER_TOKEN)).resolves.toBe(BROKER_TOKEN);
+    await expect(resolveBearerToken(rotatedToken)).resolves.toBe(rotatedToken);
+    await expect(resolveBearerToken(rotatedToken)).resolves.toBe(rotatedToken);
+    expect(harness.resolveConfiguredSecretInputString).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -743,7 +940,7 @@ describe("Honcho auth broker", () => {
 
   it("registers one plugin-authenticated prefix only when enabled", () => {
     const registerHttpRoute = vi.fn();
-    const api = { registerHttpRoute } as never;
+    const api = { id: "openclaw-honcho", registerHttpRoute } as never;
 
     registerHonchoAuthBroker(api, { ...config, enabled: false });
     expect(registerHttpRoute).not.toHaveBeenCalled();

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -1,0 +1,495 @@
+import { EventEmitter, once } from "node:events";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHonchoAuthBrokerHandler,
+  HONCHO_AUTH_BROKER_BASE_PATH,
+  HONCHO_MAX_EMBEDDING_INPUT_CHARS,
+  HONCHO_MAX_EMBEDDING_INPUTS,
+  registerHonchoAuthBroker,
+  type HonchoAuthBrokerDependencies,
+} from "../broker.js";
+import type { HonchoAuthBrokerConfig } from "../config.js";
+
+const BROKER_TOKEN = "broker-test-token-that-is-at-least-32-characters";
+const OAUTH_TOKEN = "oauth-access-token-never-returned-to-the-client";
+
+const config: HonchoAuthBrokerConfig = {
+  enabled: true,
+  bearerToken: BROKER_TOKEN,
+  authAgentId: "main",
+  responseModels: ["gpt-5.4-mini", "gpt-5.4"],
+  maxRequestBytes: 4096,
+  timeoutMs: 5000,
+};
+
+const servers = new Set<Server>();
+
+afterEach(async () => {
+  await Promise.all(
+    [...servers].map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+          server.closeAllConnections?.();
+        }),
+    ),
+  );
+  servers.clear();
+});
+
+async function withBroker(
+  dependencies: HonchoAuthBrokerDependencies,
+  run: (baseUrl: string) => Promise<void>,
+  brokerConfig = config,
+): Promise<void> {
+  const handler = createHonchoAuthBrokerHandler(brokerConfig, dependencies);
+  const server = createServer(async (req, res) => {
+    const handled = await handler(req, res);
+    if (!handled && !res.writableEnded) {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+  });
+  servers.add(server);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("missing loopback address");
+  await run(`http://127.0.0.1:${address.port}`);
+}
+
+function defaultDependencies(fetchImpl: typeof fetch): HonchoAuthBrokerDependencies {
+  return {
+    fetch: fetchImpl,
+    resolveBearerToken: vi.fn(async () => BROKER_TOKEN),
+    resolveCredential: vi.fn(async () => ({
+      accessToken: OAUTH_TOKEN,
+      accountId: "account-123",
+      profileId: "openai:codex",
+    })),
+  };
+}
+
+async function invokeBrokerDirectly(
+  body: string,
+  dependencies: HonchoAuthBrokerDependencies,
+  brokerConfig: HonchoAuthBrokerConfig,
+): Promise<{ body: string; statusCode: number }> {
+  const request = Readable.from([body]) as IncomingMessage;
+  request.method = "POST";
+  request.url = `${HONCHO_AUTH_BROKER_BASE_PATH}/embeddings`;
+  request.headers = {
+    authorization: `Bearer ${BROKER_TOKEN}`,
+    "content-type": "application/json",
+  };
+
+  const responseEvents = new EventEmitter();
+  let responseBody = "";
+  const response = Object.assign(responseEvents, {
+    statusCode: 200,
+    headersSent: false,
+    writableEnded: false,
+    setHeader: vi.fn(),
+    end(chunk?: string | Buffer) {
+      responseBody += chunk?.toString() ?? "";
+      this.headersSent = true;
+      this.writableEnded = true;
+      responseEvents.emit("close");
+      return this;
+    },
+  }) as unknown as ServerResponse;
+
+  await createHonchoAuthBrokerHandler(brokerConfig, dependencies)(request, response);
+  return { body: responseBody, statusCode: response.statusCode };
+}
+
+describe("Honcho auth broker", () => {
+  it("rejects unauthenticated requests before resolving OAuth or reading upstream", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const resolveBearerToken = vi.fn(async () => BROKER_TOKEN);
+    const resolveCredential = vi.fn(async () => ({
+      accessToken: OAUTH_TOKEN,
+      accountId: "account-123",
+      profileId: "openai:codex",
+    }));
+
+    await withBroker(
+      {
+        fetch: fetchMock,
+        resolveBearerToken,
+        resolveCredential,
+      },
+      async (baseUrl) => {
+        const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/embeddings`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ model: "text-embedding-3-small", input: "hello" }),
+        });
+        expect(response.status).toBe(401);
+        expect(response.headers.get("www-authenticate")).toContain("Bearer");
+        expect(await response.text()).not.toContain(BROKER_TOKEN);
+      },
+    );
+
+    expect(resolveBearerToken).not.toHaveBeenCalled();
+    expect(resolveCredential).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when its configured bearer token cannot be resolved", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const resolveCredential = vi.fn(async () => ({
+      accessToken: OAUTH_TOKEN,
+      accountId: "account-123",
+      profileId: "openai:codex",
+    }));
+
+    await withBroker(
+      {
+        fetch: fetchMock,
+        resolveBearerToken: vi.fn(async () => {
+          throw new Error("secret provider unavailable");
+        }),
+        resolveCredential,
+      },
+      async (baseUrl) => {
+        const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/embeddings`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${BROKER_TOKEN}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ model: "text-embedding-3-small", input: "hello" }),
+        });
+        expect(response.status).toBe(503);
+        expect(await response.text()).not.toContain("secret provider unavailable");
+      },
+    );
+
+    expect(resolveCredential).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards bounded embeddings with canonical Codex OAuth to the fixed endpoint", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            model: "text-embedding-3-small",
+            data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2] }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const dependencies = defaultDependencies(fetchMock);
+
+    await withBroker(dependencies, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/embeddings`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+          "x-untrusted-header": "must-not-forward",
+        },
+        body: JSON.stringify({ model: "text-embedding-3-small", input: "hello" }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        object: "list",
+        model: "text-embedding-3-small",
+        data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2] }],
+      });
+    });
+
+    expect(dependencies.resolveCredential).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("https://api.openai.com/v1/embeddings");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${OAUTH_TOKEN}`);
+    expect(headers.get("chatgpt-account-id")).toBeNull();
+    expect(JSON.parse(String(init?.body))).toEqual({
+      model: "text-embedding-3-small",
+      input: ["hello"],
+    });
+  });
+
+  it.each([
+    {
+      name: "an unsupported model",
+      body: { model: "text-embedding-3-large", input: "hello" },
+    },
+    {
+      name: "a caller-controlled URL",
+      body: {
+        model: "text-embedding-3-small",
+        input: "hello",
+        url: "https://attacker.invalid/v1/embeddings",
+      },
+    },
+    {
+      name: "too many inputs",
+      body: {
+        model: "text-embedding-3-small",
+        input: Array.from({ length: HONCHO_MAX_EMBEDDING_INPUTS + 1 }, () => "x"),
+      },
+    },
+    {
+      name: "an oversized input",
+      body: {
+        model: "text-embedding-3-small",
+        input: "x".repeat(HONCHO_MAX_EMBEDDING_INPUT_CHARS + 1),
+      },
+    },
+  ])("rejects embeddings with $name before credential resolution", async ({ body }) => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const dependencies = defaultDependencies(fetchMock);
+
+    await withBroker(
+      dependencies,
+      async (baseUrl) => {
+        const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/embeddings`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${BROKER_TOKEN}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        expect(response.status).toBe(400);
+      },
+      { ...config, maxRequestBytes: 128 * 1024 },
+    );
+
+    expect(dependencies.resolveCredential).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "a model outside the allowlist",
+      body: { model: "gpt-4.1", input: "hello" },
+    },
+    {
+      name: "a caller-controlled URL",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        url: "https://attacker.invalid/v1/responses",
+      },
+    },
+  ])("rejects Responses with $name before OAuth resolution", async ({ body }) => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const dependencies = defaultDependencies(fetchMock);
+
+    await withBroker(dependencies, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    expect(dependencies.resolveCredential).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards Codex Responses with account routing, streaming headers, and store disabled", async () => {
+    const sse = [
+      'data: {"type":"response.created","response":{"id":"resp-1"}}',
+      'data: {"type":"response.completed","response":{"id":"resp-1","status":"completed"}}',
+      "",
+    ].join("\n\n");
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(sse, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+    );
+
+    await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "gpt-5.4-mini", input: "hello", stream: true, store: true }),
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toContain("no-store");
+      expect(response.headers.get("content-type")).toContain("text/event-stream");
+      expect(response.headers.get("chatgpt-account-id")).toBeNull();
+      expect(await response.text()).toContain("response.completed");
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("https://chatgpt.com/backend-api/codex/responses");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${OAUTH_TOKEN}`);
+    expect(headers.get("chatgpt-account-id")).toBe("account-123");
+    expect(headers.get("originator")).toBe("openclaw");
+    expect(headers.get("openai-beta")).toBe("responses=experimental");
+    expect(headers.get("accept")).toBe("text/event-stream");
+    expect(headers.get("session_id")).toMatch(/^honcho-/);
+    expect(headers.get("x-client-request-id")).toBe(headers.get("session_id"));
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      model: "gpt-5.4-mini",
+      input: "hello",
+      stream: true,
+      store: false,
+    });
+  });
+
+  it("fails closed without exposing rejected OAuth material", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ error: { message: `bad ${OAUTH_TOKEN}` } }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "gpt-5.4-mini", input: "hello" }),
+      });
+      const text = await response.text();
+      expect(response.status).toBe(503);
+      expect(text).not.toContain(OAUTH_TOKEN);
+      expect(text).not.toContain(BROKER_TOKEN);
+    });
+  });
+
+  it("force-refreshes the same OAuth profile once after a 401", async () => {
+    const refreshedToken = "refreshed-oauth-access-token-never-returned-to-the-client";
+    const resolveCredential = vi.fn(async (options?: { forceRefresh?: boolean }) => ({
+      accessToken: options?.forceRefresh ? refreshedToken : OAUTH_TOKEN,
+      accountId: "account-123",
+      profileId: "openai:codex",
+    }));
+    const fetchMock = vi.fn<typeof fetch>(async (_url, init) => {
+      const token = new Headers(init?.headers).get("authorization");
+      return token === `Bearer ${refreshedToken}`
+        ? new Response(JSON.stringify({ id: "resp-1", status: "completed" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        : new Response("unauthorized", { status: 401 });
+    });
+    const dependencies = defaultDependencies(fetchMock);
+    dependencies.resolveCredential = resolveCredential;
+
+    await withBroker(dependencies, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "gpt-5.4-mini", input: "hello" }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ status: "completed" });
+    });
+
+    expect(resolveCredential).toHaveBeenNthCalledWith(1);
+    expect(resolveCredential).toHaveBeenNthCalledWith(2, {
+      forceRefresh: true,
+      profileId: "openai:codex",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("never refreshes or retries an OAuth credential after a 403", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("forbidden", { status: 403 }));
+    const dependencies = defaultDependencies(fetchMock);
+
+    await withBroker(dependencies, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "gpt-5.4-mini", input: "hello" }),
+      });
+      expect(response.status).toBe(503);
+    });
+
+    expect(dependencies.resolveCredential).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds request bodies before resolving OpenAI OAuth", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const resolveCredential = vi.fn(async () => ({
+      accessToken: OAUTH_TOKEN,
+      accountId: "account-123",
+      profileId: "openai:codex",
+    }));
+    const response = await invokeBrokerDirectly(
+      JSON.stringify({ input: "x".repeat(2000) }),
+      {
+        fetch: fetchMock,
+        resolveBearerToken: vi.fn(async () => BROKER_TOKEN),
+        resolveCredential,
+      },
+      { ...config, maxRequestBytes: 128 },
+    );
+    expect(response.statusCode).toBe(413);
+    expect(response.body).toBe("Payload too large");
+    expect(resolveCredential).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("registers one plugin-authenticated prefix only when enabled", () => {
+    const registerHttpRoute = vi.fn();
+    const api = { registerHttpRoute } as never;
+
+    registerHonchoAuthBroker(api, { ...config, enabled: false });
+    expect(registerHttpRoute).not.toHaveBeenCalled();
+
+    registerHonchoAuthBroker(api, config);
+    expect(registerHttpRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: HONCHO_AUTH_BROKER_BASE_PATH,
+        auth: "plugin",
+        match: "prefix",
+        handler: expect.any(Function),
+      }),
+    );
+  });
+
+  it("does not claim paths outside the two exact broker endpoints", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+      const response = await fetch(
+        `${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses/unexpected`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${BROKER_TOKEN}`,
+            "content-type": "application/json",
+          },
+          body: "{}",
+        },
+      );
+      expect(response.status).toBe(404);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -836,6 +836,43 @@ describe("Honcho auth broker", () => {
     expect(JSON.parse(String(init?.body))).toMatchObject({ input });
   });
 
+  it.each(["low", "medium", "high", "xhigh"])(
+    "forwards the relay's exact nested text and %s reasoning shape",
+    async (effort) => {
+      const fetchMock = vi.fn<typeof fetch>(
+        async () =>
+          new Response(JSON.stringify({ id: "resp-1", status: "completed" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      const nestedOptions = {
+        text: { verbosity: "low" },
+        reasoning: { effort, summary: "auto" },
+      };
+
+      await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+        const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${BROKER_TOKEN}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "gpt-5.4-mini",
+            input: "hello",
+            ...nestedOptions,
+          }),
+        });
+        expect(response.status).toBe(200);
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] ?? [];
+      expect(JSON.parse(String(init?.body))).toMatchObject(nestedOptions);
+    },
+  );
+
   it("forwards the relay's exact caller-defined function tool shape", async () => {
     const fetchMock = vi.fn<typeof fetch>(
       async () =>
@@ -927,6 +964,54 @@ describe("Honcho auth broker", () => {
   });
 
   it.each([
+    {
+      name: "an unknown nested text field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        text: { verbosity: "low", format: { type: "text" } },
+      },
+    },
+    {
+      name: "a malformed nested text value",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        text: { verbosity: "high" },
+      },
+    },
+    {
+      name: "an unknown nested reasoning field",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        reasoning: { effort: "medium", summary: "auto", encrypted_content: "opaque" },
+      },
+    },
+    {
+      name: "a malformed nested reasoning effort",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        reasoning: { effort: "none", summary: "auto" },
+      },
+    },
+    {
+      name: "a malformed nested reasoning summary",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        reasoning: { effort: "medium", summary: "detailed" },
+      },
+    },
+    {
+      name: "an incomplete nested reasoning shape",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        reasoning: { effort: "medium" },
+      },
+    },
     {
       name: "a non-function tool definition",
       body: {
@@ -1342,7 +1427,7 @@ describe("Honcho auth broker", () => {
       { ...config, maxRequestBytes: 128 },
     );
     expect(response.statusCode).toBe(413);
-    expect(response.body).toBe("Payload too large");
+    expect(response.body).toMatch(/\S/);
     expect(resolveCredential).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -260,7 +260,7 @@ describe("canonical Codex OAuth resolution", () => {
         {},
         unavailable.dependencies,
       ),
-    ).rejects.toThrow("OpenAI Codex OAuth is unavailable");
+    ).rejects.toMatchObject({ name: "BrokerCredentialUnavailableError" });
     expect(unavailable.resolveApiKeyForProvider).not.toHaveBeenCalled();
 
     const mismatchedRetry = canonicalResolverHarness();
@@ -271,7 +271,7 @@ describe("canonical Codex OAuth resolution", () => {
         { forceRefresh: true, profileId: "openai:other" },
         mismatchedRetry.dependencies,
       ),
-    ).rejects.toThrow("OpenAI Codex OAuth is unavailable");
+    ).rejects.toMatchObject({ name: "BrokerCredentialUnavailableError" });
     expect(mismatchedRetry.loadAuthProfileStoreWithoutExternalProfiles).not.toHaveBeenCalled();
   });
 
@@ -285,10 +285,7 @@ describe("canonical Codex OAuth resolution", () => {
 
     await expect(
       resolveCanonicalOpenAICodexCredential(harness.api, config, {}, harness.dependencies),
-    ).rejects.toMatchObject({
-      name: "BrokerCredentialUnavailableError",
-      message: "OpenAI Codex OAuth is unavailable",
-    });
+    ).rejects.toMatchObject({ name: "BrokerCredentialUnavailableError" });
     expect(harness.resolveApiKeyForProvider).not.toHaveBeenCalled();
   });
 
@@ -778,6 +775,66 @@ describe("Honcho auth broker", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "a hosted web-search tool",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        tools: [{ type: "web_search_preview" }],
+      },
+    },
+    {
+      name: "a file input",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [{ role: "user", content: [{ type: "input_file", file_id: "file-123" }] }],
+      },
+    },
+    {
+      name: "a file URL input",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_file", file_url: "https://attacker.invalid/file" }],
+          },
+        ],
+      },
+    },
+    {
+      name: "an image input",
+      body: {
+        model: "gpt-5.4-mini",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_image", image_url: "https://attacker.invalid/image" }],
+          },
+        ],
+      },
+    },
+  ])("rejects Responses with $name before OAuth resolution", async ({ body }) => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const dependencies = defaultDependencies(fetchMock);
+
+    await withBroker(dependencies, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    expect(dependencies.resolveCredential).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("forwards Codex Responses with account routing, streaming headers, and store disabled", async () => {
     const sse = [
       'data: {"type":"response.created","response":{"id":"resp-1"}}',
@@ -853,6 +910,67 @@ describe("Honcho auth broker", () => {
       expect(response.status).toBe(503);
       expect(text).not.toContain(OAUTH_TOKEN);
       expect(text).not.toContain(BROKER_TOKEN);
+    });
+  });
+
+  it.each([
+    { retryAfter: "30", expectedRetryAfter: "30" },
+    { retryAfter: "provider-controlled", expectedRetryAfter: null },
+  ])(
+    "sanitizes rate-limit failures while forwarding only safe Retry-After values",
+    async ({ retryAfter, expectedRetryAfter }) => {
+      const providerError = "provider-only rate-limit detail that must not reach Honcho";
+      const fetchMock = vi.fn<typeof fetch>(
+        async () =>
+          new Response(JSON.stringify({ error: { message: providerError } }), {
+            status: 429,
+            headers: { "content-type": "application/json", "retry-after": retryAfter },
+          }),
+      );
+
+      await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+        const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${BROKER_TOKEN}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ model: "gpt-5.4-mini", input: "hello" }),
+        });
+        const body = await response.text();
+        expect(response.status).toBe(429);
+        expect(response.headers.get("retry-after")).toBe(expectedRetryAfter);
+        expect(body).not.toContain(providerError);
+        expect(body).toContain("upstream_rate_limited");
+      });
+    },
+  );
+
+  it("sanitizes provider error bodies", async () => {
+    const providerError = "provider-only internal diagnostic that must not reach Honcho";
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ error: { message: providerError } }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await withBroker(defaultDependencies(fetchMock), async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "gpt-5.4-mini", input: "hello" }),
+      });
+      const body = await response.text();
+      expect(response.status).toBe(502);
+      expect(body).not.toContain(providerError);
+      expect(body).not.toContain(OAUTH_TOKEN);
+      expect(body).not.toContain(BROKER_TOKEN);
+      expect(body).toContain("upstream_error");
     });
   });
 

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -882,6 +882,52 @@ describe("Honcho auth broker", () => {
 
   it.each([
     {
+      name: 'tool_choice "required" without declared tools',
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        tool_choice: "required",
+      },
+    },
+    {
+      name: "a named function tool_choice absent from declared tools",
+      body: {
+        model: "gpt-5.4-mini",
+        input: "hello",
+        tools: [
+          {
+            type: "function",
+            name: "lookup_memory",
+            description: "Look up memory",
+            parameters: { type: "object", properties: {} },
+            strict: false,
+          },
+        ],
+        tool_choice: { type: "function", name: "missing" },
+      },
+    },
+  ])("rejects Responses with $name before OAuth resolution", async ({ body }) => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const dependencies = defaultDependencies(fetchMock);
+
+    await withBroker(dependencies, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${HONCHO_AUTH_BROKER_BASE_PATH}/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${BROKER_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    expect(dependencies.resolveCredential).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
       name: "a non-function tool definition",
       body: {
         model: "gpt-5.4-mini",
@@ -1159,6 +1205,7 @@ describe("Honcho auth broker", () => {
 
   it.each([
     { retryAfter: "30", expectedRetryAfter: "30" },
+    { retryAfter: "86401", expectedRetryAfter: null },
     { retryAfter: "provider-controlled", expectedRetryAfter: null },
   ])(
     "sanitizes rate-limit failures while forwarding only safe Retry-After values",

--- a/test/broker.test.ts
+++ b/test/broker.test.ts
@@ -343,7 +343,12 @@ describe("Honcho auth broker", () => {
     expect(headers.get("x-client-request-id")).toBe(headers.get("session_id"));
     expect(JSON.parse(String(init?.body))).toMatchObject({
       model: "gpt-5.4-mini",
-      input: "hello",
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+        },
+      ],
       stream: true,
       store: false,
     });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_AUTH_BROKER_MAX_REQUEST_BYTES,
+  DEFAULT_AUTH_BROKER_RESPONSE_MODELS,
+  DEFAULT_AUTH_BROKER_TIMEOUT_MS,
+  honchoConfigSchema,
+} from "../config.js";
+
+const previousEnvToken = process.env.HONCHO_AUTH_BROKER_TOKEN;
+
+afterEach(() => {
+  if (previousEnvToken === undefined) {
+    delete process.env.HONCHO_AUTH_BROKER_TOKEN;
+  } else {
+    process.env.HONCHO_AUTH_BROKER_TOKEN = previousEnvToken;
+  }
+});
+
+describe("Honcho auth broker config", () => {
+  it("is disabled by default with bounded defaults", () => {
+    delete process.env.HONCHO_AUTH_BROKER_TOKEN;
+    const parsed = honchoConfigSchema.parse({});
+    expect(parsed.authBroker).toEqual({
+      enabled: false,
+      bearerToken: undefined,
+      authAgentId: undefined,
+      responseModels: DEFAULT_AUTH_BROKER_RESPONSE_MODELS,
+      maxRequestBytes: DEFAULT_AUTH_BROKER_MAX_REQUEST_BYTES,
+      timeoutMs: DEFAULT_AUTH_BROKER_TIMEOUT_MS,
+    });
+  });
+
+  it("requires a strong literal bearer token when enabled", () => {
+    delete process.env.HONCHO_AUTH_BROKER_TOKEN;
+    expect(() => honchoConfigSchema.parse({ authBroker: { enabled: true } })).toThrow(
+      /requires authBroker\.bearerToken/,
+    );
+    expect(() =>
+      honchoConfigSchema.parse({
+        authBroker: { enabled: true, bearerToken: "too-short" },
+      }),
+    ).toThrow(/at least 32 characters/);
+    expect(() =>
+      honchoConfigSchema.parse({
+        authBroker: { enabled: true, bearerToken: "${BROKER_TOKEN}" },
+      }),
+    ).toThrow(/at least 32 characters/);
+  });
+
+  it("accepts an OpenClaw SecretRef without resolving it in plugin code", () => {
+    const bearerToken = {
+      source: "env" as const,
+      provider: "default",
+      id: "HONCHO_AUTH_BROKER_TOKEN",
+    };
+    const parsed = honchoConfigSchema.parse({
+      authBroker: {
+        enabled: true,
+        bearerToken,
+        authAgentId: "atlas",
+        responseModels: ["gpt-5.4-mini"],
+        maxRequestBytes: 8192,
+        timeoutMs: 12_000,
+      },
+    });
+    expect(parsed.authBroker).toEqual({
+      enabled: true,
+      bearerToken,
+      authAgentId: "atlas",
+      responseModels: ["gpt-5.4-mini"],
+      maxRequestBytes: 8192,
+      timeoutMs: 12_000,
+    });
+  });
+
+  it("rejects unsupported SecretRef sources at the declared SDK minimum", () => {
+    expect(() =>
+      honchoConfigSchema.parse({
+        authBroker: {
+          enabled: true,
+          bearerToken: {
+            source: "store",
+            provider: "default",
+            id: "HONCHO_AUTH_BROKER_TOKEN",
+          },
+        },
+      }),
+    ).toThrow(/requires authBroker\.bearerToken/);
+  });
+
+  it("rejects invalid or duplicate Responses model allowlists", () => {
+    process.env.HONCHO_AUTH_BROKER_TOKEN = "broker-test-token-that-is-at-least-32-characters";
+    expect(() =>
+      honchoConfigSchema.parse({
+        authBroker: { enabled: true, responseModels: ["gpt-5.4", "../unexpected"] },
+      }),
+    ).toThrow(/invalid model ID/);
+    expect(() =>
+      honchoConfigSchema.parse({
+        authBroker: { enabled: true, responseModels: ["gpt-5.4", "gpt-5.4"] },
+      }),
+    ).toThrow(/duplicate model IDs/);
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -7,6 +7,15 @@ import {
 } from "../config.js";
 
 const previousEnvToken = process.env.HONCHO_AUTH_BROKER_TOKEN;
+const bearerToken = {
+  source: "env" as const,
+  provider: "default",
+  id: "HONCHO_AUTH_BROKER_TOKEN",
+};
+const requiredAuthScope = {
+  authAgentId: "main",
+  authProfileId: "openai:owner@example.com",
+};
 
 afterEach(() => {
   if (previousEnvToken === undefined) {
@@ -24,40 +33,86 @@ describe("Honcho auth broker config", () => {
       enabled: false,
       bearerToken: undefined,
       authAgentId: undefined,
+      authProfileId: undefined,
       responseModels: DEFAULT_AUTH_BROKER_RESPONSE_MODELS,
       maxRequestBytes: DEFAULT_AUTH_BROKER_MAX_REQUEST_BYTES,
       timeoutMs: DEFAULT_AUTH_BROKER_TIMEOUT_MS,
     });
   });
 
-  it("requires a strong literal bearer token when enabled", () => {
-    delete process.env.HONCHO_AUTH_BROKER_TOKEN;
-    expect(() => honchoConfigSchema.parse({ authBroker: { enabled: true } })).toThrow(
-      /requires authBroker\.bearerToken/,
-    );
+  it("requires an explicit SecretRef, agent, and profile without ambient fallback", () => {
+    process.env.HONCHO_AUTH_BROKER_TOKEN =
+      "ambient-broker-token-that-must-never-be-used";
     expect(() =>
       honchoConfigSchema.parse({
-        authBroker: { enabled: true, bearerToken: "too-short" },
+        authBroker: { enabled: true, ...requiredAuthScope },
       }),
-    ).toThrow(/at least 32 characters/);
+    ).toThrow(/requires an explicit authBroker\.bearerToken SecretRef/);
     expect(() =>
       honchoConfigSchema.parse({
-        authBroker: { enabled: true, bearerToken: "${BROKER_TOKEN}" },
+        authBroker: {
+          enabled: true,
+          bearerToken,
+          authProfileId: requiredAuthScope.authProfileId,
+        },
       }),
-    ).toThrow(/at least 32 characters/);
+    ).toThrow(/requires an explicit authBroker\.authAgentId/);
+    expect(() =>
+      honchoConfigSchema.parse({
+        authBroker: {
+          enabled: true,
+          bearerToken,
+          authAgentId: requiredAuthScope.authAgentId,
+        },
+      }),
+    ).toThrow(/requires an explicit authBroker\.authProfileId/);
+  });
+
+  it("accepts the strong bearer string produced by host SecretRef resolution", () => {
+    const resolvedToken = "broker-test-token-that-is-at-least-32-characters";
+    const parsed = honchoConfigSchema.parse({
+      authBroker: {
+        enabled: true,
+        bearerToken: resolvedToken,
+        ...requiredAuthScope,
+      },
+    });
+
+    expect(parsed.authBroker.bearerToken).toBe(resolvedToken);
+  });
+
+  it("rejects strings that cannot be strong host-resolved bearer values", () => {
+    expect(() =>
+      honchoConfigSchema.parse({
+        authBroker: {
+          enabled: true,
+          bearerToken: "${BROKER_TOKEN}",
+          ...requiredAuthScope,
+        },
+      }),
+    ).toThrow(/host-resolved string of at least 32 characters/);
+  });
+
+  it("rejects malformed explicit OAuth profile IDs", () => {
+    expect(() =>
+      honchoConfigSchema.parse({
+        authBroker: {
+          enabled: true,
+          bearerToken,
+          authAgentId: "main",
+          authProfileId: "openai:owner profile",
+        },
+      }),
+    ).toThrow(/invalid profile ID/);
   });
 
   it("accepts an OpenClaw SecretRef without resolving it in plugin code", () => {
-    const bearerToken = {
-      source: "env" as const,
-      provider: "default",
-      id: "HONCHO_AUTH_BROKER_TOKEN",
-    };
     const parsed = honchoConfigSchema.parse({
       authBroker: {
         enabled: true,
         bearerToken,
         authAgentId: "atlas",
+        authProfileId: "openai:owner@example.com",
         responseModels: ["gpt-5.4-mini"],
         maxRequestBytes: 8192,
         timeoutMs: 12_000,
@@ -67,6 +122,7 @@ describe("Honcho auth broker config", () => {
       enabled: true,
       bearerToken,
       authAgentId: "atlas",
+      authProfileId: "openai:owner@example.com",
       responseModels: ["gpt-5.4-mini"],
       maxRequestBytes: 8192,
       timeoutMs: 12_000,
@@ -83,21 +139,31 @@ describe("Honcho auth broker config", () => {
             provider: "default",
             id: "HONCHO_AUTH_BROKER_TOKEN",
           },
+          ...requiredAuthScope,
         },
       }),
-    ).toThrow(/source must be env, file, or exec for OpenClaw 2026\.7\.1 compatibility/);
+    ).toThrow(/must be an env, file, or exec OpenClaw SecretRef/);
   });
 
   it("rejects invalid or duplicate Responses model allowlists", () => {
-    process.env.HONCHO_AUTH_BROKER_TOKEN = "broker-test-token-that-is-at-least-32-characters";
     expect(() =>
       honchoConfigSchema.parse({
-        authBroker: { enabled: true, responseModels: ["gpt-5.4", "../unexpected"] },
+        authBroker: {
+          enabled: true,
+          bearerToken,
+          ...requiredAuthScope,
+          responseModels: ["gpt-5.4", "../unexpected"],
+        },
       }),
     ).toThrow(/invalid model ID/);
     expect(() =>
       honchoConfigSchema.parse({
-        authBroker: { enabled: true, responseModels: ["gpt-5.4", "gpt-5.4"] },
+        authBroker: {
+          enabled: true,
+          bearerToken,
+          ...requiredAuthScope,
+          responseModels: ["gpt-5.4", "gpt-5.4"],
+        },
       }),
     ).toThrow(/duplicate model IDs/);
   });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -85,7 +85,7 @@ describe("Honcho auth broker config", () => {
           },
         },
       }),
-    ).toThrow(/requires authBroker\.bearerToken/);
+    ).toThrow(/source must be env, file, or exec for OpenClaw 2026\.7\.1 compatibility/);
   });
 
   it("rejects invalid or duplicate Responses model allowlists", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -106,6 +106,22 @@ describe("Honcho auth broker config", () => {
     ).toThrow(/invalid profile ID/);
   });
 
+  it.each(["../main", "main/child", `a${"b".repeat(256)}`])(
+    "rejects malformed auth agent ID %s",
+    (authAgentId) => {
+      expect(() =>
+        honchoConfigSchema.parse({
+          authBroker: {
+            enabled: true,
+            bearerToken,
+            authAgentId,
+            authProfileId: requiredAuthScope.authProfileId,
+          },
+        }),
+      ).toThrow(/invalid agent ID/);
+    },
+  );
+
   it("accepts an OpenClaw SecretRef without resolving it in plugin code", () => {
     const parsed = honchoConfigSchema.parse({
       authBroker: {


### PR DESCRIPTION
## Summary

- add opt-in, bearer-protected OpenClaw routes for Honcho embeddings and Codex Responses;
- resolve OAuth through OpenClaw's canonical, agent-scoped auth store instead of mounting credential stores into Honcho containers;
- pin credential refresh to one configured OAuth profile and account, retrying once after HTTP 401 only;
- validate models, fields, nested Responses items, function tools, body sizes, embedding batches, rate, concurrency, and timeouts before upstream access;
- resolve the broker bearer only from authored env, file, or exec SecretRefs;
- sanitize provider failures and forward only a bounded numeric `Retry-After` value.

This branch is rebased onto official openclaw-honcho `1.5.5`
(`ff2ac03c9661dd9370c3cb91baeeb5da208e6370`).

## Security and reliability properties

- fixed upstream URLs; callers cannot choose an upstream host;
- caller bearer authentication happens before OAuth resolution;
- upstream OAuth material is never returned to the caller;
- API-key/token profiles, external CLI profiles, alternate-profile fallback,
  and raw literal broker tokens fail closed;
- `authAgentId`, `authProfileId`, and response models are explicitly pinned;
- Responses requests force `store=false`;
- only the relay's text-message, function-call, and function-result item shapes
  are accepted; file, URL, image, hosted-tool, arbitrary-item, undeclared-tool,
  and malformed nested shapes are rejected before OAuth resolution;
- OAuth refresh stays pinned to the original profile/account;
- bearer SecretRef resolution uses a five-second cache with shared in-flight
  reads while allowing token rotation without restarting OpenClaw;
- configuration, agent-directory, auth-store, and provider failures are
  normalized to generic broker errors.

## Compatibility note

OpenClaw documentation currently says Codex OAuth is not a supported general
OpenAI Platform credential. The embeddings route is therefore explicitly
opt-in and documented as an empirically working, unsupported compatibility
contract that may stop working upstream. This PR does not add or silently fall
back to a Platform API key.

Stock Honcho calls Chat Completions, so current deployments still need a small
compatibility adapter to translate those calls to Responses. That adapter is
intentionally outside this plugin PR. This PR does not claim adapter-free or
native Honcho OAuth support.

## Verification at pushed head

Pushed head: `2e7ce4b42f6269bd486bcfe6384344e6633a8f2d`

- 81/81 focused broker/config tests passed;
- 147/147 full plugin tests passed across 9 files;
- TypeScript no-emit check and build passed;
- package dry-run listed the expected 44 files for version `1.5.5`;
- built-plugin import passed;
- diff, whitespace, scope, and secret-pattern scans passed;
- positive fixtures reproduce the deployed relay's user-text, assistant-text,
  function-call, and function-result payloads;
- negative fixtures cover hosted tools/tool choices, file/URL/image input,
  arbitrary nested items, undeclared function choices, unsupported nested
  `text`/`reasoning` options, unsafe `Retry-After`, and provider error-body
  sanitization;
- the exact head is live on official OpenClaw `2026.8.1`: a wrong bearer
  returned 401, an unsupported nested Responses option returned 400, the
  OAuth embeddings route returned one 1,536-dimensional vector, and the
  deployment adapter completed both non-streaming and streaming Terra calls
  through canonical Codex OAuth.

The implementation and tests were prepared with AI assistance and manually
reviewed and validated.
