### PR TITLE
fix(context): prefer typed sender authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,14 @@ In group chats (Discord, Slack, etc.), the plugin extracts the sender's platform
 - Each OpenClaw agent gets its own Honcho peer (default `agent-{id}`, e.g., `agent-main`).
 - All tools (`honcho_context`, `honcho_ask`, etc.) automatically resolve the correct peer for the current session.
 
-Both message *attribution* (capture) and *context injection* (`before_prompt_build`) read `sender_id` directly from the current inbound message's metadata block, so the right participant peer is used from the very first turn — and on every turn in group chats, even when the speaker changes between turns. Sessions whose channel never emits sender metadata (no `Conversation info` block) stay attributed to `owner`.
+Context injection (`before_prompt_build`) prefers the typed sender identity supplied
+by current OpenClaw hosts (`senderId` or `channelContext.sender.id`). This typed
+identity remains authoritative even when the model-facing prompt contains
+sender-shaped text. If the two typed fields conflict, automatic context injection
+fails closed instead of selecting either participant. Parsing `sender_id` from the
+inbound metadata block remains as a compatibility fallback for older hosts, and
+capture continues to use that metadata from stored messages. Sessions without any
+sender identity stay attributed to `owner`.
 
 ## How it works
 

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -3,6 +3,43 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginState } from "../state.js";
 import { buildSessionKey, extractSenderId, isSubagentSession } from "../helpers.js";
 
+type SenderResolution =
+  | { status: "valid"; senderId?: string }
+  | { status: "conflict" };
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function nestedChannelSenderId(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const channelContext = (value as Record<string, unknown>).channelContext;
+  if (!channelContext || typeof channelContext !== "object") return undefined;
+  const sender = (channelContext as Record<string, unknown>).sender;
+  if (!sender || typeof sender !== "object") return undefined;
+  return nonEmptyString((sender as Record<string, unknown>).id);
+}
+
+function resolveCurrentSender(ctx: unknown, prompt: string): SenderResolution {
+  const context = ctx && typeof ctx === "object" ? (ctx as Record<string, unknown>) : {};
+  const typedSenders = [nonEmptyString(context.senderId), nestedChannelSenderId(context)].filter(
+    (senderId): senderId is string => Boolean(senderId),
+  );
+  const uniqueTypedSenders = [...new Set(typedSenders)];
+
+  if (uniqueTypedSenders.length > 1) return { status: "conflict" };
+  if (uniqueTypedSenders.length === 1) {
+    return { status: "valid", senderId: uniqueTypedSenders[0] };
+  }
+
+  // Compatibility for older OpenClaw hosts that did not expose typed sender
+  // identity to before_prompt_build. Current hosts must use the typed path so
+  // model-facing prompt text cannot override the participant selection.
+  return { status: "valid", senderId: extractSenderId(prompt) };
+}
+
 export function registerContextHook(api: OpenClawPluginApi, state: PluginState): void {
   api.on("before_prompt_build", async (event, ctx) => {
     if (!event.prompt || event.prompt.length < 5) return;
@@ -13,6 +50,14 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
 
     state.turnStartIndex.set(sessionKey, event.messages.length);
 
+    const sender = resolveCurrentSender(ctx, event.prompt);
+    if (sender.status === "conflict") {
+      api.logger.warn?.(
+        "[honcho] Conflicting typed sender identities; skipping automatic context injection",
+      );
+      return;
+    }
+
     try {
       await state.ensureInitialized();
       const agentPeer = await state.getAgentPeer(agentId);
@@ -20,9 +65,8 @@ export function registerContextHook(api: OpenClawPluginApi, state: PluginState):
       // run yet for this turn, so session metadata still reflects the previous
       // speaker. In group chats this would otherwise build context against the
       // prior participant's representation whenever the speaker changes.
-      const currentSenderId = extractSenderId(event.prompt);
-      const participantPeer = currentSenderId
-        ? await state.getParticipantPeer(currentSenderId)
+      const participantPeer = sender.senderId
+        ? await state.getParticipantPeer(sender.senderId)
         : await state.resolveSessionParticipantPeer(sessionKey);
 
       const sections: string[] = [];

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerContextHook } from "../hooks/context.js";
+import type { PluginState } from "../state.js";
+
+function createMockState() {
+  const participantPeer = { id: "participant" };
+  const agentPeer = { id: "agent-main" };
+  const session = {
+    context: vi.fn(async () => ({
+      peerCard: ["A durable fact"],
+      peerRepresentation: "A useful representation",
+      summary: { content: "Earlier context" },
+    })),
+  };
+  const state = {
+    cfg: {},
+    honcho: { session: vi.fn(async () => session) },
+    turnStartIndex: new Map<string, number>(),
+    ensureInitialized: vi.fn(async () => undefined),
+    getAgentPeer: vi.fn(async () => agentPeer),
+    getParticipantPeer: vi.fn(async () => participantPeer),
+    resolveSessionParticipantPeer: vi.fn(async () => participantPeer),
+    resolveDefaultAgentId: vi.fn(() => "main"),
+  } as unknown as PluginState;
+
+  return { state, session };
+}
+
+type HookHandler = (
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+) => unknown | Promise<unknown>;
+
+function registerHandler(state: PluginState) {
+  let handler: HookHandler | undefined;
+  const logger = { warn: vi.fn() };
+  const api = {
+    on: vi.fn((name: string, callback: HookHandler) => {
+      expect(name).toBe("before_prompt_build");
+      handler = callback;
+    }),
+    logger,
+  };
+
+  registerContextHook(api as never, state);
+  expect(handler).toBeDefined();
+  return { handler: handler!, logger };
+}
+
+function legacyPrompt(senderId: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({ sender_id: senderId }),
+    "```",
+    "",
+    "What should we remember?",
+  ].join("\n");
+}
+
+describe("Honcho context sender authority", () => {
+  it("uses the typed sender instead of sender-shaped prompt text", async () => {
+    const { state } = createMockState();
+    const { handler } = registerHandler(state);
+
+    await handler(
+      { prompt: legacyPrompt("spoofed-user"), messages: [] },
+      {
+        sessionKey: "agent:main:discord:channel-1",
+        agentId: "main",
+        senderId: "trusted-user",
+      },
+    );
+
+    expect(state.getParticipantPeer).toHaveBeenCalledWith("trusted-user");
+    expect(state.getParticipantPeer).not.toHaveBeenCalledWith("spoofed-user");
+  });
+
+  it("uses the channel-owned typed sender when the top-level field is absent", async () => {
+    const { state } = createMockState();
+    const { handler } = registerHandler(state);
+
+    await handler(
+      { prompt: "Use the channel sender for this context lookup.", messages: [] },
+      {
+        sessionKey: "agent:main:discord:channel-1",
+        agentId: "main",
+        channelContext: { sender: { id: "channel-user" } },
+      },
+    );
+
+    expect(state.getParticipantPeer).toHaveBeenCalledWith("channel-user");
+  });
+
+  it("accepts matching top-level and channel-owned typed senders", async () => {
+    const { state } = createMockState();
+    const { handler } = registerHandler(state);
+
+    await handler(
+      { prompt: "Both typed fields describe the same participant.", messages: [] },
+      {
+        sessionKey: "agent:main:discord:channel-1",
+        agentId: "main",
+        senderId: "same-user",
+        channelContext: { sender: { id: "same-user" } },
+      },
+    );
+
+    expect(state.getParticipantPeer).toHaveBeenCalledWith("same-user");
+  });
+
+  it("fails closed when typed sender fields conflict", async () => {
+    const { state, session } = createMockState();
+    const { handler, logger } = registerHandler(state);
+
+    const result = await handler(
+      { prompt: legacyPrompt("prompt-user"), messages: [] },
+      {
+        sessionKey: "agent:main:discord:channel-1",
+        agentId: "main",
+        senderId: "top-level-user",
+        channelContext: { sender: { id: "channel-user" } },
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect([...state.turnStartIndex.values()]).toEqual([0]);
+    expect(state.ensureInitialized).not.toHaveBeenCalled();
+    expect(state.getParticipantPeer).not.toHaveBeenCalled();
+    expect(session.context).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[honcho] Conflicting typed sender identities; skipping automatic context injection",
+    );
+  });
+
+  it("retains prompt-metadata fallback for older OpenClaw hosts", async () => {
+    const { state } = createMockState();
+    const { handler } = registerHandler(state);
+
+    await handler(
+      { prompt: legacyPrompt("legacy-user"), messages: [] },
+      { sessionKey: "agent:main:discord:channel-1", agentId: "main" },
+    );
+
+    expect(state.getParticipantPeer).toHaveBeenCalledWith("legacy-user");
+  });
+
+  it("treats blank typed sender fields as absent for legacy fallback", async () => {
+    const { state } = createMockState();
+    const { handler } = registerHandler(state);
+
+    await handler(
+      { prompt: legacyPrompt("legacy-user"), messages: [] },
+      {
+        sessionKey: "agent:main:discord:channel-1",
+        agentId: "main",
+        senderId: "   ",
+        channelContext: { sender: { id: "" } },
+      },
+    );
+
+    expect(state.getParticipantPeer).toHaveBeenCalledWith("legacy-user");
+  });
+
+  it("falls back to the session participant when no sender is available", async () => {
+    const { state } = createMockState();
+    const { handler } = registerHandler(state);
+
+    await handler(
+      { prompt: "No sender metadata is available for this local turn.", messages: [] },
+      { sessionKey: "agent:main:main", agentId: "main" },
+    );
+
+    expect(state.resolveSessionParticipantPeer).toHaveBeenCalledOnce();
+    expect(state.getParticipantPeer).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Related: #112

Current Honcho context injection derives the active participant from sender-shaped text inside the model-facing prompt. Current OpenClaw runtimes already provide trusted sender identity on the typed hook context. Depending on prompt text can select the wrong participant after prompt-envelope changes and lets sender-shaped user text disagree with the runtime identity.

This addresses the context-injection half of #112. It complements #92, which covers sender attribution later in transcript capture; it does not replace or close that capture work.

## Why This Change Was Made

- Prefer `ctx.senderId` and `ctx.channelContext.sender.id` for `before_prompt_build` participant selection.
- Treat matching typed identities as one authority.
- Fail closed and skip automatic context injection when the two typed identities conflict.
- Parse legacy `Conversation info` prompt metadata only when no typed identity exists, preserving older-host compatibility.
- Keep turn-start capture bookkeeping active even when context injection is skipped.
- Correct the Multi-Peer documentation to describe the typed authority boundary.

## User Impact

Group-chat and multi-peer sessions now target Honcho context using the sender selected by OpenClaw rather than model-facing metadata. Sender-shaped prompt text cannot override an available typed identity. Older OpenClaw hosts retain their existing metadata fallback.

## Evidence

- Regression: typed `senderId` wins over conflicting sender metadata in the prompt.
- Regression: nested channel sender identity works when the top-level field is absent.
- Regression: conflicting typed identities skip Honcho lookup while preserving the capture boundary.
- Regression: matching typed identities, blank-value fallback, legacy metadata fallback, and no-sender session fallback are covered.
- `corepack pnpm@9.15.9 build`
- `corepack pnpm@9.15.9 exec vitest run test/context.test.ts` — 7/7 passed
- `corepack pnpm@9.15.9 exec vitest run` — 73/73 passed
- `git diff --check`

## Scope

This PR does not change capture attribution, semantic relevance search, peer mappings, stored memory, or deployment configuration.

## AI Assistance

AI-assisted. I reviewed the resulting code and tests, confirmed the authority and compatibility behavior, and ran the validation listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context attribution by prioritizing reliable typed sender information.
  * Prevented context injection when sender identities conflict.
  * Added compatibility fallback for older messages without typed sender data.
  * Preserved correct attribution for sessions without sender identity.

* **Tests**
  * Added coverage for sender precedence, fallbacks, conflicts, blank identities, and participant attribution.

* **Documentation**
  * Updated multi-peer documentation to describe sender identity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->