### PR TITLE
fix: use focused plugin SDK subpath imports

### DIFF
--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import * as readline from "node:readline";
 import { Honcho } from "@honcho-ai/sdk";
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 import { OWNER_ID } from "../state.js";
 

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -1,5 +1,5 @@
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 import { OWNER_ID } from "../state.js";
 import {

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -1,5 +1,5 @@
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 import { buildSessionKey, extractSenderId, isSubagentSession } from "../helpers.js";
 

--- a/hooks/gateway.ts
+++ b/hooks/gateway.ts
@@ -1,5 +1,5 @@
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 
 export function registerGatewayHook(api: OpenClawPluginApi, state: PluginState): void {

--- a/state.ts
+++ b/state.ts
@@ -6,7 +6,7 @@
 
 import { Honcho, type Peer } from "@honcho-ai/sdk";
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { honchoConfigSchema, type HonchoConfig } from "./config.js";
 import {
   PeersPersister,

--- a/tools/ask.ts
+++ b/tools/ask.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 

--- a/tools/context.ts
+++ b/tools/context.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 

--- a/tools/memory-passthrough.ts
+++ b/tools/memory-passthrough.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 import { getHonchoMemorySearchManager } from "../runtime.js";

--- a/tools/message-search.ts
+++ b/tools/message-search.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { Message } from "@honcho-ai/sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 import { buildSessionKey } from "../helpers.js";
 

--- a/tools/session.ts
+++ b/tools/session.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 // @ts-ignore - resolved by openclaw runtime
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginState } from "../state.js";
 import { buildSessionKey, cleanMessageContent } from "../helpers.js";
 


### PR DESCRIPTION
## Summary
- Replace legacy `openclaw/plugin-sdk` barrel imports with focused `openclaw/plugin-sdk/core` subpath imports across 11 source files
- Resolves `legacy-root-sdk-import` plugin validation warning

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 66 tests pass
- [x] `grep` confirms no legacy barrel imports remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the latest plugin SDK structure.
  * Preserved existing command, capture, context, gateway, search, memory, messaging, and session functionality without behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->