### PR TITLE
fix(openclaw): dual-kind registration so the plugin stays loaded alongside memory-core on 2026.8.x

### DIFF
--- a/clawdbot.plugin.json
+++ b/clawdbot.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openclaw-honcho",
-  "kind": "memory",
+  "kind": ["memory", "context-engine"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/index.ts
+++ b/index.ts
@@ -89,7 +89,7 @@ const honchoPlugin: OpenClawPluginDefinition = definePluginEntry({
   id: "openclaw-honcho",
   name: "Memory (Honcho)",
   description: "AI-native memory with dialectic reasoning",
-  kind: "memory",
+  kind: ["memory", "context-engine"],
   configSchema: honchoConfigSchema,
 
   register(api) {

--- a/index.ts
+++ b/index.ts
@@ -89,6 +89,8 @@ const honchoPlugin: OpenClawPluginDefinition = definePluginEntry({
   id: "openclaw-honcho",
   name: "Memory (Honcho)",
   description: "AI-native memory with dialectic reasoning",
+  // Dual-kind on purpose: OpenClaw >= 2026.8 hard-disables pure memory-kind plugins that don't own slots.memory.
+  // No context engine is registered; the second kind only keeps the plugin loaded as a companion. Do not select this plugin for slots.contextEngine.
   kind: ["memory", "context-engine"],
   configSchema: honchoConfigSchema,
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-honcho",
   "name": "Honcho Memory",
-  "kind": "memory",
+  "kind": ["memory", "context-engine"],
   "setup": {
     "providers": [
       {


### PR DESCRIPTION
## Problem

Since OpenClaw 2026.8.2, the loader hard-disables any pure `kind: "memory"` plugin that doesn't own `plugins.slots.memory` (`resolveMemorySlotDecisionShared`: pure memory kind, not slot-selected -> disabled, "memory slot set to memory-core"). I hit this directly: after moving the memory slot to the built-in `memory-core` on 2026.8.2, this plugin was silently deactivated. No tools, no hooks, no capture, nothing surfaced beyond the loader log line.

## Repro

1. OpenClaw 2026.8.2, `plugins.slots.memory = "memory-core"`.
2. Install `@honcho-ai/openclaw-honcho` 1.5.5 and enable the entry.
3. Restart the gateway.

Result: the plugin is disabled at load, `plugins.loaded` doesn't include `openclaw-honcho`, `honcho_*` tools are gone. Same symptom reported for another memory plugin in NateBJones-Projects/OB1#385.

## Fix

Declare the plugin dual-kind, `["memory", "context-engine"]`, in `openclaw.plugin.json` and in the `definePluginEntry` kind, and keep `clawdbot.plugin.json` in sync so the manifest/entry kind cross-check passes on both loaders.

On 2026.8.x a dual-kind plugin that isn't slot-selected stays enabled and only skips memory-capability registration, which is exactly the companion behavior this plugin needs next to memory-core. When the plugin IS the selected memory slot, behavior is unchanged: the loader registers its memory capability as before.

`"memory"` and `"context-engine"` are the only kinds the loader accepts; anything else is silently dropped (I tried `["memory", "tools"]` first, no-op). The plugin registers no context-engine capability, so the second kind is inert beyond escaping the hard-disable. If you point `plugins.slots.contextEngine` at this plugin the host falls back to the legacy engine - don't; it registers no context engine.

## Why not the alternatives

- **Drop `kind: "memory"` entirely** (the route OB1 took in NateBJones-Projects/OB1#384): turns the plugin into a tools-only sidecar and breaks the primary use case, being the memory slot plugin.
- **Additive supplement surfaces** (`registerMemoryPromptSupplement` / `registerMemoryCorpusSupplement`, the blessed pattern from openclaw/openclaw#38874): built for companions that don't replace memory. This plugin's whole point is to be the slot when asked, so it can't give the kind up. A config-driven companion mode isn't possible either: on 2026.8.2 plugin config is read after the kind/slot gate, so no config key can keep a pure memory-kind plugin alive.
- **Wait for gateway multi-slot** (openclaw/openclaw#60572, openclaw/openclaw#88504): stalled, and it needs a product decision that cuts against VISION.md's one-active-memory-plugin stance.

Dual-kind is the smallest change that un-breaks 2026.8.x users today while keeping slot mode intact everywhere.

## Testing

I've been running exactly this as a hand patch in node_modules on my production gateway (2026.8.2, memory-core owning the slot); it reverts on every plugin upgrade, which is what pushed me to send this. With the patch:

- Plugin loads: log shows "dual-kind plugin not selected for memory slot; skipping memory capability registration", then "Honcho memory plugin loaded" / "Honcho memory ready".
- Hooks and capture register, `honcho_*` tools round-trip (verified end to end with `honcho_ask`).
- No gateway config change needed; memory-core keeps the slot.

The change is limited to the kind declarations; no runtime code touched, so install/typecheck/test are unaffected.

Refs: openclaw/openclaw#70489 (dreaming sidecar coexistence, shipped 2026.4.23), openclaw/openclaw#38874 (additive supplements, shipped 2026.4.7), openclaw/openclaw#60572 + openclaw/openclaw#88504 (multi-slot, stalled), NateBJones-Projects/OB1#385 (same symptom, another plugin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The plugin is now recognized as both a memory provider and a context engine.
  * This enables compatibility with systems that support context-engine plugins while retaining existing memory functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
